### PR TITLE
fix: feg go files formatted with gofmt

### DIFF
--- a/feg/cloud/go/protos/mconfig/mconfigs.pb.go
+++ b/feg/cloud/go/protos/mconfig/mconfigs.pb.go
@@ -917,8 +917,7 @@ func (x *EapAkaConfig) GetMncLen() int32 {
 
 // EapProviderTimeouts is a generic EAP provider timeout config for all new providers
 // TODO: It should eventually replace EapAkaConfig as well, but due to the braking nature
-//
-//	of the switch farther planning is required
+// of the switch farther planning is required
 type EapProviderTimeouts struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/feg/cloud/go/services/controller/protos/feg_config.pb.go
+++ b/feg/cloud/go/services/controller/protos/feg_config.pb.go
@@ -817,8 +817,7 @@ func (x *EapAkaConfig) GetPlmnIds() []string {
 
 // EapProviderTimeouts is a generic EAP provider timeout config for all new providers
 // TODO: It should eventually replace EapAkaConfig as well, but due to the braking nature
-//
-//	of the switch farther planning is required
+// of the switch farther planning is required
 type EapProviderTimeouts struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/feg/cloud/go/services/controller/protos/feg_config.proto
+++ b/feg/cloud/go/services/controller/protos/feg_config.proto
@@ -128,7 +128,7 @@ message EapAkaConfig {
 
 // EapProviderTimeouts is a generic EAP provider timeout config for all new providers
 // TODO: It should eventually replace EapAkaConfig as well, but due to the braking nature
-//       of the switch farther planning is required
+// of the switch farther planning is required
 message EapProviderTimeouts {
     uint32 ChallengeMs = 1;
     uint32 ErrorNotificationMs = 2;

--- a/feg/gateway/diameter/diameter_client.go
+++ b/feg/gateway/diameter/diameter_client.go
@@ -277,11 +277,11 @@ func (client *Client) DisableConnectionCreation(period time.Duration) {
 // back the answer on the given channel. A key is required to identify the
 // corresponding answer. Additionally, SendRequest will add the OriginHost/Realm
 // AVPs to the message because they are mandatory for all requests
-// Input: server - cfg containing info on what server to send to
-//
-//	done - channel to send the answer to when received
-//	message - request to send
-//	key - something to uniquely identify the request
+// Input:
+//   - server  -- cfg containing info on what server to send to
+//   - done    -- channel to send the answer to when received
+//   - message -- request to send
+//   - key     -- something to uniquely identify the request
 //
 // Output: error if message sending failed, nil otherwise
 func (client *Client) SendRequest(
@@ -329,9 +329,9 @@ func (client *Client) IgnoreAnswer(key interface{}) {
 // matching the given command is received. The AnswerHandler is responsible for
 // parsing the diameter message into something usable and extracting a key to identify
 // the corresponding request
-// Input: command - the diameter code for the command (like diam.CreditControl)
-//
-//	handler - the function to call when a message is received
+// Input:
+//   - command -- the diameter code for the command (like diam.CreditControl)
+//   - handler -- the function to call when a message is received
 func (client *Client) RegisterAnswerHandlerForAppID(command uint32, appID uint32, handler AnswerHandler) {
 	index := diam.CommandIndex{AppID: appID, Code: command, Request: false}
 	muxHandler := diam.HandlerFunc(func(c diam.Conn, m *diam.Message) {
@@ -358,9 +358,9 @@ func (client *Client) RegisterAnswerHandlerForAppID(command uint32, appID uint32
 // matching the given command is received. The AnswerHandler is responsible for
 // parsing the diameter message into something usable and extracting a key to identify
 // the corresponding request
-// Input: command - the diameter code for the command (like diam.CreditControl)
-//
-//	handler - the function to call when a message is received
+// Input:
+//   - command -- the diameter code for the command (like diam.CreditControl)
+//   - handler -- the function to call when a message is received
 func (client *Client) RegisterAnswerHandler(command uint32, handler AnswerHandler) {
 	client.RegisterAnswerHandlerForAppID(command, client.cfg.AppID, handler)
 }
@@ -370,9 +370,9 @@ func (client *Client) RegisterAnswerHandler(command uint32, handler AnswerHandle
 // the diameter message, taking any actions required, and sending a response back
 // through the responder argument of the handler. This responder is given so that
 // the response can happen asynchonously in another go routine.
-// Input: command - the diameter code for the command (like diam.CreditControl)
-//
-//	handler - the function to call when a message is received
+// Input:
+//   - command -- the diameter code for the command (like diam.CreditControl)
+//   - handler -- the function to call when a message is received
 func (client *Client) RegisterRequestHandlerForAppID(command uint32, appID uint32, handler diam.HandlerFunc) {
 	client.mux.HandleIdx(diam.CommandIndex{AppID: appID, Code: command, Request: true}, handler)
 }
@@ -383,8 +383,7 @@ func (client *Client) RegisterHandler(command uint32, appID uint32, request bool
 }
 
 // GenSessionIDOpt generates rfc6733 compliant session ID:
-//
-//	<DiameterIdentity>;<high 32 bits>;<low 32 bits>[;<optional value>]
+// <DiameterIdentity>;<high 32 bits>;<low 32 bits>[;<optional value>]
 func GenSessionIDOpt(identity, protocol, opt string) string {
 	if len(identity) == 0 {
 		identity = "magma"
@@ -398,8 +397,7 @@ func GenSessionIDOpt(identity, protocol, opt string) string {
 }
 
 // GenSessionIDOpt generates rfc6733 compliant session ID:
-//
-//	<DiameterIdentity>;<high 32 bits>;<low 32 bits>;IMSI<imsi value>
+// <DiameterIdentity>;<high 32 bits>;<low 32 bits>;IMSI<imsi value>
 func GenSessionIdImsi(identity, protocol, imsi string) string {
 	if len(identity) == 0 {
 		identity = "magma"
@@ -413,18 +411,14 @@ func GenSessionIdImsi(identity, protocol, imsi string) string {
 }
 
 // GenSessionID generates rfc6733 compliant session ID:
-//
-//	<DiameterIdentity>;<high 32 bits>;<low 32 bits>[;<optional value>]
-//
+// <DiameterIdentity>;<high 32 bits>;<low 32 bits>[;<optional value>]
 // Where <optional value> is base 16 uint32 random number
 func GenSessionID(identity, protocol string) string {
 	return GenSessionIDOpt(identity, protocol, strconv.FormatUint(uint64(rand.Uint32()), 16))
 }
 
 // GenSessionIDOpt generates rfc6733 compliant session ID:
-//
-//	<DiameterIdentity>;<high 32 bits>;<low 32 bits>[;<optional value>]
-//
+// <DiameterIdentity>;<high 32 bits>;<low 32 bits>[;<optional value>]
 // Where <DiameterIdentity> is client.Host|ProductName-protocol
 func (client *DiameterClientConfig) GenSessionIDOpt(protocol, opt string) string {
 	if client != nil {
@@ -438,23 +432,17 @@ func (client *DiameterClientConfig) GenSessionIDOpt(protocol, opt string) string
 }
 
 // GenSessionID generates rfc6733 compliant session ID:
-//
-//	<DiameterIdentity>;<high 32 bits>;<low 32 bits>[;<optional value>]
-//
+// <DiameterIdentity>;<high 32 bits>;<low 32 bits>[;<optional value>]
 // Where <DiameterIdentity> is client.Host|ProductName-protocol
-//
-//	and <optional value> is base 16 uint32 random number
+// and <optional value> is base 16 uint32 random number
 func (client *DiameterClientConfig) GenSessionID(protocol string) string {
 	return client.GenSessionIDOpt(protocol, strconv.FormatUint(uint64(rand.Uint32()), 16))
 }
 
 // GenSessionIdImsi generates rfc6733 compliant session ID:
-//
-//	<DiameterIdentity>;<high 32 bits>;<low 32 bits>;IMSI<imsi>]
-//
+// <DiameterIdentity>;<high 32 bits>;<low 32 bits>;IMSI<imsi>]
 // Where <DiameterIdentity> is client.Host|ProductName-protocol
-//
-//	and <optional value> is base 16 uint32 random number
+// and <optional value> is base 16 uint32 random number
 func (client *DiameterClientConfig) GenSessionIdImsi(protocol, imsi string) string {
 	if len(imsi) == 0 {
 		return client.GenSessionID(protocol)

--- a/feg/gateway/diameter/msg_definitions.go
+++ b/feg/gateway/diameter/msg_definitions.go
@@ -16,7 +16,9 @@ package diameter
 import "github.com/fiorix/go-diameter/v4/diam/datatype"
 
 //https://tools.ietf.org/html/rfc4005#page-16
-/*  Abort-Session Request (ASR)
+/*
+Abort-Session Request (ASR)
+
 < Session-Id >
 { Origin-Host }
 { Origin-Realm }
@@ -41,7 +43,7 @@ type ASR struct {
 }
 
 /*
-	Abort-Session Answer (ASA)
+Abort-Session Answer (ASA)
 
 < Session-Id >
 { Origin-Host }

--- a/feg/gateway/services/aaa/aaa_server/aaa_aka_linked_auth_test.go
+++ b/feg/gateway/services/aaa/aaa_server/aaa_aka_linked_auth_test.go
@@ -58,13 +58,12 @@ func TestLinkedEapAkaConcurent(t *testing.T) {
 // See: https://tools.ietf.org/html/rfc3748#section-5.3 for more details
 //
 // "...Where a peer receives a Request for an unacceptable authentication
-//
-//	Type (4-253,255), or a peer lacking support for Expanded Types
-//	receives a Request for Type 254, a Nak Response (Type 3) MUST be
-//	sent.  The Type-Data field of the Nak Response (Type 3) MUST
-//	contain one or more octets indicating the desired authentication
-//	Type(s), one octet per Type, or the value zero (0) to indicate no
-//	proposed alternative."
+// Type (4-253,255), or a peer lacking support for Expanded Types
+// receives a Request for Type 254, a Nak Response (Type 3) MUST be
+// sent. The Type-Data field of the Nak Response (Type 3) MUST
+// contain one or more octets indicating the desired authentication
+// Type(s), one octet per Type, or the value zero (0) to indicate no
+// proposed alternative."
 func TestLinkedEAPPeerNak(t *testing.T) {
 	failureEAP := []byte{4, 237, 0, 4}
 	akaPrimeIdentity := eap.NewPacket(

--- a/feg/gateway/services/eap/providers/aka/provider/identity.go
+++ b/feg/gateway/services/eap/providers/aka/provider/identity.go
@@ -21,8 +21,7 @@ var akaRe = regexp.MustCompile(`^0\d{6,15}@\w(?:\w|\.|-)*\w$`)
 // WillHandleIdentity returns true if the provider 1) recognizes the given Identity and 2) can hendle authentication
 // for this type of identity.
 // Note: a negative (false) result doesn't necessary mean that the provider cannot handle the auth for the client,
-//
-//	it may also mean that the client did not pass enough information for the provider to recognize it
+// it may also mean that the client did not pass enough information for the provider to recognize it
 func (p *providerImpl) WillHandleIdentity(identityData []byte) bool {
 	return len(identityData) > 10 && akaRe.Match(identityData)
 }

--- a/feg/gateway/services/eap/providers/sim/mac.go
+++ b/feg/gateway/services/eap/providers/sim/mac.go
@@ -73,15 +73,13 @@ func AppendMac(p eap.Packet, K_aut []byte) (eap.Packet, error) {
 // using recommended SRES Derivation Function #1
 //
 // Inputs:
-//
-//	ik   - 128-bit integrity key
-//	ck   - 128-bit confidentiality key
-//	xres - 64-bit signed response
+//   - ik   - 128-bit integrity key
+//   - ck   - 128-bit confidentiality key
+//   - xres - 64-bit signed response
 //
 // Outputs:
-//
-//	kc   - 64-bit Kc
-//	sres - 32-bit SRES
+//   - kc   - 64-bit Kc
+//   - sres - 32-bit SRES
 func GsmFromUmts1(ck, ik, xres []byte) (kc, sres []byte) {
 	kc, sres = make([]byte, 8), make([]byte, 4)
 	for i, i8 := 0, 8; i < 8; i, i8 = i+1, i8+1 {
@@ -97,15 +95,13 @@ func GsmFromUmts1(ck, ik, xres []byte) (kc, sres []byte) {
 // using recommended SRES Derivation Function #2
 //
 // Inputs:
-//
-//	ik   - 128-bit integrity key
-//	ck   - 128-bit confidentiality key
-//	xres - 64-bit signed response
+//   - ik   - 128-bit integrity key
+//   - ck   - 128-bit confidentiality key
+//   - xres - 64-bit signed response
 //
 // Outputs:
-//
-//	kc   - 64-bit Kc
-//	sres - 32-bit SRES
+//   - kc   - 64-bit Kc
+//   - sres - 32-bit SRES
 func GsmFromUmts2(ck, ik, xres []byte) (kc, sres []byte) {
 	kc, sres = make([]byte, 8), make([]byte, 4)
 	for i, i8 := 0, 8; i < 8; i, i8 = i+1, i8+1 {

--- a/feg/gateway/services/eap/providers/sim/provider/identity.go
+++ b/feg/gateway/services/eap/providers/sim/provider/identity.go
@@ -21,8 +21,7 @@ var simRe = regexp.MustCompile(`^1\d{6,15}@\w(?:\w|\.|-)*\w$`)
 // WillHandleIdentity returns true if the provider 1) recognizes the given Identity and 2) can hendle authentication
 // for this type of identity.
 // Note: a negative (false) result doesn't necessary mean that the provider cannot handle the auth for the client,
-//
-//	it may also mean that the client did not pass enough information for the provider to recognize it
+// it may also mean that the client did not pass enough information for the provider to recognize it
 func (*providerImpl) WillHandleIdentity(identityData []byte) bool {
 	return len(identityData) > 10 && simRe.Match(identityData)
 }

--- a/feg/gateway/services/n7_n40_proxy/n7/notifier_handler.go
+++ b/feg/gateway/services/n7_n40_proxy/n7/notifier_handler.go
@@ -51,9 +51,9 @@ const (
 //
 // where
 //
-//			notifyRoot = http://magma-feg.magma.com/sm-policy-control/v1
-//	     encodedSessionId = MTIzNDU2Nzg5MDsxMjM0NQo= (Session-Id is urlencoded)
-//	     operation = update
+//	notifyRoot = http://magma-feg.magma.com/sm-policy-control/v1
+//	encodedSessionId = MTIzNDU2Nzg5MDsxMjM0NQo= (Session-Id is urlencoded)
+//	operation = update
 //
 // This notification url is send to PCF in the SmPolicyCreate request
 func (c *N7Client) registerHandlers() error {

--- a/feg/gateway/services/s6a_proxy/servicers/s6a_definitions.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_definitions.go
@@ -109,45 +109,45 @@ type AIA struct {
 // Update-Location-Answer (ULA)
 // {Code:316,Flags:0x40,Version:0x1,Length:516,ApplicationId:16777251,HopByHopId:0x22910d0a,EndToEndId:0x8d330652}
 //
-//		Session-Id {Code:263,Flags:0x40,Length:24,VendorId:0,Value:UTF8String{session;89988919},Padding:0}
-//		ULA-Flags {Code:1406,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{1}}
-//		Subscription-Data {Code:1400,Flags:0xc0,Length:380,VendorId:10415,Value:Grouped{
-//			MSISDN {Code:701,Flags:0xc0,Length:20,VendorId:10415,Value:OctetString{0x33638060010f},Padding:2},
-//			Access-Restriction-Data {Code:1426,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{47}},
-//			Subscriber-Status {Code:1424,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
-//			Network-Access-Mode {Code:1417,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{2}},
-//			AMBR {Code:1435,Flags:0xc0,Length:44,VendorId:10415,Value:Grouped{
-//				Max-Requested-Bandwidth-UL {Code:516,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{50000000}},
-//				Max-Requested-Bandwidth-DL {Code:515,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{100000000}},
-//			}}
-//			APN-Configuration-Profile {Code:1429,Flags:0xc0,Length:240,VendorId:10415,Value:Grouped{
-//				Context-Identifier {Code:1423,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{0}},
-//				All-APN-Configurations-Included-Indicator {Code:1428,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
-//				APN-Configuration {Code:1430,Flags:0xc0,Length:196,VendorId:10415,Value:Grouped{
-//					Context-Identifier {Code:1423,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{0}},
-//					PDN-Type {Code:1456,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
-//					Service-Selection {Code:493,Flags:0xc0,Length:20,VendorId:10415,Value:UTF8String{oai.ipv4},Padding:0},
-//					EPS-Subscribed-QoS-Profile {Code:1431,Flags:0xc0,Length:88,VendorId:10415,Value:Grouped{
-//						QoS-Class-Identifier {Code:1028,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{9}},
-//						Allocation-Retention-Priority {Code:1034,Flags:0x80,Length:60,VendorId:10415,Value:Grouped{
-//							Priority-Level {Code:1046,Flags:0x80,Length:16,VendorId:10415,Value:Unsigned32{15}},
-//							Pre-emption-Capability {Code:1047,Flags:0x80,Length:16,VendorId:10415,Value:Enumerated{1}},
-//							Pre-emption-Vulnerability {Code:1048,Flags:0x80,Length:16,VendorId:10415,Value:Enumerated{0}},
-//						}}
-//					}},
-//	             TGPP-Charging-Characteristics {Code: 13,Flags:0x80,VendorId:10415,Value:UTF8String{12}},
-//					AMBR {Code:1435,Flags:0xc0,Length:44,VendorId:10415,Value:Grouped{
-//						Max-Requested-Bandwidth-UL {Code:516,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{50000000}},
-//						Max-Requested-Bandwidth-DL {Code:515,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{100000000}},
-//					}}
-//				}}
-//			}}
-//			Subscribed-Periodic-RAU-TAU-Timer {Code:1619,Flags:0x80,Length:16,VendorId:10415,Value:Unsigned32{120}},
-//		}}
-//		Auth-Session-State {Code:277,Flags:0x40,Length:12,VendorId:0,Value:Enumerated{0}}
-//		Origin-Host {Code:264,Flags:0x40,Length:28,VendorId:0,Value:DiameterIdentity{hss.openair4G.eur},Padding:3}
-//		Origin-Realm {Code:296,Flags:0x40,Length:24,VendorId:0,Value:DiameterIdentity{openair4G.eur},Padding:3}
-//		Result-Code {Code:268,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{2001}}
+//	Session-Id {Code:263,Flags:0x40,Length:24,VendorId:0,Value:UTF8String{session;89988919},Padding:0}
+//	ULA-Flags {Code:1406,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{1}}
+//	Subscription-Data {Code:1400,Flags:0xc0,Length:380,VendorId:10415,Value:Grouped{
+//	   MSISDN {Code:701,Flags:0xc0,Length:20,VendorId:10415,Value:OctetString{0x33638060010f},Padding:2},
+//	   Access-Restriction-Data {Code:1426,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{47}},
+//	   Subscriber-Status {Code:1424,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
+//	   Network-Access-Mode {Code:1417,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{2}},
+//	   AMBR {Code:1435,Flags:0xc0,Length:44,VendorId:10415,Value:Grouped{
+//	   	Max-Requested-Bandwidth-UL {Code:516,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{50000000}},
+//	   	Max-Requested-Bandwidth-DL {Code:515,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{100000000}},
+//	   }}
+//	   APN-Configuration-Profile {Code:1429,Flags:0xc0,Length:240,VendorId:10415,Value:Grouped{
+//	   	   Context-Identifier {Code:1423,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{0}},
+//	   	   All-APN-Configurations-Included-Indicator {Code:1428,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
+//	   	   APN-Configuration {Code:1430,Flags:0xc0,Length:196,VendorId:10415,Value:Grouped{
+//	   	   	  Context-Identifier {Code:1423,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{0}},
+//	   	   	  PDN-Type {Code:1456,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{0}},
+//	   	   	  Service-Selection {Code:493,Flags:0xc0,Length:20,VendorId:10415,Value:UTF8String{oai.ipv4},Padding:0},
+//	   	   	  EPS-Subscribed-QoS-Profile {Code:1431,Flags:0xc0,Length:88,VendorId:10415,Value:Grouped{
+//	   	   		  QoS-Class-Identifier {Code:1028,Flags:0xc0,Length:16,VendorId:10415,Value:Enumerated{9}},
+//	   	   		  Allocation-Retention-Priority {Code:1034,Flags:0x80,Length:60,VendorId:10415,Value:Grouped{
+//	   	   			  Priority-Level {Code:1046,Flags:0x80,Length:16,VendorId:10415,Value:Unsigned32{15}},
+//	   	   			  Pre-emption-Capability {Code:1047,Flags:0x80,Length:16,VendorId:10415,Value:Enumerated{1}},
+//	   	   			  Pre-emption-Vulnerability {Code:1048,Flags:0x80,Length:16,VendorId:10415,Value:Enumerated{0}},
+//	   	   		  }}
+//	   	   	  }},
+//	          TGPP-Charging-Characteristics {Code: 13,Flags:0x80,VendorId:10415,Value:UTF8String{12}},
+//	   	   	  AMBR {Code:1435,Flags:0xc0,Length:44,VendorId:10415,Value:Grouped{
+//	   	   	      Max-Requested-Bandwidth-UL {Code:516,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{50000000}},
+//	   	   		  Max-Requested-Bandwidth-DL {Code:515,Flags:0xc0,Length:16,VendorId:10415,Value:Unsigned32{100000000}},
+//	   	   	  }}
+//	      }}
+//	  }}
+//	  Subscribed-Periodic-RAU-TAU-Timer {Code:1619,Flags:0x80,Length:16,VendorId:10415,Value:Unsigned32{120}},
+//	}}
+//	Auth-Session-State {Code:277,Flags:0x40,Length:12,VendorId:0,Value:Enumerated{0}}
+//	Origin-Host {Code:264,Flags:0x40,Length:28,VendorId:0,Value:DiameterIdentity{hss.openair4G.eur},Padding:3}
+//	Origin-Realm {Code:296,Flags:0x40,Length:24,VendorId:0,Value:DiameterIdentity{openair4G.eur},Padding:3}
+//	Result-Code {Code:268,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{2001}}
 type AMBR struct {
 	MaxRequestedBandwidthUL uint32 `avp:"Max-Requested-Bandwidth-UL"`
 	MaxRequestedBandwidthDL uint32 `avp:"Max-Requested-Bandwidth-DL"`

--- a/feg/gateway/services/session_proxy/credit_control/gx/definitions.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/definitions.go
@@ -112,8 +112,9 @@ type RedirectInformation struct {
 	RedirectServerAddress string `avp:"Redirect-Server-Address"`
 }
 
-// Flow-Information ::= < AVP Header: 1058 >
+// Flow-Information ::=
 //
+//	< AVP Header: 1058 >
 //	[ Flow-Description ]
 //	[ Packet-Filter-Identifier ]
 //	[ Packet-Filter-Usage ]
@@ -197,36 +198,37 @@ type CCADiameterMessage struct {
 	Offline          int32                  `avp:"Offline"`
 }
 
-// <RA-Request> ::= 	< Diameter Header: 258, REQ, PXY >
+// <RA-Request> ::=
 //
-//	< Session-Id >
-//	[ DRMP ]
-//	{ Auth-Application-Id }
-//	{ Origin-Host }
-//	{ Origin-Realm }
-//	{ Destination-Realm }
-//	{ Destination-Host }
-//	{ Re-Auth-Request-Type }
-//	[ Session-Release-Cause ]
-//	[ Origin-State-Id ]
-//	[ OC-Supported-Features ]
-//	*[ Event-Trigger ]
-//	[ Event-Report-Indication ]
-//	*[ Charging-Rule-Remove ]
-//	*[ Charging-Rule-Install ]
-//	[ Default-EPS-Bearer-QoS ]
-//	*[ QoS-Information ]
-//	[ Default-QoS-Information ]
-//	[ Revalidation-Time ]
-//	*[ Usage-Monitoring-Information ]
-//	[ PCSCF-Restoration-Indication ] 0*4[ Conditional-Policy-Information ]
-//	[ Removal-Of-Access ]
-//	[ IP-CAN-Type ]
-//	[ PRA-Install ]
-//	[ PRA-Remove ]
-//	*[ Proxy-Info ]
-//	*[ Route-Record ]
-//	*[ AVP ]
+//	    < Diameter Header: 258, REQ, PXY >
+//		< Session-Id >
+//		[ DRMP ]
+//		{ Auth-Application-Id }
+//		{ Origin-Host }
+//		{ Origin-Realm }
+//		{ Destination-Realm }
+//		{ Destination-Host }
+//		{ Re-Auth-Request-Type }
+//		[ Session-Release-Cause ]
+//		[ Origin-State-Id ]
+//		[ OC-Supported-Features ]
+//		*[ Event-Trigger ]
+//		[ Event-Report-Indication ]
+//		*[ Charging-Rule-Remove ]
+//		*[ Charging-Rule-Install ]
+//		[ Default-EPS-Bearer-QoS ]
+//		*[ QoS-Information ]
+//		[ Default-QoS-Information ]
+//		[ Revalidation-Time ]
+//		*[ Usage-Monitoring-Information ]
+//		[ PCSCF-Restoration-Indication ] 0*4[ Conditional-Policy-Information ]
+//		[ Removal-Of-Access ]
+//		[ IP-CAN-Type ]
+//		[ PRA-Install ]
+//		[ PRA-Remove ]
+//		*[ Proxy-Info ]
+//		*[ Route-Record ]
+//		*[ AVP ]
 type PolicyReAuthRequest struct {
 	SessionID        string                 `avp:"Session-Id"`
 	OriginHost       string                 `avp:"Origin-Host"`
@@ -238,54 +240,56 @@ type PolicyReAuthRequest struct {
 	RevalidationTime *time.Time             `avp:"Revalidation-Time"`
 }
 
-// <RA-Answer> ::= 	< Diameter Header: 258, PXY >
+// <RA-Answer> ::=
 //
-//	< Session-Id >
-//	[ DRMP ]
-//	{ Origin-Host }
-//	{ Origin-Realm }
-//	[ Result-Code ]
-//	[ Experimental-Result ]
-//	[ Origin-State-Id ]
-//	[ OC-Supported-Features ]
-//	[ OC-OLR ]
-//	[ IP-CAN-Type ]
-//	[ RAT-Type ]
-//	[ AN-Trusted ]
-//	0*2 [ AN-GW-Address ]
-//	[ 3GPP-SGSN-MCC-MNC ]
-//	[ 3GPP-SGSN-Address ]
-//	[ 3GPP-SGSN-Ipv6-Address ]
-//	[ RAI ]
-//	[ 3GPP-User-Location-Info ]
-//	[ User-Location-Info-Time ]
-//	[ NetLoc-Access-Support ]
-//	[ User-CSG-Information ]
-//	[ 3GPP-MS-TimeZone ]
-//	[ Default-QoS-Information ]
-//	*[ Charging-Rule-Report]
-//	[ Error-Message ]
-//	[ Error-Reporting-Host ]
-//	[ Failed-AVP ]
-//	*[ Proxy-Info ]
-//	*[ AVP ]
+//	    < Diameter Header: 258, PXY >
+//		< Session-Id >
+//		[ DRMP ]
+//		{ Origin-Host }
+//		{ Origin-Realm }
+//		[ Result-Code ]
+//		[ Experimental-Result ]
+//		[ Origin-State-Id ]
+//		[ OC-Supported-Features ]
+//		[ OC-OLR ]
+//		[ IP-CAN-Type ]
+//		[ RAT-Type ]
+//		[ AN-Trusted ]
+//		0*2 [ AN-GW-Address ]
+//		[ 3GPP-SGSN-MCC-MNC ]
+//		[ 3GPP-SGSN-Address ]
+//		[ 3GPP-SGSN-Ipv6-Address ]
+//		[ RAI ]
+//		[ 3GPP-User-Location-Info ]
+//		[ User-Location-Info-Time ]
+//		[ NetLoc-Access-Support ]
+//		[ User-CSG-Information ]
+//		[ 3GPP-MS-TimeZone ]
+//		[ Default-QoS-Information ]
+//		*[ Charging-Rule-Report]
+//		[ Error-Message ]
+//		[ Error-Reporting-Host ]
+//		[ Failed-AVP ]
+//		*[ Proxy-Info ]
+//		*[ AVP ]
 type PolicyReAuthAnswer struct {
 	SessionID   string                `avp:"Session-Id"`
 	ResultCode  uint32                `avp:"Result-Code"`
 	RuleReports []*ChargingRuleReport `avp:"Charging-Rule-Report"`
 }
 
-// Charging-Rule-Report ::= < AVP Header: 1018 >
+// Charging-Rule-Report ::=
 //
-//							  *[ Charging-Rule-Name ]
-//	                       *[ Charging-Rule-Base-Name ]
-//	                        [ Bearer-Identifier ]
-//	                        [ PCC-Rule-Status ]
-//	                        [ Rule-Failure-Code ]
-//	                        [ Final-Unit-Indication ]
-//	                       *[ RAN-NAS-Release-Cause ]
-//	                       *[ Content-Version ]
-//	                       *[ AVP ]
+//	    < AVP Header: 1018 >
+//		*[ Charging-Rule-Name ]
+//		*[ Charging-Rule-Base-Name ]
+//		[ Bearer-Identifier ]
+//		[ PCC-Rule-Status ]
+//		[ Rule-Failure-Code ]
+//		[ Final-Unit-Indication ]
+//		*[ RAN-NAS-Release-Cause ]
+//		*[ Content-Version ]
+//		*[ AVP ]
 type ChargingRuleReport struct {
 	RuleNames     []string        `avp:"Charging-Rule-Name"`
 	RuleBaseNames []string        `avp:"Charging-Rule-Base-Name"`

--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
@@ -119,12 +119,13 @@ func NewGxClient(
 
 // SendCreditControlRequest sends a Gx Credit Control Requests to the
 // given connection
-// Input: DiameterServerConfig containing info about where to send messages
+// Input:
+//   - DiameterServerConfig containing info about where to send messages
+//   - chan<- *CreditControlAnswer to send answers to
+//   - CreditControlRequest with the request to send
 //
-//		chan<- *CreditControlAnswer to send answers to
-//	  CreditControlRequest with the request to send
-//
-// Output: error if server connection failed
+// Output:
+//   - error if server connection failed
 func (gxClient *GxClient) SendCreditControlRequest(
 	server *diameter.DiameterServerConfig,
 	done chan interface{},
@@ -215,12 +216,13 @@ func createReAuthAnswerMessage(
 // createCreditControlMessage creates a base message to be used for any Credit
 // Control Request message. Init will just use this, and update and terminate
 // pass in extra AVPs through additionalAVPs
-// Input: context.Context which has information on where to send to,
+// Input:
+//   - context.Context which has information on where to send to
+//   - CreditControlRequest with relevant request info
+//   - ...*diam.AVP with any AVPs to add on
 //
-//		CreditControlRequest with relevant request info
-//	  ...*diam.AVP with any AVPs to add on
-//
-// Output: *diam.Message with all AVPs filled in, error if there was an issue
+// Output:
+//   - *diam.Message with all AVPs filled in, error if there was an issue
 func (gxClient *GxClient) createCreditControlMessage(
 	request *CreditControlRequest,
 	globalConfig *GxGlobalConfig,

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
@@ -119,16 +119,17 @@ func NewGyClient(
 // Example use:
 //
 //		client := NewGyClient()
-//	 done :=  make(chan *CreditControlAnswer, 1)
+//	    done :=  make(chan *CreditControlAnswer, 1)
 //		client.SendCreditControlRequest(server, done, requests)
 //		answer := <- done
 //
-// Input: DiameterServerConfig containing info about where to send messages
+// Input:
+//   - DiameterServerConfig containing info about where to send messages
+//   - chan<- *CreditControlAnswer to send answers to
+//   - CreditControlRequest containing the request to send
 //
-//		chan<- *CreditControlAnswer to send answers to
-//	  CreditControlRequest containing the request to send
-//
-// Output: error if server connection failed
+// Output:
+//   - error if server connection failed
 func (gyClient *GyClient) SendCreditControlRequest(
 	server *diameter.DiameterServerConfig,
 	done chan interface{},
@@ -233,12 +234,13 @@ func getAdditionalAvps(request *CreditControlRequest, globalConfig *GyGlobalConf
 // createCreditControlMessage creates a base message to be used for any Credit
 // Control Request message. Init will just use this, and update and terminate
 // pass in extra AVPs through additionalAVPs
-// Input: context.Context which has information on where to send to,
+// Input:
+//   - context.Context which has information on where to send to,
+//   - CreditControlRequest with relevant request info
+//   - ...*diam.AVP with any AVPs to add on
 //
-//		CreditControlRequest with relevant request info
-//	  ...*diam.AVP with any AVPs to add on
-//
-// Output: *diam.Message with all AVPs filled in, error if there was an issue
+// Output:
+//   - *diam.Message with all AVPs filled in, error if there was an issue
 func (gyClient *GyClient) createCreditControlMessage(
 	server *diameter.DiameterServerConfig,
 	request *CreditControlRequest,
@@ -466,11 +468,12 @@ func getReceivedCredits(cca *CCADiameterMessage) []*ReceivedCredits {
 
 // getCCAHandler returns a callback function to use when an answer is received
 // over Gy. Parses the message for relevant information.
-// Input: requestTracker *diameter.RequestTracker to get channel to send answers out
+// Input:
+//   - requestTracker *diameter.RequestTracker to get channel to send answers out
+//     when one is received
 //
-//	when one is received
-//
-// Output: diam.HandlerFunc
+// Output:
+//   - diam.HandlerFunc
 func getCCAHandler() diameter.AnswerHandler {
 	return func(message *diam.Message) diameter.KeyAndAnswer {
 		glog.V(3).Infof("Received Gy CCA message:\n%s\n", message)

--- a/feg/gateway/services/testcore/hss/servicers/auth.go
+++ b/feg/gateway/services/testcore/hss/servicers/auth.go
@@ -49,14 +49,14 @@ const (
 
 // GenerateLteAuthVectors generates at most `numVectors` lte auth vectors.
 // Inputs:
+//   - numVectors  -- The maximum number of vectors to generate
+//   - milenage    -- The cipher to use to generate the vector
+//   - subscriber  -- The subscriber data for the subscriber we want to generate auth vectors for
+//   - plmn        -- 24 bit network identifier
+//   - authSqnInd  -- the IND of the current vector being generated
 //
-//	numVectors: The maximum number of vectors to generate
-//	milenage: The cipher to use to generate the vector
-//	subscriber: The subscriber data for the subscriber we want to generate auth vectors for
-//	plmn: 24 bit network identifier
-//	authSqnInd: the IND of the current vector being generated
-//
-// Returns: The E-UTRAN vectors, UTRAN vectors, the next value to set the subscriber's LteAuthNextSeq to (or an error)
+// Returns:
+//   - The E-UTRAN vectors, UTRAN vectors, the next value to set the subscriber's LteAuthNextSeq to (or an error)
 func GenerateLteAuthVectors(
 	numEutranVectors uint32,
 	numUtranVectors uint32,
@@ -113,13 +113,13 @@ func GenerateLteAuthVectors(
 
 // GenerateLteAuthVector returns the lte auth vector for the subscriber.
 // Inputs:
+//   - milenage    -- The cipher to use to generate the vector
+//   - subscriber  -- The subscriber data for the subscriber we want to generate auth vectors for
+//   - plmn        -- 24 bit network identifier
+//   - authSqnInd  -- the IND of the current vector being generated
 //
-//	milenage: The cipher to use to generate the vector
-//	subscriber: The subscriber data for the subscriber we want to generate auth vectors for
-//	plmn: 24 bit network identifier
-//	authSqnInd: the IND of the current vector being generated
-//
-// Returns: A E-UTRAN vector and the next value to set the subscriber's LteAuthNextSeq to (or an error).
+// Returns:
+//   - A E-UTRAN vector and the next value to set the subscriber's LteAuthNextSeq to (or an error).
 func GenerateLteAuthVector(
 	mcipher *milenage.Cipher,
 	subscriber *protos.SubscriberData,
@@ -149,13 +149,13 @@ func GenerateLteAuthVector(
 
 // GenerateUtranAuthVector returns the lte auth vector for the subscriber.
 // Inputs:
+//   - milenage    -- The cipher to use to generate the vector
+//   - subscriber  -- The subscriber data for the subscriber we want to generate auth vectors for
+//   - plmn        -- 24 bit network identifier
+//   - authSqnInd  -- the IND of the current vector being generated
 //
-//	milenage: The cipher to use to generate the vector
-//	subscriber: The subscriber data for the subscriber we want to generate auth vectors for
-//	plmn: 24 bit network identifier
-//	authSqnInd: the IND of the current vector being generated
-//
-// Returns: A UTRAN vector and the next value to set the subscriber's LteAuthNextSeq to (or an error).
+// Returns:
+//   - A UTRAN vector and the next value to set the subscriber's LteAuthNextSeq to (or an error).
 func GenerateUtranAuthVector(
 	mcipher *milenage.Cipher,
 	subscriber *protos.SubscriberData,
@@ -278,11 +278,11 @@ func GetOrGenerateOpc(lte *protos.LTESubscription, lteAuthOp []byte) ([]byte, er
 // 3GPP TS 33.102 Annex C.3.2. The length of IND is 5 bits.
 // SQN = SEQ || IND
 // Inputs:
+//   - seq    -- the sequence number
+//   - index  -- the index of the current vector being generated
 //
-//	seq: the sequence number
-//	index: the index of the current vector being generated
-//
-// Output: The 48 bit SQN
+// Output:
+//   - The 48 bit SQN
 func SeqToSqn(seq, index uint64) uint64 {
 	return (seq << indBits & seqMask) + (index & indMask)
 }
@@ -291,10 +291,10 @@ func SeqToSqn(seq, index uint64) uint64 {
 // 3GPP TS 33.102 Annex C.3.2. The length of IND is 5 bits.
 // SQN = SEQ || IND
 // Inputs:
+//   - seq   -- the 48 bit SQN
 //
-//	seq: the 48 bit SQN
-//
-// Outputs: SEQ and IND
+// Outputs:
+//   - -SEQ and IND
 func SplitSqn(sqn uint64) (uint64, uint64) {
 	return sqn >> indBits, sqn & indMask
 }

--- a/feg/gateway/services/testcore/hss/servicers/hss_diameter_integration_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/hss_diameter_integration_test.go
@@ -98,10 +98,10 @@ func TestHomeSubscriberServer_handleSAR(t *testing.T) {
 
 // testDiameterMessage sends a message to a test diameter server and provides the
 // response in a callback function.
-// Inputs: t - test interface
-//
-//	clientHandler - receives responses from the server
-//	msg - the message to send to the test server
+// Inputs:
+//   - t               -- test interface
+//   - clientHandler   -- receives responses from the server
+//   - msg             -- the message to send to the test server
 func testDiameterMessage(t *testing.T, clientHandler diam.HandlerFunc, msg *diam.Message) {
 	// Wrap the test client interface so we can signal that a message has been
 	// received.

--- a/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
@@ -80,10 +80,10 @@ type OCSDiamServer struct {
 }
 
 // NewOCSDiamServer initializes an OCS with an empty account map
-// Input: *sm.Settings containing the diameter related parameters
-//
-//	*TestOCSConfig containing the server address, and standard OCS settings
-//		like how many bytes to allocate to users
+// Input:
+//   - *sm.Settings containing the diameter related parameters
+//   - *TestOCSConfig containing the server address, and standard OCS settings
+//     like how many bytes to allocate to users
 //
 // Output: a new OCSDiamServer
 func NewOCSDiamServer(
@@ -170,10 +170,10 @@ func (srv *OCSDiamServer) CreateAccount(
 
 // SetOCSSettings changes the standard OCS return values. All parameters are
 // optional, and this only sets the non-nil ones.
-// Input: *uint32 optional maximum bytes to return in a CCA
-//
-//	*uint32 optional maximum time to return in a CCA
-//	*uint32 optional credit validity time to return in a CCA
+// Input:
+//   - *uint32 optional maximum bytes to return in a CCA
+//   - *uint32 optional maximum time to return in a CCA
+//   - *uint32 optional credit validity time to return in a CCA
 func (srv *OCSDiamServer) SetOCSSettings(
 	_ context.Context,
 	ocsConfig *protos.OCSConfig,
@@ -192,13 +192,14 @@ func (srv *OCSDiamServer) SetOCSSettings(
 }
 
 // SetCredit sets or overrides the prepaid credit allocated for an account
-// Input: string IMSI for the account
+// Input:
+//   - string IMSI for the account
+//   - uint32 charging key to add credit to
+//   - uint64 volume (in any units) to set this bucket to
+//   - UnitType dictating which unit the volume represents
 //
-//		  uint32 charging key to add credit to
-//		  uint64 volume (in any units) to set this bucket to
-//	    UnitType dictating which unit the volume represents
-//
-// Output: error if account could not be found
+// Output:
+//   - error if account could not be found
 func (srv *OCSDiamServer) SetCredit(
 	_ context.Context,
 	creditInfo *protos.CreditInfo,
@@ -215,10 +216,12 @@ func (srv *OCSDiamServer) SetCredit(
 }
 
 // GetCredits returns all the credits allocated for an account
-// Input: string IMSI for the account
-// Output: map[uint32]*CreditBucket a map of charging key to credit bucket
+// Input:
+//   - string IMSI for the account
 //
-//	error if account could not be found
+// Output:
+//   - map[uint32]*CreditBucket a map of charging key to credit bucket
+//     error if account could not be found
 func (srv *OCSDiamServer) GetCredits(
 	_ context.Context,
 	subscriberID *lteprotos.SubscriberID,

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
@@ -68,11 +68,12 @@ type PCRFServer struct {
 }
 
 // NewPCRFServer initializes an PCRF with an empty rule map
-// Input: *sm.Settings containing the diameter related parameters
+// Input:
+//   - *sm.Settings containing the diameter related parameters
+//   - *TestPCRFConfig containing the server address
 //
-//	*TestPCRFConfig containing the server address
-//
-// Output: a new PCRFServer
+// Output:
+//   - a new PCRFServer
 func NewPCRFServer(clientConfig *diameter.DiameterClientConfig, serverConfig *diameter.DiameterServerConfig) *PCRFServer {
 	return &PCRFServer{
 		diameterClientConfig: clientConfig,
@@ -168,13 +169,14 @@ func (srv *PCRFServer) CreateAccount(
 }
 
 // SetRules sets or overrides the rules applicable to the subscriber
-// Input: imsi string IMSI for the subscriber
+// Input:
+//   - imsi string IMSI for the subscriber
+//   - ruleNames []string containing all rule names to apply
+//   - ruleBaseNames []string containing all rule base names to apply
+//   - ruleDefinitions []*RuleDefinition containing all dynamic rules to apply
 //
-//	ruleNames []string containing all rule names to apply
-//	ruleBaseNames []string containing all rule base names to apply
-//	ruleDefinitions []*RuleDefinition containing all dynamic rules to apply
-//
-// Output: error if subscriber could not be found
+// Output:
+//   - error if subscriber could not be found
 func (srv *PCRFServer) SetRules(
 	_ context.Context,
 	accountRules *protos.AccountRules,
@@ -205,10 +207,12 @@ func (srv *PCRFServer) SetUsageMonitors(
 }
 
 // GetRuleNames returns all the rules set for a subscriber
-// Input: string IMSI for the subscriber
-// Output: []string containing all applicable rules
+// Input:
+//   - string IMSI for the subscriber
 //
-//	error if subscriber could not be found
+// Output:
+//   - []string containing all applicable rules
+//     error if subscriber could not be found
 func (srv *PCRFServer) GetRuleNames(imsi string) ([]string, error) {
 	account, ok := srv.subscribers[imsi]
 	if !ok {
@@ -218,10 +222,12 @@ func (srv *PCRFServer) GetRuleNames(imsi string) ([]string, error) {
 }
 
 // GetRuleBaseNames returns all the rule base names set for a subscriber
-// Input: string IMSI for the subscriber
-// Output: []string containing all applicable rule base names
+// Input:
+//   - string IMSI for the subscriber
 //
-//	error if subscriber could not be found
+// Output:
+//   - []string containing all applicable rule base names
+//     error if subscriber could not be found
 func (srv *PCRFServer) GetRuleBaseNames(imsi string) ([]string, error) {
 	account, ok := srv.subscribers[imsi]
 	if !ok {
@@ -231,10 +237,12 @@ func (srv *PCRFServer) GetRuleBaseNames(imsi string) ([]string, error) {
 }
 
 // GetRuleDefinitions returns all the dynamic rule definitions set for a subscriber
-// Input: string IMSI for the subscriber
-// Output: []*RuleDefinition containing all applicable rules
+// Input:
+//   - string IMSI for the subscriber
 //
-//	error if subscriber could not be found
+// Output:
+//   - []*RuleDefinition containing all applicable rules
+//     error if subscriber could not be found
 func (srv *PCRFServer) GetRuleDefinitions(
 	imsi string,
 ) ([]*protos.RuleDefinition, error) {

--- a/feg/protos/mconfig/mconfigs.proto
+++ b/feg/protos/mconfig/mconfigs.proto
@@ -136,7 +136,7 @@ message EapAkaConfig {
 
 // EapProviderTimeouts is a generic EAP provider timeout config for all new providers
 // TODO: It should eventually replace EapAkaConfig as well, but due to the braking nature
-//       of the switch farther planning is required
+// of the switch farther planning is required
 message EapProviderTimeouts {
     uint32 ChallengeMs = 1;
     uint32 ErrorNotificationMs = 2;


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

This PR fixes formatting problems in FEG Go comments caused by the Go 1.19 formatter tool. The changes are now compatible with the new `gofmt` format and will not be modified on the next auto-format call. 

## Test Plan

## Additional Information
