### PR TITLE
chore: bazel debian artifacts are published

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,7 @@ build --announce_rc
 build --color=yes
 
 build:production --config=lsan --copt=-O3
+build:production --define=production=1
 
 # C/C++ CONFIGS
 build --cxxopt=-std=c++14

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -296,35 +296,26 @@ jobs:
               --profile=Bazel_build_package_profile
             mkdir packages
             mv /tmp/packages/*.deb packages
-      - name: Publish magma and sctpd
-        if: github.event_name == 'push' && github.repository_owner == 'magma'
+      - name: Setup JFROG CLI
+        uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
         env:
-          ARTIFACTORY_URL: "https://artifactory.magmacore.org/artifactory/debian-test/pool"
-          DEBIAN_META_INFO: ";deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64"
-        working-directory: packages
+          JF_ENV_1: ${{ secrets.JFROG_TOKEN }}
+      - name: Set dry run environment variable
+        if: ${{ ! ( github.event_name == 'push' && github.repository_owner == 'magma' ) }}
         run: |
-          for package in *.deb
-          do
-            echo "Pushing package ${package} to JFROG artifactory: ${ARTIFACTORY_URL}"
-            HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -uci-bot:${{ secrets.JFROG_CIBOT_APIKEYS }} -XPUT "${ARTIFACTORY_URL}/focal-ci/${package}${DEBIAN_META_INFO}" -T $package)
-            echo "$HTTP_RESPONSE"
-            # extract the body and download uri
-            HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
-            URI=$(echo $HTTP_BODY | jq -r '.uri')
-            if [[ "$URI" == "null" ]]; then
-              PUBLISH_ERROR="true"
-            fi
-            # extract and check status
-            HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
-            if [[ "$HTTP_STATUS" != "2"* ]]; then
-              PUBLISH_ERROR="true"
-            fi
-          done
-          # evaluate
-          if [[ "$PUBLISH_ERROR" == "true" ]]; then
-            echo "There were errors during publishing. See logging above."
-            exit 1
-          fi
+          echo "IS_DRY=--dry-run" >> $GITHUB_ENV
+      - name: Publish debian packages
+        env:
+          ARTIFACTORY_URL: https://artifactory.magmacore.org:443/artifactory/
+          DEBIAN_META_INFO: deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64
+        run: |
+          jf rt upload \
+            --recursive=false \
+            --url=${ARTIFACTORY_URL} \
+            --detailed-summary \
+            ${{ env.IS_DRY }} \
+            --target-props="${DEBIAN_META_INFO}" \
+            "packages/(*).deb" debian-test/pool/focal-ci/{1}.deb
       - name: Publish bazel profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: ${{ always() && github.event.inputs.publish_bazel_profile == 'true' }}

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -291,9 +291,40 @@ jobs:
           run: |
             cd /workspaces/magma
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
-            bazel build lte/gateway/release:sctpd_deb_pkg lte/gateway/release:magma_deb_pkg \
+            bazel run //lte/gateway/release:release_build \
               --config=production \
               --profile=Bazel_build_package_profile
+            mkdir packages
+            mv /tmp/packages/*.deb packages
+      - name: Publish magma and sctpd
+        if: github.event_name == 'push' && github.repository_owner == 'magma'
+        env:
+          ARTIFACTORY_URL: "https://artifactory.magmacore.org/artifactory/debian-test/pool"
+          DEBIAN_META_INFO: ";deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64"
+        working-directory: packages
+        run: |
+          for package in *.deb
+          do
+            echo "Pushing package ${package} to JFROG artifactory: ${ARTIFACTORY_URL}"
+            HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -uci-bot:${{ secrets.JFROG_CIBOT_APIKEYS }} -XPUT "${ARTIFACTORY_URL}/focal-ci/${package}${DEBIAN_META_INFO}" -T $package)
+            echo "$HTTP_RESPONSE"
+            # extract the body and download uri
+            HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
+            URI=$(echo $HTTP_BODY | jq -r '.uri')
+            if [[ "$URI" == "null" ]]; then
+              PUBLISH_ERROR="true"
+            fi
+            # extract and check status
+            HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+            if [[ "$HTTP_STATUS" != "2"* ]]; then
+              PUBLISH_ERROR="true"
+            fi
+          done
+          # evaluate
+          if [[ "$PUBLISH_ERROR" == "true" ]]; then
+            echo "There were errors during publishing. See logging above."
+            exit 1
+          fi
       - name: Publish bazel profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: ${{ always() && github.event.inputs.publish_bazel_profile == 'true' }}

--- a/.github/workflows/build_magma_dep.yml
+++ b/.github/workflows/build_magma_dep.yml
@@ -69,7 +69,7 @@ jobs:
           name: nettle
           path: ${{ env.MAGMA_PACKAGE_DIR }}
       - name: Setup JFROG CLI
-        uses: jfrog/setup-jfrog-cli@v2
+        uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
         env:
           JF_ENV_1: ${{ secrets.JFROG_TOKEN }}
       - name: Set dry run environment variable

--- a/dev_tools/BUILD.bazel
+++ b/dev_tools/BUILD.bazel
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@python_deps//:requirements.bzl", "all_requirements")
 load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_pyvenv//:venv.bzl", "py_venv")
-load("@python_deps//:requirements.bzl", "all_requirements")
 
 lte_protos = [
     # List generated with bazel query 'kind(py_library, //lte/protos:*) | sed 's/.*/    "&",/'

--- a/docs/readmes/lte/build_install_magma_pkg_in_agw.md
+++ b/docs/readmes/lte/build_install_magma_pkg_in_agw.md
@@ -5,71 +5,78 @@ hide_title: true
 ---
 # Build and install a magma package in AGW
 
-**Description:** Purpose of this document is describe how to build and install a magma package in AGW.
+## Description
 
-**Environment:** AGW
+The purpose of this document is to describe how to build and install a magma package in AGW.
 
-**Steps:**
+## Environment
 
-1. **Clone or Update  your local repository**. In any machine (i.e. your computer) clone the magma repo  and checkout the version from where you would like to build your package. For example, for v1.8 you can run:
+AGW
+
+## Steps
+
+Note that the following is supported starting with magma v1.9. For older versions see respective documentation.
+
+1. **Clone or Update your local repository**.
+    In any machine (i.e. your computer) clone the magma repo (and switch to the branch you want to build).
 
     ```bash
     git clone https://github.com/magma/magma.git
-    git checkout v1.8
     ```
 
-2. **Install prerequisites**. Make sure you have installed all the tools specified in the prerequisites <https://magma.github.io/magma/docs/basics/prerequisites#prerequisites>
+2. **Install prerequisites**.
+    Make sure you have installed all the tools specified in the prerequisites <https://magma.github.io/magma/docs/basics/prerequisites#prerequisites>
 
 3. **Build and create deb package**.
-    To build an AGW package, use the script located at `$MAGMA_ROOT/lte/gateway/fabfile.py`. The commands below will create a vagrant machine, then build and create a deb package.
+    To build an AGW package spin up a vagrant machine and then build and create a deb package.
 
-    The following commands are to be run from `$MAGMA_ROOT/lte/gateway` on your host machine.
-    To create a package for production, run
+    From `$MAGMA_ROOT/lte/gateway` on your host machine run:
 
     ```bash
-    fab release package
+    vagrant up magma
+    vagrant ssh magma
+    ```
+
+    In the VM from `$MAGMA_ROOT` run:
+
+    ```bash
+    bazel run //lte/gateway/release:release_build --config=production
     ```
 
     To create a package for development or testing, run
 
     ```bash
-    fab dev package
+    bazel run //lte/gateway/release:release_build
     ```
 
-    The `dev` flag will compile all C++ services with `Debug` compiler flags and enable ASAN. This is recommended for testing only as it will impact performance. In contrast, the production package has C++ services built with `RelWithDebInfo` compiler flags.
+    Omitting the `--config=production` flag will compile all C++ services with `Debug` compiler flags and enable ASAN. This is recommended for testing only as it will impact performance. In contrast, the production package has C++ services built with `RelWithDebInfo` compiler flags.
 
-4. **Locate the packages**. Once the above command finished. You need to enter the VM to verify the deb packages are there.
+4. **Locate the packages**.
+    Once the above command finished you can find the packages inside the VM:
 
     ```bash
-    vagrant ssh magma
-    cd ~/magma-packages/
+    cd /tmp/packages
     ```
 
-    You will need only the ones that say `magma_1.1.XXX` and `magma-sctpd_1.1.XXX` (for v1.1 versions)
+    There should be two packages named `magma_1.9.XXX` and `magma-sctpd_1.9.XXX` (for v1.9 versions).
 
-5. **Download the package**. You can download the files to your computer from the vagrant machine. To do so, you can install a vagrant plugin in your computer and then download the package from the VM to your computer with the following commands:
+5. **Copy the packages to the target machine**.
 
-    ```bash
-    vagrant plugin install vagrant-scp
-    vagrant scp magma: ~/magma-packages/<deb_package>
-    ```
-
-6. **Upload the package to AGW** that you would like to install.
-
-7. **Install the package**. In order to install the new deb package in AGW, you can run
+6. **Install the package**.
+    In order to install the new deb package in AGW, you can run
 
     ```bash
     sudo apt -f install MAGMA_PACKAGE
     ```
 
-8. **Restart the magma services**
+7. **Restart the magma services**
 
     ```bash
     sudo service magma@* stop
     sudo service magma@magmad restart
     ```
 
-9. You can **verify the installed version** with
+8. You can **verify the installed version** with
 
     ```bash
     apt show magma

--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -155,7 +155,7 @@
 
 - name: Set magma package variable
   set_fact:
-    magma_package: "{{ MAGMA_PACKAGE | default('magma', true) }}"
+    magma_package: "{{ MAGMA_PACKAGE | default('magma<1.9.0', true) }}"
 
 - name: Installing magma from local debian package
   become: true

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -10,9 +10,8 @@
 # limitations under the License.
 
 """
-Artifacts in this package should be build with the production
-configuration:
-bazel build lte/gateway/release:sctpd_deb_pkg --config=production
+Definitions of the magma and sctpd debian artifacts. Look at the the comment in the
+":release_build" target for information on how to build the magma and sctpd debian artifacts.
 """
 
 load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
@@ -23,14 +22,16 @@ load(":deb_dependencies.bzl", "MAGMA_DEPS", "OAI_DEPS", "OVS_DEPS")
 
 SCTPD_PKGNAME = "magma-sctpd"
 
-VERSION = "1.8.0"
+VERSION = "1.9.0"
+
+VERSION_DEB = "{ver}-VERSION-SUFFIX".format(ver = VERSION)
 
 ARCH = "amd64"
 
 SCTPD_FILE_NAME = "{name}_{ver}_{arch}".format(
     name = SCTPD_PKGNAME,
     arch = ARCH,
-    ver = VERSION,
+    ver = VERSION_DEB,
 )
 
 MAGMA_PKGNAME = "magma"
@@ -38,7 +39,7 @@ MAGMA_PKGNAME = "magma"
 MAGMA_FILE_NAME = "{name}_{ver}_{arch}".format(
     name = MAGMA_PKGNAME,
     arch = ARCH,
-    ver = VERSION,
+    ver = VERSION_DEB,
 )
 
 ### META INFO
@@ -86,7 +87,7 @@ pkg_deb(
     maintainer = MAINTAINER,
     package = SCTPD_PKGNAME,
     package_file_name = "{fname}.deb".format(fname = SCTPD_FILE_NAME),
-    version = VERSION,
+    version = VERSION_DEB,
 )
 
 ### MAGMA BUILD
@@ -185,5 +186,46 @@ pkg_deb(
     postinst = ":magma-postinst-bazel",
     provides = [MAGMA_PKGNAME],
     replaces = [MAGMA_PKGNAME],
-    version = VERSION,
+    version = VERSION_DEB,
+)
+
+### CI BUILDS
+
+config_setting(
+    name = "is_production",
+    values = {"define": "production=1"},
+)
+
+genrule(
+    name = "update_deb_meta_info",
+    srcs = ["update_deb_meta_info.sh.template"],
+    outs = ["update_deb_meta_info.sh"],
+    cmd =
+        " && ".join([
+            "cp $(location update_deb_meta_info.sh.template) $@",
+            "sed -i 's/VERSION=REPLACE_ME/VERSION={ver}/' $@".format(ver = VERSION),
+            "sed -i 's/MAGMA_INPUT_FILE_NAME=REPLACE_ME/MAGMA_INPUT_FILE_NAME={name}.deb/' $@".format(name = MAGMA_FILE_NAME),
+            "sed -i 's/SCTPD_INPUT_FILE_NAME=REPLACE_ME/SCTPD_INPUT_FILE_NAME={name}.deb/' $@".format(name = SCTPD_FILE_NAME),
+        ]) + select({
+            ":is_production": " && sed -i 's/DEV_BUILD=true/DEV_BUILD=false/' $@",
+            "//conditions:default": "",
+        }),
+    tags = ["manual"],
+)
+
+sh_binary(
+    # Wrapper target for creating magma and sctpd debian artifacts with proper versions.
+    # Creating the debian packages with rules_pkg must be reproducible. A version like
+    # "1.9.0-1667381719-ebd3bb56" (<version>_<timestamp>_<hash>) would produce artifacts
+    # that are not reproducible. This target builds the artifacts and changes the
+    # version afterwards (also the description in case of "dev builds").
+    # Use --config=production in order to create artifacts for production usage and CI, e.g.,
+    # bazel run //lte/gateway/release:release_build --config=production
+    name = "release_build",
+    srcs = [":update_deb_meta_info"],
+    data = [
+        ":magma_deb_pkg",
+        ":sctpd_deb_pkg",
+    ],
+    tags = ["manual"],
 )

--- a/lte/gateway/release/deb_dependencies.bzl
+++ b/lte/gateway/release/deb_dependencies.bzl
@@ -13,7 +13,7 @@
 External dependencies of the magma debian build.
 """
 
-SCTPD_MIN_VERSION = "1.8.0"  # earliest version of sctpd with which this magma version is compatible
+SCTPD_MIN_VERSION = "1.9.0"  # earliest version of sctpd with which this magma version is compatible
 
 # Magma system dependencies: anything that we depend on at the top level, add
 # here.

--- a/lte/gateway/release/magma-postinst-bazel
+++ b/lte/gateway/release/magma-postinst-bazel
@@ -16,7 +16,7 @@ sed -i "s/.*OVS_CTL_OPTS.*/OVS_CTL_OPTS='--delete-bridges'/" /etc/default/openvs
 # Create /var/core directory
 mkdir -p /var/core
 
-value=`cat /usr/local/share/magma/commit_hash`
+value="COMMIT_HASH=REPLACE_ME"
 if grep -q "COMMIT_HASH" /etc/environment
 then
     sudo sed -i -e "s/^COMMIT_HASH.*/$value/" /etc/environment

--- a/lte/gateway/release/update_deb_meta_info.sh.template
+++ b/lte/gateway/release/update_deb_meta_info.sh.template
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+
+###############################################################################
+# FUNCTION DECLARATIONS
+###############################################################################
+
+update_version() {
+    local INPUT_FILE_NAME=$1
+
+    WORK_FOLDER=$(mktemp -d)
+    cd "${WORK_FOLDER}"
+
+    echo "Updating meta data in ${INPUT_FILE_NAME} ..."
+
+    ar p "${BUILD_PATH}/${INPUT_FILE_NAME}" control.tar.gz | tar -xz
+
+    INPUT_VERSION=$(dpkg-deb -f "${BUILD_PATH}/${INPUT_FILE_NAME}" Version)
+    echo "  Updating version \"${INPUT_VERSION}\" to \"${VERSION}-${VERSION_SUFFIX}\""
+    sed -i "s/VERSION-SUFFIX/${VERSION_SUFFIX}/" control
+    
+    echo "  Updating description to development build \"${DEV_BUILD}\""
+    if [ "${DEV_BUILD}" = true ] ; then
+        sed -i "s/\(Description: .*$\)/\1 - dev build/" control
+    fi
+
+    if [ -f postinst ]; then
+        COMMIT_HASH_WITH_VERSION="magma@${VERSION}.${COMMIT_COUNT}-${HASH_SHORT}"
+        echo "  Updating \"COMMIT_HASH\" in magma to \"${COMMIT_HASH_WITH_VERSION}\""
+        sed -i "s/REPLACE_ME/${COMMIT_HASH_WITH_VERSION}/" postinst
+    fi
+
+    tar czf control.tar.gz -- *[!.gz]
+
+    NEW_FILE_NAME="${INPUT_FILE_NAME/VERSION-SUFFIX/"${VERSION_SUFFIX}"}"
+    echo "  Renaming \"${INPUT_FILE_NAME}\" to \"${NEW_FILE_NAME}\""
+    cp "${BUILD_PATH}/${INPUT_FILE_NAME}" "${NEW_FILE_NAME}"
+    chmod u+w "${NEW_FILE_NAME}"
+
+    ar r "${NEW_FILE_NAME}" control.tar.gz
+
+    mv "${NEW_FILE_NAME}" "${RESULT_FOLDER}"
+    echo "  File written to ${RESULT_FOLDER}/${NEW_FILE_NAME}"
+}
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+VERSION=REPLACE_ME # set by genrule
+MAGMA_INPUT_FILE_NAME=REPLACE_ME # set by genrule
+SCTPD_INPUT_FILE_NAME=REPLACE_ME # set by genrule
+DEV_BUILD=true # can be overridden by genrule
+
+RESULT_FOLDER=/tmp/packages
+mkdir -p ${RESULT_FOLDER}
+
+BUILD_PATH="${MAGMA_ROOT}/bazel-bin/lte/gateway/release"
+
+git config --global --add safe.directory "${MAGMA_ROOT}"
+
+HASH=$(git -C "${MAGMA_ROOT}" rev-parse HEAD)
+COMMIT_COUNT=$(git -C "${MAGMA_ROOT}" rev-list --count HEAD)
+HASH_SHORT=${HASH::8}
+TIMESTAMP=$(date +%s)
+VERSION_SUFFIX="${TIMESTAMP}-${HASH_SHORT}"
+
+update_version $MAGMA_INPUT_FILE_NAME
+update_version $SCTPD_INPUT_FILE_NAME


### PR DESCRIPTION
## Summary

This change will allow publishing magma and sctpd debian packages created with bazel to the magmacore artifactory. For this the following was implemented (corresponds to the commits):
1. Create a bazel target that builds the debian packages and afterwards changes the meta info of the artifacts (version, description, post-install script) and renames the files. This target is for manual execution - CI and local builds. Note that the version for these artifacts is set to 1.9.0 - the make artifacts still use 1.8.0 (see also https://magmacore.slack.com/archives/C0301NRRL7K/p1667298024205399).
2. +5. In the bazel.yml workflow add a step where the packages are published to the artifactory (only for merges on master). This is mostly reused from ~~build_all.yml~~ build_magma_dep.yml.
3. Make sure that a locally created magma_deb VM (or executing the [lte make debian integ tests](https://github.com/magma/magma/actions/workflows/lte-integ-test-magma-deb.yml) on a fork still use the latest magm artifact created with make.
4. Adapt documentation for manually building magma/sctpd debian artifacts.

Will also close #14121.

## Test Plan

build locally based on the documentation.

Run in CI (only uploads on master). Here the output for a modified run where the upload step was enabled but only produced logging (https://github.com/magma/magma/actions/runs/3371605060/jobs/5594061360):
```
Pushing package magma-sctpd_1.9.0-1667325390-acda59fe_amd64.deb to JFROG artifiactory: https://artifactory.magmacore.org/artifactory/debian-test/pool
Pushing package magma_1.9.0-1667325390-acda59fe_amd64.deb to JFROG artifiactory: https://artifactory.magmacore.org/artifactory/debian-test/pool

```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
