### PR TITLE
fix: class variable syntax is fixed

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1029,10 +1029,10 @@ class MagmadUtil(object):
             self._wait_for_pipelined_to_initialize()
 
             print(
-                f"Waiting {EXTRA_WAIT_TIME_FOR_OTHER_SERVICES_SECONDS} "
+                f"Waiting {self.EXTRA_WAIT_TIME_FOR_OTHER_SERVICES_SECONDS} "
                 f"seconds to ensure all services restarted ...",
             )
-            time.sleep(EXTRA_WAIT_TIME_FOR_OTHER_SERVICES_SECONDS)
+            time.sleep(self.EXTRA_WAIT_TIME_FOR_OTHER_SERVICES_SECONDS)
         elif self._init_system == InitMode.DOCKER:
             self.exec_command(
                 "cd /home/vagrant/magma/lte/gateway/docker "
@@ -1051,8 +1051,8 @@ class MagmadUtil(object):
         wait_time_seconds = 0
 
         print(
-            f"  check every {WAIT_INTERVAL_SECONDS} seconds "
-            f"(max {MAX_WAIT_SECONDS} seconds) if pipelined is started ...",
+            f"  check every {self.WAIT_INTERVAL_SECONDS} seconds "
+            f"(max {self.MAX_WAIT_SECONDS} seconds) if pipelined is started ...",
         )
         datapath_is_initialized = False
         while not datapath_is_initialized:
@@ -1076,15 +1076,15 @@ class MagmadUtil(object):
                 break
 
             if (
-                wait_time_seconds >= MAX_WAIT_SECONDS
+                wait_time_seconds >= self.MAX_WAIT_SECONDS
                 and not datapath_is_initialized
             ):
                 raise RuntimeError(
                     f"Pipelined failed to initialize after "
-                    f"{MAX_WAIT_SECONDS} seconds.",
+                    f"{self.MAX_WAIT_SECONDS} seconds.",
                 )
-            time.sleep(WAIT_INTERVAL_SECONDS)
-            wait_time_seconds += WAIT_INTERVAL_SECONDS
+            time.sleep(self.WAIT_INTERVAL_SECONDS)
+            wait_time_seconds += self.WAIT_INTERVAL_SECONDS
 
     def restart_services(self, services: str, wait_time: int = 0):
         """


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>


## Summary

In #14141 `s1ap_utils.py` was refactored - the `self.` prefix for class variables is missing. See errors in integ test runs, e.g., https://github.com/magma/magma/actions/runs/3445567171/jobs/5749428018 for `test_ipv6_non_nat_dp_ul_tcp.py`.

## Test Plan

Execute test that uses the variables manually, e.g., `make selected_tests TESTS=s1aptests/test_ipv6_non_nat_dp_ul_tcp.py`.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
