### PR TITLE
chore: the devcontainer uses the same grpc setup as the vm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -118,44 +118,15 @@ RUN echo "Install 3rd party dependencies" && \
         nlohmann-json3-dev && \
     echo "GRPC and it's dependencies" && \
     apt-get -y install --no-install-recommends \
-        grpc-dev
+        grpc-dev \
+        libprotobuf-dev \
+        libprotoc-dev \
+        protobuf-compiler \
+        prometheus-cpp-dev
 
 ##### Useful for logfile modification e.g. pruning all /magma/... prefix from GCC warning logs
 RUN GOBIN="/usr/bin/" go install github.com/ezekg/xo@0f7f076932dd && \
     rm --recursive --interactive=never /root/.cache/go-build
-
-##### GRPC and it's dependencies
-RUN git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc && \
-    mkdir -p grpc/cmake/build && \
-    cd grpc/cmake/build && \
-    cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON ../.. && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd ../../.. && \
-    rm --recursive --interactive=never grpc
-
-##### libprotobuf-mutator is used for randomized proto unit tests / property tests
-RUN git clone -b v1.0 https://github.com/google/libprotobuf-mutator && \
-    mkdir -p libprotobuf-mutator/build && \
-    cd libprotobuf-mutator/build && \
-    cmake .. -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug && \
-    ninja && \
-    ninja install && \
-    cd ../.. && \
-    rm --recursive --interactive=never libprotobuf-mutator
-
-##### Prometheus CPP
-RUN git clone https://github.com/jupp0r/prometheus-cpp.git && \
-    cd prometheus-cpp && \
-    git checkout d8326b2bba945a435f299e7526c403d7a1f68c1f && \
-    git submodule init && git submodule update && \
-    mkdir _build && \
-    cd _build/ && \
-    cmake .. && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd ../.. && \
-    rm --recursive --interactive=never prometheus-cpp
 
 # install magma dependencies
 RUN apt-get install -y --no-install-recommends \

--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -75,7 +75,6 @@ RUN apt-get install -y --no-install-recommends \
 # setup magma artifactories and install magma dependencies
 RUN wget -qO - https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public | apt-key add - && \
     add-apt-repository 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-ci main' && \
-    add-apt-repository 'deb https://artifactory.magmacore.org/artifactory/debian-test focal-1.7.0 main' && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bcc-tools \

--- a/lte/gateway/deploy/roles/dev_common/defaults/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/defaults/main.yml
@@ -3,6 +3,5 @@ codegen_root: /var/tmp/codegen
 mvn_version: 3.5.4
 mvn_sha1: 22cac91b3557586bb1eba326f2f7727543ff15e3
 mvn_dir: '/var/tmp/apache-maven-{{ mvn_version }}'
-tmp_libprotobuf_mutator_dir: '/var/tmp/libprotobuf-mutator'
 swagger_codegen_jar: '{{ codegen_root }}/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar'
 swagger_sha1: 34dd615d37edec0b50830ca12fc34e33c17b6d86

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -301,37 +301,6 @@
       - libssl-dev
 
 ###############################################
-# Download and build libprotobuf-mutator
-###############################################
-
-- name: Clone libprotobuf-mutator repo
-  become: yes
-  git:
-    repo: 'https://github.com/google/libprotobuf-mutator'
-    dest: "{{ tmp_libprotobuf_mutator_dir }}"
-    version: v1.0
-    force: yes
-  when: preburn
-
-- name: Create a build directory for libprotobuf-mutator
-  file:
-    path: "{{ tmp_libprotobuf_mutator_dir }}/build"
-    state: directory
-  when: preburn
-
-# Fails build unless we add -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON
-#  to download and build updated proto lib.
-- name: Build libprotobuf-mutator
-  become: yes
-  shell: |
-    cd {{ tmp_libprotobuf_mutator_dir }}/build && \
-    cmake .. -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON && \
-    ninja && \
-    ninja install && \
-    rm -rf {{ tmp_libprotobuf_mutator_dir }}
-  when: preburn
-
-###############################################
 # Download and build sentry-native
 ###############################################
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Analysis:
* grpc-dev (1.15.0-3) is on debian-test focal-ci, focal-1.8.0 (used on the vm)
* grpc-dev (1.43.2-3) is on debian-test focal-1.7.0 (used on the devcontainer)
* it looks like 1.43 also contains (parts of the) libraries libprotobuf-dev, libprotoc-dev, protobuf-compiler and that the manual prometheus-cpp build is not compatible to 1.15 (prometheus-cpp-dev can be used)
  * only using 1.15 breaks the mme and sessiond build (see link in issue)

Here:
* use grpc-dev 1.15 on the devcontainer (by removing the focal-1.7.0 artif from the bazel base container)
* install libraries that are additionally needed (and remove the self-build parts) <- this is actually the vm setup
* remove other unneeded self-build libraries - libprotobuf-mutator (I did not found a usage)
  * this was introduced in #6881 and #7079 but never used
* building the devcontainer is way faster with this change (less compiling)

## Test Plan

build devcontainer and execute tests:
```
docker build -f .devcontainer/bazel-base/Dockerfile -t bb:foo01 .
add bb:foo01 to devcontainer docker file
docker build -f .devcontainer/Dockerfile -t dc:foo01 .
docker run -v ${MAGMA_ROOT}:/workspaces/magma/ -v ${MAGMA_ROOT}/lte/gateway/configs:/etc/magma/ -it dc:foo01 /bin/bash
cd /workspaces/magma/lte/gateway
make test_session_manager
make test_oai
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
