### PR TITLE
chore: bazel debian artifacts are only created for master merges and manual runs

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -260,11 +260,10 @@ jobs:
 
   bazel_package:
     needs: path_filter
-    # Only run workflow if this is a push to the magma repository,
-    # if the workflow has been triggered manually or if it is a pull_request.
+    # Only run workflow if this is a push to the magma repository
+    # or if the workflow has been triggered manually.
     if: |
-      (github.event_name == 'push' && github.repository_owner == 'magma') ||
-      needs.path_filter.outputs.files_changed == 'true' ||
+      (github.event_name == 'push' && github.repository_owner == 'magma' && needs.path_filter.outputs.files_changed == 'true') ||
       github.event_name == 'workflow_dispatch'
     name: Bazel Package Job
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In order to decrease AWS costs (remote caches), debian packages are only build for master merges.

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
