### PR TITLE
chore: the module not found check is robust regarding non daemon processes

### DIFF
--- a/bazel/scripts/test_python_service_imports.sh
+++ b/bazel/scripts/test_python_service_imports.sh
@@ -85,7 +85,7 @@ do
 # the same options as the 'bazel run' below. For 'bazel run' the option is set
 # in the bazelrc, due to https://github.com/bazelbuild/bazel/issues/11920
     echo "Testing service: ${SERVICE}"
-    if timeout --preserve-status 5 bazel run "${SERVICE}" 2>&1  | tee "${LOGGING_FILE}";
+    if timeout --signal 9 --preserve-status 5 bazel run "${SERVICE}" 2>&1  | tee "${LOGGING_FILE}";
     then
         echo "Service successfully started."
         NUM_SUCCESS=$((NUM_SUCCESS + 1))


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In #14355 pipelined is refactored.

During the smoke test where the service is started and the log is checked for ModuleNotFound exceptions pipelined was stopped because the network configuration is not sufficient on the devcontainer (completely ok for the smoke test). In #14355 the service runs longer and comes to a state where the timeout command can not end the service gracefully.

Here: give timeout a signal 9 option in order to make sure that the process is ended

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
