### PR TITLE
chore: Remove small code owner groups

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,11 +14,6 @@
 /.golangci.yml @magma/approvers-orc8r
 /orc8r/ @magma/approvers-orc8r
 
-# approvers-orc8r-infra
-/orc8r/cloud/docker/ @magma/approvers-orc8r-infra
-/orc8r/cloud/deploy/ @magma/approvers-orc8r-infra
-*/cloud/helm/ @magma/approvers-orc8r-infra
-
 # approvers-nms
 /nms/ @magma/approvers-nms
 
@@ -43,7 +38,6 @@
 /src/go/ @magma/approvers-orc8r
 
 # approvers-agw-<subsection>
-/lte/gateway/c/session_manager @magma/approvers-agw-sessiond
 /lte/gateway/c/core/oai @magma/approvers-agw-mme
 /lte/gateway/c/sctpd @magma/approvers-agw-mme
 /lte/gateway/python/integ_tests @magma/approvers-agw-integtests


### PR DESCRIPTION
## Summary

As discussed in [a recent TSC meeting](https://wiki.magmacore.org/display/HOME/November+7%2C+2022+Meeting), we want to merge some small code owner groups with little activity into their larger counterparts. (The members of the groups will be merged.)

- approvers-orc8r-infra is merged into approvers-orc8r-infra
- approvers-agw-sessiond is merged into approvers-agw

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking