### PR TITLE
fix(ci): restrict docker push to Github push event

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -400,6 +400,7 @@ jobs:
           REGISTRY: ${{ env.DOCKER_REGISTRY }}
           IMAGE: ${{ env.DOCKER_IMAGE }}
           DOCKERCONTEXT: ${{ env.DOCKERCONTEXT }}
+          PUSH: ${{ github.event_name == 'push' }}
 
   agw-container-build-python-ghz:
     runs-on: ubuntu-latest
@@ -427,6 +428,7 @@ jobs:
           REGISTRY: ${{ env.DOCKER_REGISTRY }}
           IMAGE: ${{ env.DOCKER_IMAGE }}
           DOCKERCONTEXT: ${{ env.DOCKERCONTEXT }}
+          PUSH: ${{ github.event_name == 'push' }}
 
   agw-container-build-c:
     if: github.repository_owner == 'magma'
@@ -453,6 +455,7 @@ jobs:
           REGISTRY: ${{ env.DOCKER_REGISTRY }}
           IMAGE: ${{ env.DOCKER_IMAGE }}
           DOCKERFILE: ${{ env.DOCKER_FILE }}
+          PUSH: ${{ github.event_name == 'push' }}
 
   agw-container-build-python:
     if: github.repository_owner == 'magma'
@@ -479,6 +482,7 @@ jobs:
           REGISTRY: ${{ env.DOCKER_REGISTRY }}
           IMAGE: ${{ env.DOCKER_IMAGE }}
           DOCKERFILE: ${{ env.DOCKER_FILE }}
+          PUSH: ${{ github.event_name == 'push' }}
 
   agw-container-build-go:
     if: github.repository_owner == 'magma'
@@ -505,6 +509,7 @@ jobs:
           REGISTRY: ${{ env.DOCKER_REGISTRY }}
           IMAGE: ${{ env.DOCKER_IMAGE }}
           DOCKERFILE: ${{ env.DOCKER_FILE }}
+          PUSH: ${{ github.event_name == 'push' }}
 
   agw-container-build-is-successful:
     runs-on: ubuntu-latest

--- a/.github/workflows/composite/docker-builder-agw/action.yml
+++ b/.github/workflows/composite/docker-builder-agw/action.yml
@@ -37,7 +37,7 @@ inputs:
     default: .
   PUSH:
     description: Push to registry?
-    default: true
+    default: false
     type: boolean
 
 outputs:
@@ -54,6 +54,7 @@ runs:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
 
     - name: Login to Docker Hub
+      if: ${{ inputs.PUSH == 'true' }}
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin@v2.1.0
       with:
         registry: ${{ inputs.REGISTRY }}


### PR DESCRIPTION
## Summary

Restrict the docker push, as credentials are not accessible for forked workflows.

## Test Plan

- CI:
  - https://github.com/magma/magma/actions/runs/3418737229
  - https://github.com/magma/magma/actions/runs/3418692916

## Additional Information

- Follow up on https://github.com/magma/magma/pull/14302.
