### PR TITLE
fix: Pass command through shell

### DIFF
--- a/bazel/scripts/setup_bazel_bash_completion.sh
+++ b/bazel/scripts/setup_bazel_bash_completion.sh
@@ -49,7 +49,7 @@ fi
 if ! grep --quiet bazel-complete.bash ~/.bashrc
 then
   log "Adapting ~/.bashrc to source completion script"
-  echo "source ~/.bash_completion.d/bazel-complete.bash" > ~/.bashrc
+  echo "source ~/.bash_completion.d/bazel-complete.bash" >> ~/.bashrc
 else
   log ".bashrc already sources the completion script"
 fi

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -258,7 +258,7 @@
   when: preburn
 
 - name: Setup Bazel Bash completion
-  ansible.builtin.command: "{{ magma_root }}/bazel/scripts/setup_bazel_bash_completion.sh $(cat {{ magma_root }}/.bazelversion)"
+  ansible.builtin.shell: "{{ magma_root }}/bazel/scripts/setup_bazel_bash_completion.sh $(cat {{ magma_root }}/.bazelversion)"
   become: yes
   become_user: "{{ ansible_user }}"
 


### PR DESCRIPTION
## Summary

The parameters passed to the completion generation script were wrong because they were not expanded by a shell as expected. This fixes it. Also the `.bashrc` was overwritten, this PR appends to `.bashrc` instead.

Fixes #14399 

## Test Plan

```
vagrant destroy magma_test
vagrant up magma_test
```
Verify that completions are working.