### PR TITLE
chore: Bazel Bash completion

### DIFF
--- a/.devcontainer/post-create-commands.sh
+++ b/.devcontainer/post-create-commands.sh
@@ -20,4 +20,4 @@ echo "Generating compile_commands.json for C/C++ code navigation"
 "$1"/dev_tools/gen_compilation_database.py
 
 echo "Setting up Bazel Bash completion"
-"$1"/bazel/scripts/setup_bazel_bash_completion.sh
+"$1"/bazel/scripts/setup_bazel_bash_completion.sh $(cat "$1"/.bazelversion)

--- a/.devcontainer/post-create-commands.sh
+++ b/.devcontainer/post-create-commands.sh
@@ -18,3 +18,6 @@ fi
 
 echo "Generating compile_commands.json for C/C++ code navigation"
 "$1"/dev_tools/gen_compilation_database.py
+
+echo "Setting up Bazel Bash completion"
+"$1"/bazel/scripts/setup_bazel_bash_completion.sh

--- a/bazel/scripts/setup_bazel_bash_completion.sh
+++ b/bazel/scripts/setup_bazel_bash_completion.sh
@@ -19,6 +19,8 @@
 
 set -euo pipefail
 
+bazelversion="$1"  # We need a semantic version including patchlevel. This is usually read from .bazelversion
+
 function log() {
   echo "$@" >&2
 }
@@ -28,8 +30,10 @@ function generate_completion() {
   #
   # inspired by https://github.com/bazelbuild/bazel/blob/5f3f59ba367158b6c2e811f68cc946537b9b74d6/scripts/BUILD#L6-L26
   # which is referenced in https://bazel.build/install/completion
-  curl https://raw.githubusercontent.com/bazelbuild/bazel/release-5.3.0/scripts/bazel-complete-header.bash
-  curl https://raw.githubusercontent.com/bazelbuild/bazel/release-5.3.0/scripts/bazel-complete-template.bash
+  version="$1"
+  log "Downloading completions for Bazel version ${version}"
+  curl https://raw.githubusercontent.com/bazelbuild/bazel/release-"$version"/scripts/bazel-complete-header.bash
+  curl https://raw.githubusercontent.com/bazelbuild/bazel/release-"$version"/scripts/bazel-complete-template.bash
   bazel help completion
 }
 
@@ -37,7 +41,7 @@ if ! [ -f ~/.bash_completion.d/bazel-complete.bash ]
 then
   log "Creating completion script"
   mkdir -p ~/.bash_completion.d
-  generate_completion > ~/.bash_completion.d/bazel-complete.bash
+  generate_completion "$bazelversion" > ~/.bash_completion.d/bazel-complete.bash
 else
   log "Completion script already exists"
 fi

--- a/bazel/scripts/setup_bazel_bash_completion.sh
+++ b/bazel/scripts/setup_bazel_bash_completion.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+########################################################
+# Configures Bazel Bash-completion for the invoking user
+########################################################
+
+set -euo pipefail
+
+function log() {
+  echo "$@" >&2
+}
+
+function generate_completion() {
+  # outputs the completion script to stdout
+  #
+  # inspired by https://github.com/bazelbuild/bazel/blob/5f3f59ba367158b6c2e811f68cc946537b9b74d6/scripts/BUILD#L6-L26
+  # which is referenced in https://bazel.build/install/completion
+  curl https://raw.githubusercontent.com/bazelbuild/bazel/release-5.3.0/scripts/bazel-complete-header.bash
+  curl https://raw.githubusercontent.com/bazelbuild/bazel/release-5.3.0/scripts/bazel-complete-template.bash
+  bazel help completion
+}
+
+if ! [ -f ~/.bash_completion.d/bazel-complete.bash ]
+then
+  log "Creating completion script"
+  mkdir -p ~/.bash_completion.d
+  generate_completion > ~/.bash_completion.d/bazel-complete.bash
+else
+  log "Completion script already exists"
+fi
+
+if ! grep --quiet bazel-complete.bash ~/.bashrc
+then
+  log "Adapting ~/.bashrc to source completion script"
+  echo "source ~/.bash_completion.d/bazel-complete.bash" > ~/.bashrc
+else
+  log ".bashrc already sources the completion script"
+fi

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -258,7 +258,7 @@
   when: preburn
 
 - name: Setup Bazel Bash completion
-  ansible.builtin.command: "{{ magma_root }}/bazel/scripts/setup_bazel_bash_completion.sh"
+  ansible.builtin.command: "{{ magma_root }}/bazel/scripts/setup_bazel_bash_completion.sh $(cat {{ magma_root }}/.bazelversion)"
   become: yes
   become_user: "{{ ansible_user }}"
 

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -257,6 +257,11 @@
     force: yes
   when: preburn
 
+- name: Setup Bazel Bash completion
+  ansible.builtin.command: "{{ magma_root }}/bazel/scripts/setup_bazel_bash_completion.sh"
+  become: yes
+  become_user: "{{ ansible_user }}"
+
 ########################################
 # Install common Magma dev dependencies
 ########################################


### PR DESCRIPTION
## Summary

Setup Bash completion for Bazel for the VM and devcontainer

## Test Plan

VM: On host, do `cd $MAGMA_ROOT && vagrant provision magma; ssh magma`
Devcontainer: Close VS Code, run `docker ps -a | grep vsc`, `docker rm` the found container IDs, start VS Code

Inside VM/Devcontainer, verify that typing `bazel` and hitting Tab shows a list of options and verbs
