### PR TITLE
chore: bazel magma deb content is compressed

### DIFF
--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -28,6 +28,8 @@ VERSION_DEB = "{ver}-VERSION-SUFFIX".format(ver = VERSION)
 
 ARCH = "amd64"
 
+TAR_EXTENSION = "tar.gz"
+
 SCTPD_FILE_NAME = "{name}_{ver}_{arch}".format(
     name = SCTPD_PKGNAME,
     arch = ARCH,
@@ -76,7 +78,11 @@ pkg_tar(
         ":sctpd_version",
         "//lte/gateway/deploy/roles/magma/files/systemd:sctpd_service_definition",
     ],
-    package_file_name = "{fname}.tar".format(fname = SCTPD_FILE_NAME),
+    extension = TAR_EXTENSION,
+    package_file_name = "{fname}.{ext}".format(
+        ext = TAR_EXTENSION,
+        fname = SCTPD_FILE_NAME,
+    ),
 )
 
 pkg_deb(
@@ -172,7 +178,11 @@ pkg_tar(
         "//lte/gateway/deploy/roles/magma/files:ansible_configs",
         "//orc8r/tools/ansible/roles/fluent_bit/files:magma_config_fluent_bit",
     ],
-    package_file_name = "{fname}.tar".format(fname = MAGMA_FILE_NAME),
+    extension = TAR_EXTENSION,
+    package_file_name = "{fname}.{ext}".format(
+        ext = TAR_EXTENSION,
+        fname = MAGMA_FILE_NAME,
+    ),
 )
 
 pkg_deb(


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

The data is not compressed in the bazel build debian package. This is the default of the `pkg_tar` rule (create `data.tar`). Changing this to `tar.gz` decreases the size of the created artifacts. Downside is that the build takes slightly longer (locally ~ 90 seconds).

#### before

```
ll /tmp/packages/
-rwxr-xr-x 1 vscode vscode 393M Nov  7 20:13 magma_1.9.0-1667851997-cef13c0c_amd64.deb*
-rwxr-xr-x 1 vscode vscode  35M Nov  7 20:13 magma-sctpd_1.9.0-1667851997-cef13c0c_amd64.deb*
```

#### after

```
ll /tmp/packages/
-rwxr-xr-x 1 vscode vscode 115M Nov  7 20:22 magma_1.9.0-1667852545-fe43df73_amd64.deb*
-rwxr-xr-x 1 vscode vscode 8.4M Nov  7 20:22 magma-sctpd_1.9.0-1667852545-fe43df73_amd64.deb*
```

## Test Plan

* local build:
  * `bazel run //lte/gateway/release:release_build`
  * `ll /tmp/packages/`
* local fork run that uses the artifact: https://github.com/nstng/magma/actions/runs/3413840891
  * flaky, but shows that artifact was build, installed and did run

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
