### PR TITLE
refactor(ci): use filenames instead titles for dependencies

### DIFF
--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -13,9 +13,9 @@ name: PR Generate Comment On Workflow Failure
 on:
   workflow_run:
     workflows:
-      - PR Check DCO
-      - AGW Build & Format Python
-      - Docs Lint & Check Generated Files In Sync
+      - dco-check
+      - python-workflow
+      - docs-workflow
     types:
       - completed
 


### PR DESCRIPTION
## Summary

- Closes https://github.com/magma/magma/issues/14325

## Test Plan

- CI
