### PR TITLE
chore(ci): Replace to-be-deprecated set-output statement in GitHub workflow

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -227,7 +227,7 @@ jobs:
       success: ${{ steps.setoutput.outputs.success }}
     steps:
       - id: setoutput
-        run: echo "::set-output name=success::true"
+        run: echo "success=true" >> $GITHUB_OUTPUT
 
   report_result_bazel_build_and_test:
     name: Bazel build and test status


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #14310
- Replace `set-output` due to deprecation warning - see also [1] 
- :warning: Even though [1] specifies `run: echo "{name}={value}" >> $GITHUB_OUTPUT` as the correct replacement this results in the output not being found. Only `run: echo "name=value" >> $GITHUB_OUTPUT` works.
  - I tested this in a minimal example workflow and the braces seem to break the mechanism. 
  - On this help page they omit the braces: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs.
  - Discussion thread with minimal example https://github.com/orgs/community/discussions/37896


[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
