### PR TITLE
chore: remote cache traffic is reduced by not caching large artifacts

### DIFF
--- a/lte/gateway/python/BUILD.bazel
+++ b/lte/gateway/python/BUILD.bazel
@@ -28,6 +28,7 @@ LTE_PY_SERVICES = [
 [
     expand_runfiles(
         name = "{py_service}_expanded".format(py_service = py_service),
+        tags = ["no-cache"],
         targets = [
             "//lte/gateway/python/magma/{py_service}:{py_service}".format(py_service = py_service),
         ],
@@ -38,5 +39,6 @@ LTE_PY_SERVICES = [
 pkg_filegroup(
     name = "magma_python_lte_services",
     srcs = ["{py_service}_expanded".format(py_service = py_service) for py_service in LTE_PY_SERVICES],
+    tags = ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
 )

--- a/lte/gateway/python/scripts/BUILD.bazel
+++ b/lte/gateway/python/scripts/BUILD.bazel
@@ -51,6 +51,7 @@ SCRIPTS = [
 
 expand_runfiles(
     name = "scripts_expanded",
+    tags = ["no-cache"],
     targets = [":{script}".format(script = script) for script in SCRIPTS],
 )
 
@@ -58,6 +59,7 @@ expand_runfiles(
     pkg_mklink(
         name = "{script}_symlink".format(script = script),
         link_name = "/usr/local/bin/{script}.py".format(script = script),
+        tags = ["no-cache"],
         target = "{dest}/scripts/{script}.py".format(
             dest = PY_DEST,
             script = script,
@@ -71,6 +73,7 @@ pkg_filegroup(
     srcs = [":scripts_expanded"] +
            ["{script}_symlink".format(script = script) for script in SCRIPTS],
     prefix = PY_DEST,
+    tags = ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
 )
 

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -69,6 +69,7 @@ pkg_files(
     srcs = ["//lte/gateway/c/sctpd/src:sctpd"],
     attributes = pkg_attributes(mode = "0755"),
     prefix = "/usr/local/sbin",
+    tags = ["no-cache"],
 )
 
 pkg_tar(
@@ -83,6 +84,7 @@ pkg_tar(
         ext = TAR_EXTENSION,
         fname = SCTPD_FILE_NAME,
     ),
+    tags = ["no-cache"],
 )
 
 pkg_deb(
@@ -94,6 +96,7 @@ pkg_deb(
     maintainer = MAINTAINER,
     package = SCTPD_PKGNAME,
     package_file_name = "{fname}.deb".format(fname = SCTPD_FILE_NAME),
+    tags = ["no-cache"],
     version = VERSION_DEB,
 )
 
@@ -124,6 +127,7 @@ pkg_filegroup(
         "//lte/gateway/python/scripts:magma_lte_scripts",
         "//orc8r/gateway/python/scripts:magma_orc8r_scripts",
     ],
+    tags = ["no-cache"],
 )
 
 pkg_files(
@@ -131,6 +135,7 @@ pkg_files(
     srcs = ["//feg/gateway/services/envoy_controller"],
     attributes = pkg_attributes(mode = "0755"),
     prefix = "/usr/local/bin",
+    tags = ["no-cache"],
 )
 
 pkg_files(
@@ -144,6 +149,7 @@ pkg_files(
     attributes = pkg_attributes(mode = "0755"),
     prefix = "/usr/local/bin",
     renames = {"//lte/gateway/c/core:agw_of": "mme"},
+    tags = ["no-cache"],
 )
 
 pkg_filegroup(
@@ -153,6 +159,7 @@ pkg_filegroup(
         "//orc8r/gateway/python:magma_python_orc8r_services",
     ],
     prefix = PY_DEST,
+    tags = ["no-cache"],
 )
 
 pkg_filegroup(
@@ -196,6 +203,7 @@ pkg_tar(
         ext = TAR_EXTENSION,
         fname = MAGMA_FILE_NAME,
     ),
+    tags = ["no-cache"],
 )
 
 pkg_deb(
@@ -211,6 +219,7 @@ pkg_deb(
     postinst = ":magma-postinst-bazel",
     provides = [MAGMA_PKGNAME],
     replaces = [MAGMA_PKGNAME],
+    tags = ["no-cache"],
     version = VERSION_DEB,
 )
 
@@ -252,5 +261,8 @@ sh_binary(
         ":magma_deb_pkg",
         ":sctpd_deb_pkg",
     ],
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-cache",
+    ],
 )

--- a/orc8r/gateway/python/BUILD.bazel
+++ b/orc8r/gateway/python/BUILD.bazel
@@ -23,6 +23,7 @@ ORC8R_PY_SERVICES = [
 [
     expand_runfiles(
         name = "{py_service}_expanded".format(py_service = py_service),
+        tags = ["no-cache"],
         targets = [
             "//orc8r/gateway/python/magma/{py_service}:{py_service}".format(py_service = py_service),
         ],
@@ -33,5 +34,6 @@ ORC8R_PY_SERVICES = [
 pkg_filegroup(
     name = "magma_python_orc8r_services",
     srcs = ["{py_service}_expanded".format(py_service = py_service) for py_service in ORC8R_PY_SERVICES],
+    tags = ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
 )

--- a/orc8r/gateway/python/scripts/BUILD.bazel
+++ b/orc8r/gateway/python/scripts/BUILD.bazel
@@ -36,6 +36,7 @@ SCRIPTS = [
 
 expand_runfiles(
     name = "scripts_expanded",
+    tags = ["no-cache"],
     targets = [":{script}".format(script = script) for script in SCRIPTS],
 )
 
@@ -43,6 +44,7 @@ expand_runfiles(
     pkg_mklink(
         name = "{script}_symlink".format(script = script),
         link_name = "/usr/local/bin/{script}.py".format(script = script),
+        tags = ["no-cache"],
         target = "{dest}/scripts/{script}.py".format(
             dest = PY_DEST,
             script = script,
@@ -56,6 +58,7 @@ pkg_filegroup(
     srcs = [":scripts_expanded"] +
            ["{script}_symlink".format(script = script) for script in SCRIPTS],
     prefix = PY_DEST,
+    tags = ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
 )
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In order to reduce aws costs caused by remote caches, large artifacts are not cached.

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
