### PR TITLE
fix: ryu (and all other magma dependencies) are upgraded with magma

### DIFF
--- a/lte/gateway/release/upgrade_magma.sh
+++ b/lte/gateway/release/upgrade_magma.sh
@@ -42,6 +42,10 @@ echo "deb https://artifactory.magmacore.org/artifactory/debian $OS_VERSION-$MAGM
 apt update
 apt install -y magma -o Dpkg::Options::="--force-overwrite"
 
+# update all direct dependencies of magma - this is needed for an update to 1.8 where
+# ryu can be updated from an unpatched version 4.34 to a patched version 4.34-1.
+apt install -y $(apt-cache depends magma | grep "Dep" | cut -d':' -f2)
+
 #Upgrade OVS
 ovs-kmod-upgrade.sh -y
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

During the release of 1.8 it was found that ryu (4.34) was installed without needed patches. In order to solve that ryu 4.34-1 was uploaded to the magmacore artifactory with the needed patches.

**Problem**: magma 1.7 and 1.8 has a python3-ryu dependency on >= 4.34. This is, when magma is upgraded from 1.7 to 1.8 (via apt install magma in upgrade_magma.sh) then ryu is not upgraded to 4.34-1.

**Approach here**: upgrade all dependencies of magma in the upgrade script.
* this could be scaled down to only upgrade python3-ryu - opinions?

## Test Plan

Do the upgrade and see that everything works.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
