### PR TITLE
fix(ci): node is pinned to version 17 that can be used on xenial

### DIFF
--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -175,7 +175,7 @@ else ifeq ($(OS_NAME),Darwin)
 endif
 
 nms_prereqs_ubuntu:
-	curl -sL https://deb.nodesource.com/setup_lts.x | bash -
+	curl -sL https://deb.nodesource.com/setup_17.x | bash -
 	apt install -y nodejs
 	npm install --global yarn
 	yarn


### PR DESCRIPTION
## Summary

[Orc8r Check Generated Files In Sync](https://github.com/magma/magma/actions/workflows/insync-checkin.yml) is broken because yarn can not be installed with the latest node 18 on xenial.

### suggested follow-ups

* the containers should be upgraded to a more recent ubuntu version -> [14344](https://github.com/magma/magma/issues/14344)

## Test Plan

CI - especially https://github.com/magma/magma/actions/runs/3377829368

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
