### PR TITLE
fix: metrics test is independent from execution of unrelated tests

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_gateway_metrics_attach_detach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_gateway_metrics_attach_detach.py
@@ -39,11 +39,10 @@ class TestGatewayMetricsAttachDetach(unittest.TestCase):
         """ Basic gateway metrics with attach/detach for a single UE """
 
         label_values_success = {"result": "success"}
-        mme_new_association = self._getMetricValueGivenLabel(
+        mme_new_association_before = self._getMetricValueGivenLabel(
             "mme_new_association",
             label_values_success,
         )
-        assert mme_new_association > 0
 
         num_ues = 2
         detach_type = [
@@ -137,6 +136,12 @@ class TestGatewayMetricsAttachDetach(unittest.TestCase):
                 label_values_success,
             )
             assert (val == v_spgw_delete_session + 1)
+
+        mme_new_association = self._getMetricValueGivenLabel(
+            "mme_new_association",
+            label_values_success,
+        )
+        assert (mme_new_association == mme_new_association_before + 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

#14351 moved `test_gateway_metrics_attach_detach.py` in the execution order. This made an early assert fail because no `mme_new_association` event happened yet (see, e.g., https://github.com/magma/magma/runs/9277319986). Another attach/detach test needs to be executed firs, e.g., `test_attach_detach.py` if mme was restarted in the mean time.

Here: move the assert to the end of the test and check that the event counter actually increased during the test - dynamically so that possible events from other tests do not matter.

## Test Plan

Execute `test_gateway_metrics_attach_detach.py` after a freshly restarted mme.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
