### PR TITLE
fix(amf): Incorrect SecurityType in PDU Session Release

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_pdu_resource_setup_req_rel.cpp
@@ -243,7 +243,8 @@ int pdu_session_resource_release_request(ue_m5gmm_context_s* ue_context,
       M5G_MOBILITY_MANAGEMENT_MESSAGES;
   msg.security_protected.plain.amf.header.message_type =
       M5GMessageType::DLNASTRANSPORT;
-  msg.header.security_header_type = SECURITY_HEADER_TYPE_INTEGRITY_PROTECTED;
+  msg.header.security_header_type =
+      SECURITY_HEADER_TYPE_INTEGRITY_PROTECTED_CYPHERED;
   msg.header.extended_protocol_discriminator = M5G_MOBILITY_MANAGEMENT_MESSAGES;
   msg.header.sequence_number =
       ue_context->amf_context._security.dl_count.seq_num;


### PR DESCRIPTION
fix(amf): Incorrect SecurityType in PDU Session Release
Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

 PDU Session Release has an incorrect Security Header 

## Test Plan
 Registration
PDU Session Establishment/ PDU Session Release
![image](https://user-images.githubusercontent.com/83060027/201329058-f77aeeb6-5512-4ce6-a526-7f3a405fb001.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
