### PR TITLE
fix: bazel debian handling is fixed II

### DIFF
--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -155,7 +155,7 @@
 
 - name: Set magma package variable
   set_fact:
-    magma_package: "{{ MAGMA_PACKAGE | default('magma<1.9.0', true) }}"
+    magma_package: "{{ MAGMA_PACKAGE | default('magma=1.8.0*', true) }}"
 
 - name: Installing magma from local debian package
   become: true

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -81,6 +81,7 @@ pkg_tar(
 
 pkg_deb(
     name = "sctpd_deb_pkg",
+    architecture = ARCH,
     data = ":sctpd_content",
     description = "Magma SCTPD",
     homepage = URL,
@@ -176,6 +177,7 @@ pkg_tar(
 
 pkg_deb(
     name = "magma_deb_pkg",
+    architecture = ARCH,
     data = ":magma_content",
     depends = MAGMA_DEPS + OAI_DEPS + OVS_DEPS,
     description = "Magma Access Gateway",


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Two issues from #14338 are fixed here:
1. with bazel created magma and sctpd artifacts have architecture `all` set - this should be `amd64`
2. running the magma debian make workflow manually was trying to install `magma<1.9.0`  - this is just wrong. apt does not allow such syntax - I did not test this correctly (it does not suffice that `MAGMA_PACKAGE` is not set, it must be set to ""). Changed to `magma=1.8.0*` which seems to install the latest 1.8.0 version.

## Test Plan

* bazel run //lte/gateway/release:release_build
  * before:
dpkg -I /tmp/packages/magma_1.9.0-foo_amd64.deb 
Architecture: all
  * after:
dpkg -I /tmp/packages/magma_1.9.0-bar_amd64.deb 
Architecture: amd64
* make deb integ tests manual run: https://github.com/nstng/magma/actions/runs/3412291519/jobs/5677611779
  * manual workflow run can be started and magma is installed

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
