### PR TITLE
fix(amf): Periodic Registration failure

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -783,7 +783,7 @@ void amf_ue_context_update_ue_sig_connection_state(
         ue_context_p->m5_mobile_reachability_timer.id ==
             AMF_APP_TIMER_INACTIVE_ID) {
       ue_context_p->m5_mobile_reachability_timer.sec =
-          (amf_config.nas_config.t3512_min + (4 * 60));
+          (amf_config.nas_config.t3512_min + 4) * 60;
       ue_context_p->m5_implicit_deregistration_timer.sec =
           ue_context_p->m5_mobile_reachability_timer.sec;
 


### PR DESCRIPTION
Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

fix(amf): Periodic Registration failure

## Summary
Periodic Registration is failing due to a timer value mismatch with the reachability timer.
As per Spec "The default value of the implicit de-registration timer over 3GPP access is 4 minutes greater
than the value of timer T3512"

## Test Plan

verified Periodic Registration 
![image](https://user-images.githubusercontent.com/83060027/199980854-de7cbc92-c22d-4f2c-965c-3be617e0ea9d.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
