### PR TITLE
fix: missing sctpd min version file is added to magma artifact

### DIFF
--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -18,7 +18,7 @@ load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazel:deb_build.bzl", "PY_DEST")
-load(":deb_dependencies.bzl", "MAGMA_DEPS", "OAI_DEPS", "OVS_DEPS")
+load(":deb_dependencies.bzl", "MAGMA_DEPS", "OAI_DEPS", "OVS_DEPS", "SCTPD_MIN_VERSION")
 
 SCTPD_PKGNAME = "magma-sctpd"
 
@@ -159,6 +159,18 @@ pkg_filegroup(
     prefix = "/etc/magma",
 )
 
+genrule(
+    name = "gen_magma_sctpd_min_version",
+    outs = ["sctpd_min_version"],
+    cmd = "echo \"{ver}\" > \"$@\"".format(ver = SCTPD_MIN_VERSION),
+)
+
+pkg_files(
+    name = "magma_sctpd_min_version",
+    srcs = [":gen_magma_sctpd_min_version"],
+    prefix = "/usr/local/share/magma/",
+)
+
 pkg_tar(
     name = "magma_content",
     srcs = [
@@ -168,6 +180,7 @@ pkg_tar(
         ":magma_go_binaries",
         ":magma_python_scripts",
         ":magma_python_services",
+        ":magma_sctpd_min_version",
         ":magma_service_definitions",
         "//lte/gateway/deploy/roles/magma/files:ansible_configs",
         "//orc8r/tools/ansible/roles/fluent_bit/files:magma_config_fluent_bit",


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

The missing file `/usr/local/share/magma/sctpd_min_version` containing the min sctpd version compatible to magma is added to the bazel build magma debian package.

## Test Plan

* build packages: bazel run //lte/gateway/release:release_build
* dpkg -c magma.deb | grep sctpd_min_version
* ar x magma.deb, extract tar, see content

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
