### PR TITLE
test(agw): Fix broken integration test

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_non_nat_dp_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_non_nat_dp_ul_tcp.py
@@ -22,13 +22,9 @@ from s1ap_utils import MagmadUtil
 class TestAttachDetachNonNatDpUlTcp(unittest.TestCase):
     """Integration Test: TestAttachDetachNonNatDpUlTcp"""
 
-    def __init__(self) -> None:
-        """Initialize unittest class"""
-        super().__init__()
-        self.magma_utils = MagmadUtil(None)
-
     def setUp(self):
         """Initialize before test case execution"""
+        self.magma_utils = MagmadUtil(None)
         self.magma_utils.disable_nat()
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
 


### PR DESCRIPTION
## Summary

Pytest fails calling the constructor. But moving the `magma_utils` initialization to `setUp` works.

## Test Plan

Execute the test. (It is part of the non-sanity tests and does not run in the CI.)

## Additional Information

- [ ] This change is backwards-breaking