### PR TITLE
chore: Link folly dynamically in bazel by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,9 +23,6 @@ build --per_file_copt=^lte/gateway/c/.*$@-g
 # Please read the GH issue #13073 before adding "test" options.
 test --test_output=errors
 
-# Use dynamically linked folly library
-build --define=folly_so=1
-
 # MAGMA VM CONFIGS
 build:specify_vm_cc --action_env=CC=/usr/bin/gcc
 build:vm --config=specify_vm_cc

--- a/bazel/bazelrcs/cwag.bazelrc
+++ b/bazel/bazelrcs/cwag.bazelrc
@@ -1,2 +1,1 @@
 build --define=disable_sentry_native=1
-build --define=folly_so=1

--- a/bazel/external/system_libraries.BUILD
+++ b/bazel/external/system_libraries.BUILD
@@ -14,37 +14,15 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
-# This configuration is used for building inside the Magma VM
-# The default configuration applies for building inside the bazel build Docker container
-config_setting(
-    name = "use_folly_so",
-    values = {"define": "folly_so=1"},
-)
-
 cc_library(
     name = "folly",
-    srcs = select({
-        ":use_folly_so": ["usr/local/lib/libfolly.so"],
-        "//conditions:default": [
-            "usr/local/lib/libfolly.a",
-            "usr/local/lib/libfmt.a",
-        ],
-    }),
-    linkopts = select({
-        ":use_folly_so": [
-            "-ldl",
-            "-levent",
-            "-ldouble-conversion",
-            "-lgflags",
-        ],
-        "//conditions:default": [
-            "-ldl",
-            "-levent",
-            "-ldouble-conversion",
-            "-lgflags",
-            "-liberty",
-        ],
-    }),
+    srcs = ["usr/local/lib/libfolly.so"],
+    linkopts = [
+        "-ldl",
+        "-levent",
+        "-ldouble-conversion",
+        "-lgflags",
+    ],
 )
 
 cc_library(

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -146,8 +146,7 @@ RUN bazel build  \
   //lte/gateway/c/sctpd/src:sctpd \
   //lte/gateway/c/connection_tracker/src:connectiond \
   //lte/gateway/c/li_agent/src:liagentd \
-  //lte/gateway/c/session_manager:sessiond \
-  --define=folly_so=1
+  //lte/gateway/c/session_manager:sessiond
 
 RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_oai BUILD_TYPE="${BUILD_TYPE}"
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #13365
- Link folly dynamically in bazel by default


## Test Plan

- `bazel build //lte/gateway/c/session_manager/...`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
