### PR TITLE
docs: remove resolved warning in Vagrant installation

### DIFF
--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -60,7 +60,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
 1. Install the following tools
    1. [Docker](https://docs.docker.com/engine/install/ubuntu/) and [Docker Compose](https://docs.docker.com/compose/install/)
    2. [VirtualBox](https://www.virtualbox.org/wiki/Linux_Downloads)
-   3. [Vagrant](https://www.vagrantup.com/downloads) (Install by downloading the `.deb` file. Installing via the command line using `apt-get` can currently cause an issue with OpenSSL. See also [this discussion](https://github.com/hashicorp/vagrant/issues/12751).)
+   3. [Vagrant](https://www.vagrantup.com/downloads)
 2. Install golang version 18.
 
    1. Download the tar file.


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This warning can be removed since the issue was resolved as described in the linked discussion. Adding the `hashicorp.list` to `/etc/apt/sources.list.d` and installing via `apt` gives fixed version 2.3.2.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
