### PR TITLE
Break a test to see if it's run in the CI

### DIFF
--- a/feg/gateway/multiplex/multiplex_test.go
+++ b/feg/gateway/multiplex/multiplex_test.go
@@ -56,6 +56,7 @@ func TestMultiplexContextSessionIdConversions(t *testing.T) {
 	for _, scenario := range muxSelectorTestScenarios {
 		assertIMSIConversion(t, multiplex.NewContext().WithSessionId(scenario.sessionId), scenario)
 	}
+	assert.Equal(t, 1+1, 3)
 }
 
 func TestMultiplexContextIMSIstrConversions(t *testing.T) {

--- a/feg/radius/src/server/server_test.go
+++ b/feg/radius/src/server/server_test.go
@@ -58,6 +58,7 @@ func TestAnalyticsModulesAuthenticate(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
 	testParam := analyticsModuleTestEnvCreate(t, logger)
+	require.Equal(t, 1+1, 3)
 	testFullRADIUSSessiontWithAnalyticsModulesAuthenticate(t, logger, testParam)
 	analyticsModuleTestEnvDestroy(testParam)
 }


### PR DESCRIPTION
Do not merge. This PR is just to test the CI.

Results: Normal FEG tests run in the CI (see `make -C ${MAGMA_ROOT}/feg/gateway precommit` in `feg-workflow.yml`) but there is no CI step to execute the linter or unit tests for the code in `feg/radius/src`. 