### PR TITLE
chore(ci): improve readability in `magma_deb/tasks/main.yml`

### DIFF
--- a/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deb/tasks/main.yml
@@ -13,7 +13,12 @@
 ################################################################################
 
 - name: Enable IP forwarding
-  sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    sysctl_set: yes
+    state: present
+    reload: yes
 
 - name: Set a convenience function for disabling TCP checksumming for traffic test
   lineinfile:
@@ -51,7 +56,9 @@
     force: yes
 
 - name: Copy preferences file for backports
-  copy: src=magma-preferences dest=/etc/apt/preferences.d/magma-preferences
+  copy:
+    src: magma-preferences
+    dest: /etc/apt/preferences.d/magma-preferences
 
 - name: Change network settings
   ansible.builtin.shell: sudo bash /home/vagrant/magma/lte/gateway/deploy/agw_network_ubuntu.sh
@@ -92,7 +99,9 @@
     force: yes
 
 - name: Create test certificates directory
-  file: path='/home/vagrant/magma/.cache/test_certs' state=directory
+  file:
+    path: /home/vagrant/magma/.cache/test_certs
+    state: directory
 
 - name: Generate the cloud VM's certs if they are not already generated
   command: '/home/vagrant/magma/orc8r/tools/ansible/roles/gateway_dev/files/create_rootca /home/vagrant/magma/.cache/test_certs'


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Adapt the layout of several Ansible steps from an in-line command to a multi-line step to improve readability.

## Test Plan

- `vagrant up magma_deb`
- All changed Ansible steps were executed as before.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
