### PR TITLE
fix(amf): added n11 unit test cases

### DIFF
--- a/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.hpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.hpp
@@ -57,12 +57,18 @@ class AmfServiceImpl final : public SmfPduSessionSmContext::Service {
   grpc::Status SetSmfSessionContext(ServerContext* context,
                                     const SetSMSessionContextAccess* request,
                                     SmContextVoid* response) override;
+  bool SetSmfSessionContext_itti(
+      const SetSMSessionContextAccess* request,
+      itti_n11_create_pdu_session_response_t* itti_msg_p);
+  grpc::Status SetAmfNotification_itti(
+      const SetSmNotificationContext* notif,
+      itti_n11_received_notification_t* itti_msg);
   bool fillUpPacketFilterContents(packet_filter_contents_t* pf_content,
                                   const FlowMatch* flow_match_rule);
   bool fillIpv6(packet_filter_contents_t* pf_content,
-                const std::string ipv6addr);
+                const std::string ipv6network_str);
   bool fillIpv4(packet_filter_contents_t* pf_content,
-                const std::string& ipv4addr);
+                const std::string& ipv4network_str);
   ipv4_networks_t parseIpv4Network(const std::string& ipv4network_str);
 };
 

--- a/lte/gateway/c/core/oai/test/n11/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/test/n11/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(smf_service_client test_smf_service_client.cpp)
 add_executable(auth_service_client test_auth_service_client.cpp)
 
 target_link_libraries(smf_service_client
-	LIB_N11 gtest gtest_main pthread protobuf rt yaml-cpp
+	LIB_N11 gtest gtest_main pthread protobuf rt yaml-cpp TASK_GRPC_SERVICE
     )
 target_link_libraries(auth_service_client
 	LIB_N11 TASK_AMF_APP gtest gtest_main pthread protobuf grpc++ dl m rt yaml-cpp

--- a/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
+++ b/lte/gateway/c/core/oai/test/n11/test_smf_service_client.cpp
@@ -16,6 +16,7 @@
 
 #include "lte/protos/session_manager.pb.h"
 #include "lte/gateway/c/core/oai/lib/n11/SmfServiceClient.hpp"
+#include "lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.hpp"
 
 using ::testing::Test;
 
@@ -85,6 +86,122 @@ TEST(test_create_sm_pdu_session_v4, create_sm_pdu_session_v4) {
   uint8_t pti_decoded = (uint8_t)rat_req->procedure_trans_identity();
   EXPECT_EQ(pti, pti_decoded);
   EXPECT_EQ(ue_ipv4_addr, req_cmn->ue_ipv4());
+}
+
+TEST(test_create_sm_pdu_session_response, create_sm_pdu_session_response) {
+  SetSMSessionContextAccess request;
+  AmfServiceImpl amfservice;
+
+  itti_n11_create_pdu_session_response_t itti_msg;
+
+  auto* req_common = request.mutable_common_context();
+  auto* req_m5g =
+      request.mutable_rat_specific_context()->mutable_m5g_session_context_rsp();
+
+  req_common->mutable_sid()->set_id("IMSI901700000000001");
+  req_common->set_ue_ipv4("192.168.128.12");
+  req_common->set_apn("internet");
+
+  req_m5g->set_pdu_session_id(1);
+  req_m5g->set_pdu_session_type(magma::lte::PduSessionType::IPV4);
+  req_m5g->set_selected_ssc_mode(magma::lte::SscMode::SSC_MODE_1);
+  req_m5g->set_allowed_ssc_mode(magma::lte::SscMode::SSC_MODE_2);
+  req_m5g->mutable_subscribed_qos()->set_apn_ambr_dl(4000);
+  req_m5g->mutable_subscribed_qos()->set_apn_ambr_ul(3000);
+  req_m5g->mutable_subscribed_qos()->set_priority_level(1);
+  req_m5g->mutable_subscribed_qos()->set_qos_class_id(magma::lte::QCI::QCI_9);
+  req_m5g->mutable_subscribed_qos()->set_preemption_capability(
+      magma::lte::prem_capab::SHALL_NOT_TRIGGER_PRE_EMPTION);
+  req_m5g->mutable_subscribed_qos()->set_preemption_vulnerability(
+      magma::lte::prem_vuner::PRE_EMPTABLE);
+  req_m5g->set_m5gsm_cause(magma::lte::M5GSMCause::OPERATION_SUCCESS);
+  req_m5g->set_m5g_sm_congestion_reattempt_indicator(true);
+  req_m5g->set_procedure_trans_identity(1);
+  req_m5g->mutable_upf_endpoint()->set_teid(2147483647);
+  req_m5g->mutable_upf_endpoint()->set_end_ipv4_addr("192.168.60.142");
+  req_m5g->set_always_on_pdu_session_indication(true);
+
+  amfservice.SetSmfSessionContext_itti(&request, &itti_msg);
+
+  EXPECT_EQ(itti_msg.pdu_session_id, req_m5g->pdu_session_id());
+  EXPECT_EQ(itti_msg.pdu_session_type, req_m5g->pdu_session_type());
+  EXPECT_EQ(itti_msg.selected_ssc_mode, req_m5g->selected_ssc_mode());
+  EXPECT_EQ(itti_msg.allowed_ssc_mode, req_m5g->allowed_ssc_mode());
+  EXPECT_EQ(itti_msg.m5gsm_cause, req_m5g->m5gsm_cause());
+  EXPECT_EQ(itti_msg.m5gsm_congetion_re_attempt_indicator,
+            req_m5g->m5g_sm_congestion_reattempt_indicator());
+  EXPECT_EQ(itti_msg.always_on_pdu_session_indication,
+            req_m5g->always_on_pdu_session_indication());
+  EXPECT_EQ(itti_msg.procedure_trans_identity,
+            req_m5g->procedure_trans_identity());
+  EXPECT_EQ(itti_msg.session_ambr.uplink_units,
+            req_m5g->mutable_subscribed_qos()->apn_ambr_ul());
+  EXPECT_EQ(itti_msg.session_ambr.downlink_units,
+            req_m5g->mutable_subscribed_qos()->apn_ambr_dl());
+  EXPECT_EQ(
+      itti_msg.qos_flow_list.item[0].qos_flow_req_item.qos_flow_identifier,
+      req_m5g->mutable_subscribed_qos()->qos_class_id());
+  EXPECT_EQ(itti_msg.qos_flow_list.item[0]
+                .qos_flow_req_item.qos_flow_descriptor.qos_flow_identifier,
+            req_m5g->mutable_subscribed_qos()->qos_class_id());
+  EXPECT_EQ(itti_msg.qos_flow_list.item[0]
+                .qos_flow_req_item.qos_flow_descriptor.fiveQi,
+            req_m5g->mutable_subscribed_qos()->qos_class_id());
+  EXPECT_EQ(itti_msg.qos_flow_list.item[0]
+                .qos_flow_req_item.qos_flow_level_qos_param.qos_characteristic
+                .non_dynamic_5QI_desc.fiveQI,
+            req_m5g->mutable_subscribed_qos()->qos_class_id());
+  EXPECT_EQ(itti_msg.qos_flow_list.item[0]
+                .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
+                .priority_level,
+            req_m5g->mutable_subscribed_qos()->priority_level());
+  EXPECT_EQ(itti_msg.qos_flow_list.item[0]
+                .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
+                .pre_emption_cap,
+            req_m5g->mutable_subscribed_qos()->preemption_capability());
+  EXPECT_EQ(itti_msg.qos_flow_list.item[0]
+                .qos_flow_req_item.qos_flow_level_qos_param.alloc_reten_priority
+                .pre_emption_vul,
+            req_m5g->mutable_subscribed_qos()->preemption_vulnerability());
+}
+
+TEST(test_received_notification_t, create_received_notification_t) {
+  SetSmNotificationContext notif;
+  AmfServiceImpl amfservice;
+
+  itti_n11_received_notification_t itti_msg;
+  auto* notify_common = notif.mutable_common_context();
+  auto* req_m5g = notif.mutable_rat_specific_notification();
+
+  // CommonSessionContext
+  notify_common->mutable_sid()->set_id("IMSI901700000000001");
+  notify_common->set_sm_session_state(
+      magma::lte::SMSessionFSMState::CREATING_0);
+  notify_common->set_sm_session_version(1);
+
+  // RatSpecificContextAccess
+  req_m5g->set_pdu_session_id(1);
+  req_m5g->set_request_type(magma::lte::RequestType::INITIAL_REQUEST);
+  req_m5g->set_pdu_session_type(magma::lte::PduSessionType::IPV4);
+  req_m5g->mutable_m5g_sm_capability()->set_reflective_qos(1);
+  req_m5g->mutable_m5g_sm_capability()->set_multi_homed_ipv6_pdu_session(2);
+  req_m5g->set_m5gsm_cause(magma::lte::M5GSMCause::OPERATION_SUCCESS);
+  req_m5g->set_notify_ue_event(PDU_SESSION_STATE_NOTIFY);
+
+  amfservice.SetAmfNotification_itti(&notif, &itti_msg);
+
+  EXPECT_EQ(itti_msg.pdu_session_id, req_m5g->pdu_session_id());
+  EXPECT_EQ(itti_msg.pdu_session_type, req_m5g->pdu_session_type());
+  EXPECT_EQ(itti_msg.sm_session_version, notify_common->sm_session_version());
+  EXPECT_EQ(itti_msg.sm_session_fsm_state, notify_common->sm_session_state());
+  EXPECT_EQ(itti_msg.request_type, req_m5g->request_type());
+  EXPECT_EQ(itti_msg.m5g_sm_capability.reflective_qos,
+            req_m5g->mutable_m5g_sm_capability()->reflective_qos());
+  EXPECT_EQ(
+      itti_msg.m5g_sm_capability.multi_homed_ipv6_pdu_session,
+      req_m5g->mutable_m5g_sm_capability()->multi_homed_ipv6_pdu_session());
+  EXPECT_EQ(itti_msg.m5gsm_cause, req_m5g->m5gsm_cause());
+  EXPECT_EQ(itti_msg.notify_ue_evnt, req_m5g->notify_ue_event());
 }
 }  // namespace lte
 }  // namespace magma


### PR DESCRIPTION
Signed-off-by: priya-wavelabs <priya.agrawal@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Added n11 unit test cases for N11_CREATE_PDU_SESSION_RESPONSE and N11_NOTIFICATION_RECEIVED.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

1. Verified with Unit Test.
![Screenshot from 2022-11-08 11-46-49](https://user-images.githubusercontent.com/102359835/200489641-c02e6e59-1d73-422e-9557-9dcfd538e015.png)

2. Verified basic sanity with ueransim.
pcap snap :
![image](https://user-images.githubusercontent.com/102359835/200492644-eae17b6e-a23f-470c-a2ad-275f70e25956.png)



3. Logs
[mme.log](https://github.com/magma/magma/files/9958242/mme.log)



<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
