### PR TITLE
chore: deb integ test uses artifact from bazel workflow

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -296,6 +296,22 @@ jobs:
               --profile=Bazel_build_package_profile
             mkdir packages
             mv /tmp/packages/*.deb packages
+      - name: Get magma version
+        run: |
+          version_pattern="magma_([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-[a-z0-9]+)_amd64.deb"
+          for i in packages/*.deb; do
+              if [[ $i =~ $version_pattern ]]; then
+                  magma_version=${BASH_REMATCH[1]}
+              fi
+          done
+          if [[ -z "$magma_version" ]]; then
+              echo "No file found with a matching version pattern \"${version_pattern}\". Files in folder:"
+              ls -la packages/*.deb
+              exit 1
+          else
+              echo "Exporting magma version \"${magma_version}\""
+              echo "MAGMA_VERSION=${magma_version}" >> $GITHUB_ENV
+          fi
       - name: Setup JFROG CLI
         uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
         env:
@@ -303,7 +319,7 @@ jobs:
           JF_USER: ${{ secrets.JFROG_USERNAME }}
           JF_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
       - name: Set dry run environment variable
-        if: ${{ ! ( github.event_name == 'push' && github.repository_owner == 'magma' ) }}
+        if: ${{ ! ( github.event_name == 'push' && github.repository_owner == 'magma' && github.ref_name == 'master' ) }}
         run: |
           echo "IS_DRY=--dry-run" >> $GITHUB_ENV
       - name: Publish debian packages
@@ -316,6 +332,16 @@ jobs:
             ${{ env.IS_DRY }} \
             --target-props="${DEBIAN_META_INFO}" \
             "packages/(*).deb" debian-test/pool/focal-ci/{1}.deb
+
+      - name: Trigger debian integ test workflow
+        uses: peter-evans/repository-dispatch@f2696244ec00ed5c659a5cc77f7138ad0302dffb # pin@v2.1.0
+        if: github.event_name == 'push' && github.repository_owner == 'magma' && github.ref_name == 'master'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: magma/magma
+          event-type: magma-debian-artifact
+          client-payload: '{ "magma_version": "${{ env.MAGMA_VERSION }}" }'
+
       - name: Publish bazel profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: ${{ always() && github.event.inputs.publish_bazel_profile == 'true' }}

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1095,7 +1095,7 @@ jobs:
     needs: agw-build
     steps:
       - name: Trigger debian integ test workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@f2696244ec00ed5c659a5cc77f7138ad0302dffb # pin@v2.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: magma/magma

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -13,16 +13,8 @@ name: AGW Build & Test LTE Integration With Bazel Debian Build
 
 on:
   workflow_dispatch: null
-  push:
-    branches:
-      - master
-      - 'v1.*'
-
-env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
-  # see GH14041
-  CACHE_KEY: bazel-base-image-sha-c4de1e5
-  REMOTE_DOWNLOAD_OPTIMIZATION: true
+  repository_dispatch:
+    types: [magma-debian-artifact]
 
 jobs:
   lte-integ-test-bazel-magma-deb:
@@ -55,38 +47,23 @@ jobs:
           pip3 install --upgrade pip
           pip3 install ansible fabric3 jsonpickle requests PyYAML
           vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
-      - name: Install docker
-        uses: docker-practice/actions-setup-docker@5d9a5f65f510c01ec5f0bd81d5c95768b1ec032a # pin@v1
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/
           echo '* 192.168.0.0/16' | sudo tee /etc/vbox/networks.conf
           echo '* 3001::/64' | sudo tee -a /etc/vbox/networks.conf
 
-      - name: Build .deb packages
-        run: |
-          docker run \
-            -v ${{ github.workspace }}:/workspaces/magma/ \
-            -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma \
-            -i \
-            ${{ env.BAZEL_BASE_IMAGE }} \
-            bash -c \
-              'cd /workspaces/magma && \
-              bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}" && \
-              bazel build lte/gateway/release:sctpd_deb_pkg lte/gateway/release:magma_deb_pkg \
-                --config=production \
-                --profile=Bazel_build_package_profile && \
-              mv /workspaces/magma/bazel-bin/lte/gateway/release/magma*.deb /workspaces/magma/'
-      - name: Delete all docker containers
-        run: |
-          docker system prune -f -a --volumes
-
       - name: Run the integ test
         env:
           MAGMA_DEV_CPUS: 3
           MAGMA_DEV_MEMORY_MB: 9216
-          MAGMA_PACKAGE: magma_1.9.0-VERSION-SUFFIX_amd64.deb
         run: |
+          if [[ -z "${{ github.event.client_payload.magma_version }}" ]]; then
+            export MAGMA_PACKAGE=magma
+          else
+            export MAGMA_PACKAGE=magma=${{ github.event.client_payload.magma_version }}
+          fi
+          echo "Starting integration tests using magma artifact \"${MAGMA_PACKAGE}\"."
           cd lte/gateway
           fab integ_test_deb_installation
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In #14338 a bazel created debian artifact was published to the magmacore artifactory. In the current bazel debian integ test workflow the artifact is build on-the-fly.

Here: use the artifact from the artifactory in the integration test workflow.

This uses the same mechanic that was introduced in `.github/workflows/lte-integ-test-magma-deb.yml` (triggered by `.github/workflows/build_all.yml`).

## Test Plan

This is not easy to test on a fork run.
* `bazel.yml` trigger logging: https://github.com/nstng/magma/actions/runs/3419776199/jobs/5693727190
`Exporting magma version "1.9.0-1667914145-e2a104b9"`
* `lte-integ-test-magma-deb.yml` run without version (installs latest magma artifact): https://github.com/nstng/magma/actions/runs/3420337375/jobs/5695026753

The actual transfer of the version can only be tested on master.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
