### PR TITLE
chore: Persist bazel artifacts after VM restart

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-startup --output_base=/tmp/bazel
+startup --output_base=/var/tmp/bazel
 startup --host_jvm_args="-Xmx8g"
 
 # STYLE CONFIGS

--- a/.devcontainer/bazel-base/docker-compose.yml
+++ b/.devcontainer/bazel-base/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         volumes:
             - ${MAGMA_ROOT}:/workspaces/magma
             - ${MAGMA_ROOT}/lte/gateway/configs:/etc/magma
-            - bazel-output:/tmp/bazel
+            - bazel-output:/var/tmp/bazel
         working_dir: /workspaces/magma
 volumes:
     bazel-output:

--- a/dev_tools/BUILD.bazel
+++ b/dev_tools/BUILD.bazel
@@ -110,10 +110,10 @@ genrule(
     name = "external_deps_pth",
     outs = ["external_deps.pth"],
     cmd = "\n".join([
-        "echo /tmp/bazel/external/ryu_repo >> $@",
-        "echo /tmp/bazel/external/aioh2_repo >> $@",
-        "echo /tmp/bazel/external/aioeventlet_repo >> $@",
-        "echo /tmp/bazel/external/bcc_repo >> $@",
+        "echo /var/tmp/bazel/external/ryu_repo >> $@",
+        "echo /var/tmp/bazel/external/aioh2_repo >> $@",
+        "echo /var/tmp/bazel/external/aioeventlet_repo >> $@",
+        "echo /var/tmp/bazel/external/bcc_repo >> $@",
     ]),
 )
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Change bazel output base to `/var/tmp/bazel`, which is not deleted after VM reboot.
- Resolves #14382

## Test Plan
- Check `bazel info` logging
- Test VM
  - `vagrant up magma && vagrant ssh magma && cd magma`
  - `bazel build :buildifier`
  - Check that artifact exists in `bazel-bin`
  - Reboot VM
  - Check that artifact exists in `bazel-bin`
- Devcontainer builds work  
- [LTE integ tests](https://github.com/LKreutzer/magma/actions/runs/3445391767)
- [bazel workflow](https://github.com/LKreutzer/magma/actions/runs/3445389882)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
