### PR TITLE
chore(mme): Build MME for the OAI-MME variant with Bazel

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
+++ b/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
@@ -15,13 +15,13 @@ RUN rm -Rf $MAGMA_ROOT $C_BUILD && mkdir -p $C_BUILD
 COPY ./ $MAGMA_ROOT
 
 # Build MME executables
-RUN cd $MAGMA_ROOT/lte/gateway && \
+RUN cd $MAGMA_ROOT && \
     echo $FEATURES && \
-    make build_oai && \
-    make build_sctpd && \
-    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme && \
-    ldd $C_BUILD/core/oai/oai_mme/oai_mme && \
-    ldd $C_BUILD/sctpd/src/sctpd
+    bazel build //lte/gateway/c/core:mme_oai --define=disable_sentry_native=1 && \
+    bazel build //lte/gateway/c/sctpd/src:sctpd --define=disable_sentry_native=1 && \
+    mv $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/mme_oai $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
+    ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
+    ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd
 
 # Prepare config file
 RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
@@ -101,9 +101,9 @@ COPY --from=magma-mme-builder \
     /usr/local/lib/libgflags.so.2.2 \
     /usr/local/lib/libcares.so.2 \
     /usr/local/lib/libaddress_sorting.so \
-    /usr/local/lib/libnettle.so.4 \
-    /usr/local/lib/libgnutls.so.28 \
-    /usr/local/lib/libhogweed.so.2 \
+    /usr/lib/libnettle.so.4 \
+    /usr/lib/libgnutls.so.28 \
+    /usr/lib/libhogweed.so.2 \
     /usr/local/lib/
 
 # Copy all fdx files from freeDiameter installation
@@ -116,8 +116,8 @@ RUN ldconfig
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
 COPY --from=magma-mme-builder \
-    $C_BUILD/core/oai/oai_mme/oai_mme \
-    $C_BUILD/sctpd/src/sctpd \
+    $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme \
+    $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd \
     ./
 
 # For the moment, we are not putting any etc/*.conf files

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -58,7 +58,7 @@ RUN wget --quiet https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
     cd nettle-2.5 && \
     mkdir build && \
     cd build/ && \
-    ../configure --disable-openssl --enable-shared --libdir=/usr/local/lib && \
+    ../configure --disable-openssl --enable-shared --libdir=/usr/lib && \
     make -j`nproc` && \
     make install && \
     ldconfig -v && \
@@ -66,7 +66,7 @@ RUN wget --quiet https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
     wget --quiet https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
     tar xf gnutls-3.1.23.tar.xz && \
     cd gnutls-3.1.23 && \
-    ./configure --with-libnettle-prefix=/usr/local && \
+    ./configure --with-libnettle-prefix=/usr --prefix=/usr && \
     make -j`nproc` && \
     make install && \
     ldconfig -v
@@ -185,15 +185,20 @@ RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git 
     make -j`nproc` && \
     make install
 
+# Install bazel
+WORKDIR /usr/sbin
+RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
+    chmod +x bazelisk-linux-amd64 && \
+    ln -sf /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
+
 # Build MME executables
-RUN ldconfig && \
-    cd $MAGMA_ROOT/lte/gateway && \
+RUN cd $MAGMA_ROOT && \
     echo $FEATURES && \
-    make build_oai && \
-    make build_sctpd && \
-    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme && \
-    ldd $C_BUILD/core/oai/oai_mme/oai_mme && \
-    ldd $C_BUILD/sctpd/src/sctpd
+    bazel build //lte/gateway/c/core:mme_oai --define=disable_sentry_native=1 && \
+    bazel build //lte/gateway/c/sctpd/src:sctpd --define=disable_sentry_native=1 && \
+    mv $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/mme_oai $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
+    ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
+    ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd
 
 # Prepare config file
 RUN apt-get install -y python3-pip && \
@@ -227,8 +232,8 @@ RUN apt-get install -y python3-pip && \
 # For developer's to have the same run env as in target image to debug
 # Copy the configuration file templates and mean to modify/generate certificates
 WORKDIR /magma-mme/bin
-RUN cp $C_BUILD/core/oai/oai_mme/mme oai_mme
-RUN cp $C_BUILD/sctpd/src/sctpd .
+RUN cp $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme .
+RUN cp $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd .
 WORKDIR /magma-mme/etc
 RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme.conf .
 RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme_fd.conf .
@@ -305,9 +310,9 @@ COPY --from=magma-mme-builder \
     /usr/local/lib/libgflags.so.2.2 \
     /usr/local/lib/libcares.so.2 \
     /usr/local/lib/libaddress_sorting.so \
-    /usr/local/lib/libnettle.so.4 \
-    /usr/local/lib/libgnutls.so.28 \
-    /usr/local/lib/libhogweed.so.2 \
+    /usr/lib/libnettle.so.4 \
+    /usr/lib/libgnutls.so.28 \
+    /usr/lib/libhogweed.so.2 \
     /usr/local/lib/
 
 # Copy all fdx files from freeDiameter installation
@@ -320,8 +325,8 @@ RUN ldconfig
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
 COPY --from=magma-mme-builder \
-    $C_BUILD/core/oai/oai_mme/oai_mme \
-    $C_BUILD/sctpd/src/sctpd \
+    $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme \
+    $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd \
     ./
 
 # Copy the configuration file templates and mean to modify/generate certificates


### PR DESCRIPTION
Co-authored-by: Krisztián Varga <krisztian.varga@tngtech.com>
Co-authored-by: Lars Kreutzer <lars.kreutzer@tngtech.com>
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- MME and SCTPD are build with bazel
  - `--define=disable_sentry_native=1` is needed in order to disable Sentry, which has additional dependencies.
  - The locations of several packages (libnettle, libgnutls and libhogweed) are different and have to be modified. 
- To accelerate the build on PRs the base image already contains a build on these targets. 
- Based on https://github.com/magma/magma/pull/13113
- Resolves #14308
- Resolves #13401

## Test Plan

- [Run on PR](https://jenkins-oai.eurecom.fr/blue/organizations/jenkins/MAGMA-MME-production/detail/MAGMA-MME-production/19832/pipeline)
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
