### PR TITLE
chore(ci): remove flaky integration tests from containerized AGW tests

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -16,7 +16,6 @@ PROTO_LIST:=orc8r_protos lte_protos feg_protos
 PRECOMMIT_TESTS = s1aptests/test_services_are_running.py \
 s1aptests/test_attach_detach.py \
 s1aptests/test_attach_detach_static_ip.py \
-s1aptests/test_gateway_metrics_attach_detach.py \
 s1aptests/test_attach_detach_looped.py  \
 s1aptests/test_attach_emergency.py \
 s1aptests/test_attach_combined_eps_imsi.py \
@@ -112,7 +111,6 @@ s1aptests/test_multi_enb_complete_reset.py \
 s1aptests/test_multi_enb_sctp_shutdown.py \
 s1aptests/test_ipv6_paging_with_dedicated_bearer.py \
 s1aptests/test_ipv4v6_paging_with_dedicated_bearer.py \
-s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
 s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py \
 s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_sctpd_restart.py \
@@ -130,6 +128,7 @@ s1aptests/test_disable_ipv6_iface.py
 PRECOMMIT_TESTS_NOT_CONTAINER = \
 s1aptests/test_attach_detach_attach_dl_tcp_data.py \
 s1aptests/test_attach_detach_attach_ul_tcp_data.py \
+s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
 s1aptests/test_attach_dl_udp_data.py \
 s1aptests/test_attach_dl_tcp_data.py \
 s1aptests/test_attach_ul_tcp_data.py \
@@ -137,6 +136,7 @@ s1aptests/test_attach_ul_udp_data.py \
 s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
+s1aptests/test_gateway_metrics_attach_detach.py \
 s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
 
 EXTENDED_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \


### PR DESCRIPTION
## Summary

- were flaky in:
  - https://github.com/magma/magma/actions/runs/3343509606/jobs/5536801852#step:9:3037
  - https://github.com/magma/magma/actions/runs/3343509606/jobs/5536801852#step:9:12874
  - https://github.com/magma/magma/actions/runs/3337812368/jobs/5524636907#step:9:12652
  - https://github.com/magma/magma/actions/runs/3344170958/jobs/5538213289#step:9:12654

## Test Plan

- CI
