### PR TITLE
chore(agw): cleanup agw integtests after dockerization

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_continuous_random_attach.py
@@ -225,9 +225,7 @@ class TestContinuousRandomAttach(unittest.TestCase):
         end_timer = threading.Timer(test_duration, self.hadle_end_timer)
         end_timer.start()
 
-        while True:
-            if self.test_ended:
-                break
+        while not self.test_ended:
             response = self._s1ap_wrapper.s1_util.get_response()
             self.handle_msg(response)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_no_identity_rsp_with_mme_restart.py
@@ -105,21 +105,13 @@ class TestNoIdentityRspWithMmeRestart(unittest.TestCase):
         # part of configuraton file mme.conf.template. If MME restarts after
         # expiry of identity response timer, it will send the re-transmitted
         # identity request message
-        resp_count = 0
-        while True:
+        response = self._s1ap_wrapper.s1_util.get_response()
+        while response.msg_type != s1ap_types.tfwCmd.UE_CTX_REL_IND.value:
+            print(
+                "******************** Ignoring re-transmitted "
+                "Identity request indication",
+            )
             response = self._s1ap_wrapper.s1_util.get_response()
-            if (
-                response.msg_type
-                == s1ap_types.tfwCmd.UE_IDENTITY_REQ_IND.value
-            ):
-                resp_count += 1
-                print(
-                    "******************** Ignoring re-transmitted (",
-                    resp_count,
-                    ") Identity request indication",
-                )
-            else:
-                break
 
         # Context release
         assert response.msg_type == s1ap_types.tfwCmd.UE_CTX_REL_IND.value


### PR DESCRIPTION
## Summary

After the recent efforts to get the S1AP integration tests working for the dockerized AGW (#13684, #13964, #13965), this PR cleans up some leftovers, specifically simplifying two while loops to check for response messages from mme.

## Test Plan

Run AGW integration tests.

## Additional Information

- [ ] This change is backwards-breaking
