### PR TITLE
chore: update docu is fixed and upgrade docu is added

### DIFF
--- a/bazel/external/requirements_README.md
+++ b/bazel/external/requirements_README.md
@@ -1,16 +1,21 @@
 # Python Dependencies managed by Bazel
 
-Requirements.txt holds all Python dependencies which are required by Python-based modules in Magma and have to be built via Bazel. All entries are loadable and, thus part of the Bazel environment if necessary. However, an entry is only loaded via Bazel if a Bazel target applies it as a dependency. 
+Requirements.txt holds all Python dependencies which are required by Python-based modules in Magma and have to be built via Bazel. All entries are loadable and, thus part of the Bazel environment if necessary. However, an entry is only loaded via Bazel if a Bazel target applies it as a dependency.
 
-### How to update Python dependencies:
+## How to update Python dependencies
 
- 1. Insert missing dependencies in requirements.in 
+ 1. Add, remove or modify dependencies in requirements.in
 
- 2. Generate a new version of requirements.txt, including required hashes 
+ 2. Generate a new version of requirements.txt, including required hashes
     
        `cd $MAGMA/bazel/external`
 
-       `pip-compile --upgrade-package --generate-hashes --output-file=requirements.txt requirements.in`
+       `pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in`
 
  The changes are then automatically included in the next Bazel build process.
 
+## How to upgrade Python dependencies
+
+In general, existing and thus pinned dependencies in the requirement.txt are not upgraded when the command above is executed. In order to upgrade all dependencies (to the highest possible version) use the following command:
+
+`pip-compile --upgrade --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in`


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

* the current docu was not working - the flag is `--upgrade`
* split up to modify and upgrade docu - motivation: upgrades should be done separately in order to avoid side effects when an unrelated requirements entry is changed.

## Test Plan

-

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
