### PR TITLE
fix(ci): Remove dev dependencies before building release

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -98,6 +98,8 @@ def package(
 
     hash = pkg.get_commit_hash()
     commit_count = pkg.get_commit_count()
+    puts('Uninstalling dev dependencies of the VM')
+    run('sudo pip uninstall --yes mypy-protobuf grpcio-tools grpcio protobuf')
 
     with cd('~/magma/lte/gateway'):
         run('mkdir -p ~/magma-deps')


### PR DESCRIPTION
## Summary

When building a release with fabric, we need to remove packages that are already installed in the VM. Otherwise pydep will get confused and will not build and update them.

In particular, this commit removes the packages installed in `orc8r/tools/ansible/roles/python_dev/tasks/main.yml` and their dependencies.

## Test Plan

I tested that a Magma build using `fab release package` with the changes from #14369 includes the updated version of the protobuf. Without removing the dependencies, the Magma build will create a package that requires the new protobuf version but cannot be installed because the new protobuf is not packaged.

## Additional Information

- [ ] This change is backwards-breaking