### PR TITLE
refactor(ci): consolidate and clean up Slack messages

### DIFF
--- a/.github/workflows/agw-coverage.yml
+++ b/.github/workflows/agw-coverage.yml
@@ -110,22 +110,20 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
-      - name: Notify Bazel C/C++ coverage failure to slack
-        if: |
-          failure() &&
-          (steps.bazel-cc-codecoverage.conclusion == 'failure' ||
-          steps.c-cpp-codecov-upload.outcome == 'failure') &&
-          github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "C / C++ code coverage with Bazel"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
-
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   python-codecov:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -181,18 +179,17 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
-      - name: Notify Bazel Python coverage failure to slack
-        if: |
-          failure() &&
-          (steps.bazel-python-codecoverage.conclusion == 'failure' ||
-          steps.python-codecov-upload.outcome == 'failure') &&
-          github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Python code coverage with Bazel"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -203,17 +203,20 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Bazel Build & Test Job `bazel build //...; bazel test //...` ${{ matrix.bazel-config }}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
 
   if_bazel_build_and_test_success:
     name: Run when bazel successful
@@ -353,17 +356,20 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Bazel Package Job"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
 
   python_file_check:
     name: Check if there are not bazelified python files
@@ -375,17 +381,20 @@ jobs:
         shell: bash
         run: |
           ./bazel/scripts/check_py_bazel.sh
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Bazel Python Check Job `./bazel/scripts/check_py_bazel.sh`"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
 
   c_cpp_file_check:
     name: Check if there are non-bazelified c or c++ files
@@ -397,14 +406,17 @@ jobs:
         shell: bash
         run: |
           ./bazel/scripts/check_c_cpp_bazel.sh
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Bazel C/C++ Check Job `./bazel/scripts/check_c_cpp_bazel.sh`"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -97,7 +97,6 @@ jobs:
         if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_TITLE: "*Helm charts have been published*"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
@@ -227,7 +226,6 @@ jobs:
         if: success() && github.event_name == 'push'
         env:
           SLACK_TITLE: "Github action agw build got published"
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_USERNAME: ${{ github.workflow }}
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
@@ -367,7 +365,6 @@ jobs:
         if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_TITLE: "*Orchestrator images have been published*"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
@@ -599,7 +596,6 @@ jobs:
         if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_TITLE: "*SwaggerHub Updated*"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
@@ -715,7 +711,6 @@ jobs:
         if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_TITLE: "*CWAG Artifact Has Been Published*"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
@@ -802,7 +797,6 @@ jobs:
         if: success() && github.ref == 'refs/heads/master'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
           SLACK_TITLE: "*CWF Artifact Has Been Published*"
@@ -903,7 +897,6 @@ jobs:
         if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_TITLE: "*FeG Artifact Has Been Published*"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
@@ -985,7 +978,6 @@ jobs:
         if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_TITLE: "NMS Artifact Has Been Published*"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
@@ -1083,7 +1075,6 @@ jobs:
         if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
           SLACK_TITLE: "*Domain proxy images have been published*"
           SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -79,31 +79,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action Push helm charts to artifactory failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      # Notify ci channel when push succeeds
-      - name: Notify success to Slack
-        if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "*Helm charts have been published*"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
       - name: Only keep the last 20 uploaded versions
         if: github.event_name == 'push'
         run: |
@@ -211,26 +200,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        env:
-          SLACK_TITLE: "Github action agw build failed"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_AVATAR: ":boom:"
-        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
         with:
-          args: "AGW  build failed on [${{github.sha}}](${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}): ${{ steps.commit.outputs.title}}"
-      # Notify ci channel when push succeeds
-      - name: Notify success to Slack
-        if: success() && github.event_name == 'push'
-        env:
-          SLACK_TITLE: "Github action agw build got published"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_USERNAME: ${{ github.workflow }}
-        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
-        with:
-          args: "AGW  build succeeded on [${{github.sha}}](${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}): ${{ steps.commit.outputs.title}}"
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   sentry_release:
     if: always() && github.event_name == 'push'
     needs: [ agw-build ]
@@ -348,30 +331,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to Slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        # yamllint enable
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Github action orc8r-build failed"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      # Notify ci channel when push succeeds
-      - name: Notify success to Slack
-        if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "*Orchestrator images have been published*"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
 
   agw-container-build-c-ghz:
     runs-on: ubuntu-latest
@@ -580,29 +553,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to Slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action cloud-upload failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      # Notify ci channel when push succeeds
-      - name: Notify success to Slack
-        if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "*SwaggerHub Updated*"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   cwag-deploy:
     if: github.repository_owner == 'magma'
     name: cwag deploy job
@@ -695,29 +659,20 @@ jobs:
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       # yamllint enable
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "CWAG-deploy failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      # Notify ci channel when push succeeds
-      - name: Notify success to slack
-        if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "*CWAG Artifact Has Been Published*"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   cwf-operator-build:
     if: github.repository_owner == 'magma'
     name: cwf operator build job
@@ -781,29 +736,20 @@ jobs:
       # Notify ci channel when failing
       # Plugin info: https://github.com/marketplace/actions/slack-notify
       # yamllint enable
-      - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "CWF-operator-build failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ''
-      # Notify ci channel when push succeeds
-      - name: Notify success to slack
-        if: success() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_TITLE: "*CWF Artifact Has Been Published*"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ''
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   feg-build:
     if: github.repository_owner == 'magma'
     name: feg-build
@@ -878,32 +824,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      # yamllint enable
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "FeG-precommit tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      # Notify ci channel when push succeeds
-      - name: Notify success to slack
-        if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "*FeG Artifact Has Been Published*"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   nms-build:
     if: github.repository_owner == 'magma'
     name: nms-build job
@@ -959,32 +893,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      # yamllint enable
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Github action nms-build failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      # Notify ci channel when push succeeds
-      - name: Notify success to slack
-        if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "NMS Artifact Has Been Published*"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   Publish_to_firebase:
     name: Publish to firebase
     if: always() && github.event_name == 'push' && github.repository_owner == 'magma'
@@ -1058,30 +980,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to Slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        # yamllint enable
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Github action domain-proxy-build failed"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      # Notify ci channel when push succeeds
-      - name: Notify success to Slack
-        if: success() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_TITLE: "*Domain proxy images have been published*"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":heavy_check_mark:"
-          SLACK_COLOR: "#00FF00"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   trigger-debian-integ-test:
     if: always() && github.event_name == 'push' && github.repository_owner == 'magma' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -135,47 +135,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to Slack for deploy-sync-checkin
-        if: steps.deploy-sync-checkin.outcome=='failure' && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action insync-checkin failed"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      - name: Notify failure to Slack for cloud-test
-        if: steps.cloud-test.outcome=='failure' && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action cloud-test failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      - name: Notify failure to Slack for cloud-lint
-        if: ( steps.cloud-lint.outcome=='failure' || steps.cloud-lint-codecov.outcome=='failure' || steps.cloud-lint-cov.outcome=='failure' ) && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action cloud-test failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      - name: Notify failure to Slack for orc8r-gateway-test
-        if: ( steps.gateway_test_init.outcome=='failure' || steps.gateway_test_dep.outcome=='failure' || steps.gateway_test.outcome=='failure' ) && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action orc8r-gateway-test failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -90,16 +90,17 @@ jobs:
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
 
-      # Notify ci-info channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action CodeQL-analysis ${{ matrix.language }} failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }} ${{ matrix.language }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/composite/notify-slack/action.yml
+++ b/.github/workflows/composite/notify-slack/action.yml
@@ -1,0 +1,57 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Notify Slack
+description: Send a notification to slack about build status
+
+inputs:
+  webhook:
+    description: Slack incoming webhook specifying the channel to send to.
+  status:
+    description: Success status with valid input 'success' and 'failure'.
+  message:
+    description: Message to be displayed in notification.
+
+runs:
+  using: composite
+  # env is not allowed in composite actions
+  steps:
+    - name: Set layout for default
+      run: |
+        echo "icon=':information_source:'" >> $GITHUB_ENV
+        echo "color='#0000FF'" >> $GITHUB_ENV
+      shell: bash
+
+    - if: inputs.status == 'success'
+      name: Set layout for success
+      run: |
+        echo "icon=':heavy_check_mark:'" >> $GITHUB_ENV
+        echo "color='#00FF00'" >> $GITHUB_ENV
+      shell: bash
+
+    - if: inputs.status == 'failure'
+      name: Set layout for failure
+      run: |
+        echo "icon=':boom:'" >> $GITHUB_ENV
+        echo "color='#FF0000'" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Notify Slack
+      if: inputs.webhook != ''
+      uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+      env:
+        SLACK_WEBHOOK: ${{ inputs.webhook }}
+        SLACK_USERNAME: ${{ github.workflow }}
+        SLACK_TITLE: ${{ github.job }}
+        SLACK_ICON_EMOJI: ${{ env.icon }}
+        SLACK_COLOR: ${{ job.status }}
+        SLACK_MESSAGE: ${{ inputs.message }}
+        MSG_MINIMAL: actions url,commit

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -79,16 +79,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "CWAG-precommit tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -70,16 +70,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "CWF-operator-precommit tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ''
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -45,16 +45,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.ref == 'refs/heads/master'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action Docusaurus update failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -113,30 +113,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: ( steps.feg-lint-init.outcome=='failure' || steps.feg-lint.outcome=='failure' || steps.feg-lint-cov.outcome=='failure' || steps.feg-lint-codecov.outcome=='failure'  ) && github.event_name ==
-          'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_TITLE: "FeG-lint tests failed"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: ( steps.feg-precommit.outcome=='failure' || steps.feg-precommit-upload.outcome=='failure' ) && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "FeG-precommit tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/fossa-workflow.yml
+++ b/.github/workflows/fossa-workflow.yml
@@ -53,16 +53,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action fossa-analyze update failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -132,14 +132,17 @@ jobs:
         run: |
           echo "Available storage:"
           df -h
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Build all Bazelified C/C++ targets"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
-          MSG_MINIMAL: actions url,commit
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -88,17 +88,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "build_src_go tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
 
   test_src_go:
     needs: pre_job_src_go_determinator
@@ -134,17 +137,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "test_src_go tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
 
   test_src_go_qemu:
     needs: pre_job_src_go_determinator
@@ -185,17 +191,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "test_src_go_qemu tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
 
   codecov_src_go:
     needs: pre_job_src_go_determinator
@@ -226,14 +235,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "codecov_src_go tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -78,14 +78,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "check_helm_chart_dependencies tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -52,22 +52,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      - name: Notify failure to Slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "Github action insync-checkin failed"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_MESSAGE: "COMMIT TITLE:
-
-            \ ${{steps.commit.outputs.title}}
-
-
-
-            \ GIT STATUS OUTPUT:
-
-            \ ${{env.GIT_STATUS}}"
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -79,19 +79,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "NMS typescript failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   nms-eslint:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -126,19 +127,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "NMS eslint tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   nms-yarn-test:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -162,19 +164,20 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "NMS yarn tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}
   nms-e2e-test:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
@@ -228,16 +231,17 @@ jobs:
         run: |
           str="$(jq '.head_commit.message' $GITHUB_EVENT_PATH)"    # get the head_commit message
           echo ::set-output name=title::${str%%\\n*} | tr -d '"'
-      # Notify ci channel when failing
-      # Plugin info: https://github.com/marketplace/actions/slack-notify
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_CI }}
-          SLACK_TITLE: "NMS e2e tests failed"
-          SLACK_MESSAGE: "${{ steps.commit.outputs.title}}"
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_ICON_EMOJI: ":boom:"
-          SLACK_COLOR: "#FF0000"
-          SLACK_FOOTER: ' '
+      - name: "Set Slack channel #ci as default"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
+      - name: "Set Slack channel #ci-info for failures"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_CI }}" >> $GITHUB_ENV
+        if: failure()
+      - name: "Set Slack channel #ci-artifacts for successes"
+        run: echo "webhook=${{ secrets.SLACK_WEBHOOK_OSS }}" >> $GITHUB_ENV
+        if: success()
+      - name: Notify Slack of job status
+        uses: ./.github/workflows/composite/notify-slack
+        with:
+          webhook: ${{ env.webhook }}
+          status: ${{ job.status }}
+          message: ${{ github.event.head_commit.message || github.event.pull_request.title }}


### PR DESCRIPTION
## Context / Issues

- There are three slack channels (see below), which were used without visible pattern. Especially, the `#ci` and `#ci-info` channel seemed to be duplicated and and no consistent usage was found.
- There were several different plugins used for Slack messaging. Some of them rather small and with questionable future.
- The Slack message formatting was not consistent across the different jobs.

## Summary

- Closes https://github.com/magma/magma/issues/14283
- Closes https://github.com/magma/magma/issues/14284
- Only use one plugin for all slack messages. Use the one with the most stars, which seems to be well maintained and stable.
- Make the slack messages more homogeneous, by reducing configuration options and using defaults for some content fields.
- Reduce code duplication. However, choosing the correct channel cannot be done inside a composite action, because those are credentials in the need of explicit "hand-in".

:warning: In order to get is as homogenous as possible, I replaced all Slack calls with the standard messages, which should cover the "success" and "failed" case sufficiently with names to workflows, jobs, commits etc. _I acquiescently accepted some logic changes by this._
However, in some special cases an custom Slack message might be desired. I am open to discuss and reintroduce them where they are really needed and add additional value.

## Test Plan

- CI
- Respective Slack channel messages

## Additional Information

The following mapping from secrets to channels was discovered:
```
secrets.SLACK_WEBHOOK     = #ci
secrets.SLACK_WEBHOOK_CI  = #ci-info
secrets.SLACK_WEBHOOK_OSS = #ci-artifacts
```