### PR TITLE
fix: bazel debian handling is fixed

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -299,19 +299,19 @@ jobs:
       - name: Setup JFROG CLI
         uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
         env:
-          JF_ENV_1: ${{ secrets.JFROG_TOKEN }}
+          JF_URL: https://artifactory.magmacore.org
+          JF_USER: ${{ secrets.JFROG_USERNAME }}
+          JF_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
       - name: Set dry run environment variable
         if: ${{ ! ( github.event_name == 'push' && github.repository_owner == 'magma' ) }}
         run: |
           echo "IS_DRY=--dry-run" >> $GITHUB_ENV
       - name: Publish debian packages
         env:
-          ARTIFACTORY_URL: https://artifactory.magmacore.org:443/artifactory/
           DEBIAN_META_INFO: deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64
         run: |
           jf rt upload \
             --recursive=false \
-            --url=${ARTIFACTORY_URL} \
             --detailed-summary \
             ${{ env.IS_DRY }} \
             --target-props="${DEBIAN_META_INFO}" \

--- a/.github/workflows/build_magma_dep.yml
+++ b/.github/workflows/build_magma_dep.yml
@@ -29,7 +29,6 @@ on:
 env:
   MAGMA_PACKAGE_DIR: /home/runner/magma-packages
   LIBNETTLE_PATH: /usr/lib/libnettle.so
-  ARTIFACTORY_URL: https://artifactory.magmacore.org:443/artifactory/
 
 jobs:
   build_deps:
@@ -71,7 +70,9 @@ jobs:
       - name: Setup JFROG CLI
         uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
         env:
-          JF_ENV_1: ${{ secrets.JFROG_TOKEN }}
+          JF_URL: https://artifactory.magmacore.org
+          JF_USER: ${{ secrets.JFROG_USERNAME }}
+          JF_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
       - name: Set dry run environment variable
         id: is_dry
         if: ${{ inputs.dry_run == 'true' }}
@@ -81,7 +82,6 @@ jobs:
         run: |
           jf rt u \
             --recursive=false \
-            --url=${ARTIFACTORY_URL} \
             --detailed-summary \
             ${{ env.IS_DRY }} \
             --target-props="deb.distribution=${{ inputs.distribution }};deb.component=main;deb.architecture=amd64" \

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -85,7 +85,7 @@ jobs:
         env:
           MAGMA_DEV_CPUS: 3
           MAGMA_DEV_MEMORY_MB: 9216
-          MAGMA_PACKAGE: magma_1.8.0_amd64.deb
+          MAGMA_PACKAGE: magma_1.9.0-VERSION-SUFFIX_amd64.deb
         run: |
           cd lte/gateway
           fab integ_test_deb_installation


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Two fixes for #14338:
* the secret for the jfrog cli token does not exist on the magma repo - changed to the existing username and password credentials
* the name of the magma artifact was changed - this was not done in the integ test workflow

## Test Plan

* test secrets on fork: https://github.com/nstng/magma/actions/runs/3410390975/jobs/5673298284
  * green and uploaded
* start integ test on fork: https://github.com/nstng/magma/actions/runs/3410245956/jobs/5672969625
  * install works again

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
