### PR TITLE
fix: bazel build and test verbs use same parameter order

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -123,8 +123,8 @@ jobs:
             printf '\r%s\r' '###############################' 1>&2
             bazel build \
               ${{ matrix.bazel-target }} \
-              ${{ matrix.bazel-config }} \
               --config=mme_unit_test \
+              ${{ matrix.bazel-config }} \
               --profile=Bazel_build_all_profile
 
             printf '\r%s\r' '###############################' 1>&2


### PR DESCRIPTION
## Summary

This ensures that Bazel recognizes the actions used for build and test to be the same, and thus reuse the built artifacts for testing.

PR created in the scope of #13362

We found that when using the `--config=asan` option, `bazel test` wouldn't reuse the artifacts that `bazel build` created.
In order to see what the actual differences in the actions are, I executed
```
bazel clean
bazel build --execution_log_json_file=build.json --config=asan --config=mme_unit_test //lte/gateway/c/core/oai/test/nas:nas_converter_test
bazel test --execution_log_json_file=test.json --config=asan //lte/gateway/c/core/oai/test/nas:nas_converter_test
diff build.json test.json > build_test_diff
```

When looking at the `build_test_diff` file with a text viewer, it becomes obvious that the difference is only the order of parameters, like in this line:

```
<   "commandArgs": ["/usr/bin/gcc", "-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall", "-Wunused-but-set-parameter", "-Wno-free-nonheap-object", "-fno-omit-frame-pointer", "-MD", "-MF", "bazel-out/k8-fastbuild/bin/lte/gateway/c/core/common/_objs/backtrace/backtrace.pic.d", "-frandom-seed\u003dbazel-out/k8-fastbuild/bin/lte/gateway/c/core/common/_objs/backtrace/backtrace.pic.o", "-fPIC", "-iquote", ".", "-iquote", "bazel-out/k8-fastbuild/bin", "-g", "-DPACKAGE_BUGREPORT\u003d\"TBD\"", "-DPACKAGE_VERSION\u003d\"0.1\"", "-fsanitize\u003daddress", "-fsanitize\u003dundefined", "-O0", "-fno-omit-frame-pointer", "-DMME_UNIT_TEST", "-fno-canonical-system-headers", "-Wno-builtin-macro-redefined", "-D__DATE__\u003d\"redacted\"", "-D__TIMESTAMP__\u003d\"redacted\"", "-D__TIME__\u003d\"redacted\"", "-c", "lte/gateway/c/core/common/backtrace.c", "-o", "bazel-out/k8-fastbuild/bin/lte/gateway/c/core/common/_objs/backtrace/backtrace.pic.o"],
---
>   "commandArgs": ["/usr/bin/gcc", "-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall", "-Wunused-but-set-parameter", "-Wno-free-nonheap-object", "-fno-omit-frame-pointer", "-MD", "-MF", "bazel-out/k8-fastbuild/bin/lte/gateway/c/core/common/_objs/backtrace/backtrace.pic.d", "-frandom-seed\u003dbazel-out/k8-fastbuild/bin/lte/gateway/c/core/common/_objs/backtrace/backtrace.pic.o", "-fPIC", "-iquote", ".", "-iquote", "bazel-out/k8-fastbuild/bin", "-g", "-DPACKAGE_BUGREPORT\u003d\"TBD\"", "-DPACKAGE_VERSION\u003d\"0.1\"", "-DMME_UNIT_TEST", "-fsanitize\u003daddress", "-fsanitize\u003dundefined", "-O0", "-fno-omit-frame-pointer", "-fno-canonical-system-headers", "-Wno-builtin-macro-redefined", "-D__DATE__\u003d\"redacted\"", "-D__TIMESTAMP__\u003d\"redacted\"", "-D__TIME__\u003d\"redacted\"", "-c", "lte/gateway/c/core/common/backtrace.c", "-o", "bazel-out/k8-fastbuild/bin/lte/gateway/c/core/common/_objs/backtrace/backtrace.pic.o"],
```

## Test Plan

```
bazel clean
bazel build --config=mme_unit_test --config=asan //lte/gateway/c/core/oai/test/nas:nas_converter_test
bazel test --config=asan //lte/gateway/c/core/oai/test/nas:nas_converter_test
```

Make sure that `bazel test` reuses most of the artifacts created by `bazel build` for ASAN builds. Rebuilding around 400 artifacts is ok, but not > 4000.
