### PR TITLE
fix(ci): add typing import to `firebase_publish.py`

### DIFF
--- a/ci-scripts/firebase_publish.py
+++ b/ci-scripts/firebase_publish.py
@@ -14,6 +14,7 @@ limitations under the License.
 import json
 import os
 import time
+from typing import Dict
 
 import pyrebase
 


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Adds the correct typing to `firebase_publish.py` which causes some firebase publishes to fail.

## Test Plan

- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
