### PR TITLE
fix(ci): Use an internal network for the traffic server connection to magma VM

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -47,8 +47,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # For IPv6 network,
     # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
     # - `netmask` specified to enforce correct mask when using internal network
-    magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: true
-    magma.vm.network "private_network", type: "static6", ip: "3001::10", nic_type: "82540EM", virtualbox__intnet: true, netmask: "64"
+    magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: "sgi_ipv4"
+    magma.vm.network "private_network", type: "static6", ip: "3001::10", nic_type: "82540EM", virtualbox__intnet: "sgi_ipv6", netmask: "64"
 
 
     magma.vm.provider "virtualbox" do |vb|
@@ -82,8 +82,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # For IPv6 network,
     # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
     # - `netmask` specified to enforce correct mask when using internal network
-    magma_trfserver.vm.network "private_network", ip: "192.168.129.42", nic_type: "82540EM", virtualbox__intnet: true
-    magma_trfserver.vm.network "private_network", type: "static6", ip: "3001::2", nic_type: "82540EM", virtualbox__intnet: true, netmask: "64"
+    magma_trfserver.vm.network "private_network", ip: "192.168.129.42", nic_type: "82540EM", virtualbox__intnet: "sgi_ipv4"
+    magma_trfserver.vm.network "private_network", type: "static6", ip: "3001::2", nic_type: "82540EM", virtualbox__intnet: "sgi_ipv6", netmask: "64"
 
     magma_trfserver.vm.provider "virtualbox" do |vb|
       vb.name = "magma-trfserver"
@@ -136,8 +136,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # For IPv6 network,
     # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
     # - `netmask` specified to enforce correct mask when using internal network
-    magma_test.vm.network "private_network", ip: "192.168.128.11", nic_type: "82540EM", virtualbox__intnet: true
-    magma_test.vm.network "private_network", type: "static6", ip: "3001::3", nic_type: "82540EM", virtualbox__intnet: true, netmask: "64"
+    magma_test.vm.network "private_network", ip: "192.168.128.11", nic_type: "82540EM", virtualbox__intnet: "sgi_ipv4"
+    magma_test.vm.network "private_network", type: "static6", ip: "3001::3", nic_type: "82540EM", virtualbox__intnet: "sgi_ipv6", netmask: "64"
     config.ssh.forward_agent = true
 
     magma_test.vm.provider "virtualbox" do |vb|
@@ -230,8 +230,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # For IPv6 network,
     # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
     # - `netmask` specified to enforce correct mask when using internal network
-    magma_deb.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: true
-    magma_deb.vm.network "private_network", type: "static6", ip: "3001::10", nic_type: "82540EM", virtualbox__intnet: true, netmask: "64"
+    magma_deb.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: "sgi_ipv4"
+    magma_deb.vm.network "private_network", type: "static6", ip: "3001::10", nic_type: "82540EM", virtualbox__intnet: "sgi_ipv6", netmask: "64"
 
     magma_deb.vm.provider "virtualbox" do |vb|
       vb.name = "magma_deb"

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -44,8 +44,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     magma.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
     # iperf3 trfserver routable IP.
     # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    # For IPv6 network,
+    # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
+    # - `netmask` specified to enforce correct mask when using internal network
     magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: true
-    magma.vm.network "private_network", ip: "3001::10", nic_type: "82540EM"
+    magma.vm.network "private_network", type: "static6", ip: "3001::10", nic_type: "82540EM", virtualbox__intnet: true, netmask: "64"
 
 
     magma.vm.provider "virtualbox" do |vb|
@@ -76,8 +79,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     magma_trfserver.vm.network "private_network", ip: "192.168.60.144", nic_type: "82540EM"
     # iperf3 server IP.
     # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    # For IPv6 network,
+    # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
+    # - `netmask` specified to enforce correct mask when using internal network
     magma_trfserver.vm.network "private_network", ip: "192.168.129.42", nic_type: "82540EM", virtualbox__intnet: true
-    magma_trfserver.vm.network "private_network", ip: "3001::2", nic_type: "82540EM"
+    magma_trfserver.vm.network "private_network", type: "static6", ip: "3001::2", nic_type: "82540EM", virtualbox__intnet: true, netmask: "64"
 
     magma_trfserver.vm.provider "virtualbox" do |vb|
       vb.name = "magma-trfserver"
@@ -127,8 +133,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     magma_test.vm.network "private_network", ip: "192.168.60.141", nic_type: "82540EM"
     # UE trfgen network
     # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    # For IPv6 network,
+    # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
+    # - `netmask` specified to enforce correct mask when using internal network
     magma_test.vm.network "private_network", ip: "192.168.128.11", nic_type: "82540EM", virtualbox__intnet: true
-    magma_test.vm.network "private_network", ip: "3001::3", nic_type: "82540EM"
+    magma_test.vm.network "private_network", type: "static6", ip: "3001::3", nic_type: "82540EM", virtualbox__intnet: true, netmask: "64"
     config.ssh.forward_agent = true
 
     magma_test.vm.provider "virtualbox" do |vb|
@@ -218,8 +227,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     magma_deb.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
     # iperf3 trfserver routable IP.
     # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    # For IPv6 network,
+    # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
+    # - `netmask` specified to enforce correct mask when using internal network
     magma_deb.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: true
-    magma_deb.vm.network "private_network", ip: "3001::10", nic_type: "82540EM"
+    magma_deb.vm.network "private_network", type: "static6", ip: "3001::10", nic_type: "82540EM", virtualbox__intnet: true, netmask: "64"
 
     magma_deb.vm.provider "virtualbox" do |vb|
       vb.name = "magma_deb"

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -43,7 +43,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # 2. Any changes to the magma networking should be propagated to magma_deb
     magma.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
     # iperf3 trfserver routable IP.
-    magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: true
     magma.vm.network "private_network", ip: "3001::10", nic_type: "82540EM"
 
 
@@ -74,7 +75,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # using a specific IP.
     magma_trfserver.vm.network "private_network", ip: "192.168.60.144", nic_type: "82540EM"
     # iperf3 server IP.
-    magma_trfserver.vm.network "private_network", ip: "192.168.129.42", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    magma_trfserver.vm.network "private_network", ip: "192.168.129.42", nic_type: "82540EM", virtualbox__intnet: true
     magma_trfserver.vm.network "private_network", ip: "3001::2", nic_type: "82540EM"
 
     magma_trfserver.vm.provider "virtualbox" do |vb|
@@ -124,7 +126,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # using a specific IP.
     magma_test.vm.network "private_network", ip: "192.168.60.141", nic_type: "82540EM"
     # UE trfgen network
-    magma_test.vm.network "private_network", ip: "192.168.128.11", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    magma_test.vm.network "private_network", ip: "192.168.128.11", nic_type: "82540EM", virtualbox__intnet: true
     magma_test.vm.network "private_network", ip: "3001::3", nic_type: "82540EM"
     config.ssh.forward_agent = true
 
@@ -214,7 +217,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # 2. Any changes to the magma networking should be propagated to magma_deb
     magma_deb.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
     # iperf3 trfserver routable IP.
-    magma_deb.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    magma_deb.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: true
     magma_deb.vm.network "private_network", ip: "3001::10", nic_type: "82540EM"
 
     magma_deb.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
## Summary

Closes https://github.com/magma/magma/issues/14312

## Test Plan

- [x] Verified locally that without this change, the traffic server connects to the vagrant host, while with this change, it connects to the magma VM. In particular, I ran `ip neigh` on the traffic server and saw that the MAC address of eth2 was that of vagrant host and then magma VM
- [x] Checked the modified interfaces before and after the changes to check that the netmasks remain the same
- [ ] Ran traffic tests locally
- [x] Ran IPv6 test locally, by running `test_enable_ipv6_iface.py`, `test_ipv6_non_nat_dp_ul_tcp.py` and `test_disable_ipv6_iface.py` in succession
- [x] Checked that the above tests pass upon restarting the traffic server between runs
- [ ] Running LTE integration tests on [fork](https://github.com/voisey/magma/actions/runs/3435162044)