### PR TITLE
fix(ci): Fix upload error in agw-coverage workflow

### DIFF
--- a/.github/workflows/agw-coverage.yml
+++ b/.github/workflows/agw-coverage.yml
@@ -103,7 +103,7 @@ jobs:
           github.repository_owner == 'magma' &&
           github.ref_name == 'master'
         with:
-          name: Bazel test C/C++ coverage profile
+          name: Bazel test C and C++ coverage profile
           path: Bazel_test_cc_coverage_profile
       - name: Build space left after run
         shell: bash


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Fix upload error of bazel profile due to "/" in name.
  - See e.g. [this run](https://github.com/magma/magma/actions/runs/3335602121/jobs/5519767637) 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
