### PR TITLE
fix: cwf go files formatted with gofmt

### DIFF
--- a/cwf/gateway/integ_tests/gx_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_enforcement_test.go
@@ -332,7 +332,8 @@ func TestGxRuleInstallTime(t *testing.T) {
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
-// TestGxAbortSessionRequest
+// # TestGxAbortSessionRequest
+//
 // This test verifies the abort session request
 // Here we initially setup a session and install a pass all rule
 // We then invoke abort session request from pcrf and expect the

--- a/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
@@ -57,14 +57,14 @@ func verifyEgressRate(t *testing.T, tr *TestRunner, req *cwfProtos.GenTrafficReq
 	}
 }
 
-// TestGxUplinkTrafficQosEnforcement
+// # TestGxUplinkTrafficQosEnforcement
+//
 // This test verifies the QOS configuration(uplink) present in the rules
 //   - Set an expectation for a  CCR-I to be sent up to PCRF, to which it will
 //     respond with a rule install (static-ULQos) with QOS config setting with
 //     maximum uplink bitrate.
 //   - Generate traffic and verify if the traffic observed bitrate matches the configured
-//
-// bitrate
+//     bitrate
 func TestGxUplinkTrafficQosEnforcement(t *testing.T) {
 	t.Skip("Temporarily skipping test due to CWF QOS issues")
 	fmt.Println("\nRunning TestGxUplinkTrafficQosEnforcement")
@@ -141,7 +141,8 @@ func checkIfRuleInstalled(tr *TestRunner, ruleName string) bool {
 	return strings.Contains(cmdOutputList[0].output, ruleName)
 }
 
-// TestGxDownlinkTrafficQosEnforcement
+// # TestGxDownlinkTrafficQosEnforcement
+//
 // This test verifies the QOS configuration(downlink) present in the rules
 //   - Set an expectation for a  CCR-I to be sent up to PCRF, to which it will
 //     respond with a rule install (static-DLQos) with QOS config setting with
@@ -207,20 +208,20 @@ func TestGxDownlinkTrafficQosEnforcement(t *testing.T) {
 	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
-// TestGxQosDowngradeWithCCAUpdate
+// # TestGxQosDowngradeWithCCAUpdate
+//
 // This test verifies QOS downgrade which can be caused due to CCA-update
 //   - Set an expectation for a  CCR-I to be sent up to PCRF, to which it will
 //     respond with a rule install (static-qos-CCAI) with QOS config setting with
 //     maximum uplink bitrate.
 //   - Generate traffic and verify if the traffic observed bitrate matches the initially
-//
-// configured bitrate
-// - Set an expectation for a  CCR-U to be sent up to PCRF, which will respond with a
-// rule install static-qos-CCAU which will downgrade the QOS setting for the uplink
-// - Generate traffic and verify if the traffic observed bitrate matches the newly
-// downgraded bitrate
-// - Send another CCA-update which upgrades the QOS through a dynamic rule and verify
-// that the observed bitrate maches the newly configured bitrate
+//     configured bitrate
+//   - Set an expectation for a  CCR-U to be sent up to PCRF, which will respond with a
+//     rule install static-qos-CCAU which will downgrade the QOS setting for the uplink
+//   - Generate traffic and verify if the traffic observed bitrate matches the newly
+//     downgraded bitrate
+//   - Send another CCA-update which upgrades the QOS through a dynamic rule and verify
+//     that the observed bitrate maches the newly configured bitrate
 func TestGxQosDowngradeWithCCAUpdate(t *testing.T) {
 	t.Skip("Temporarily skipping test due to CWF QOS issues")
 	fmt.Println("\nRunning TestGxQosDowngradeWithCCAUpdate")
@@ -330,18 +331,18 @@ func TestGxQosDowngradeWithCCAUpdate(t *testing.T) {
 	tr.AssertAllGxExpectationsMetNoError()
 }
 
-// TestGxQosDowngradeWithReAuth
+// # TestGxQosDowngradeWithReAuth
+//
 // This test verifies QOS downgrade which can be caused due to ReAuth Request
 //   - Set an expectation for a  CCR-I to be sent up to PCRF, to which it will
 //     respond with a rule install (static-qos-CCAI) with QOS config setting with
 //     maximum uplink bitrate.
 //   - Generate traffic and verify if the traffic observed bitrate matches the initially
-//
-// configured bitrate
-// - Set an expectation for a  CCR-U to be sent up to PCRF, which will respond with a
-// rule install static-qos-CCAU which will downgrade the QOS setting for the uplink
-// - Generate traffic and verify if the traffic observed bitrate matches the newly
-// downgraded bitrate
+//     configured bitrate
+//   - Set an expectation for a  CCR-U to be sent up to PCRF, which will respond with a
+//     rule install static-qos-CCAU which will downgrade the QOS setting for the uplink
+//   - Generate traffic and verify if the traffic observed bitrate matches the newly
+//     downgraded bitrate
 func TestGxQosDowngradeWithReAuth(t *testing.T) {
 	t.Skip("Temporarily skipping test due to CWF QOS issues")
 	fmt.Println("\nRunning TestGxQosDowngradeWithReAuth")

--- a/cwf/gateway/integ_tests/gx_qos_restart_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_restart_test.go
@@ -63,14 +63,14 @@ const (
 	nonCleanRestartYaml = "clean_restart: false"
 )
 
-// testQosEnforcementRestart
+// # testQosEnforcementRestart
+//
 // This test verifies the QOS configuration(uplink) present in the rules
 //   - Set an expectation for a  CCR-I to be sent up to PCRF, to which it will
 //     respond with a rule install (static-ULQos) with QOS config setting with
 //     maximum uplink bitrate.
 //   - Generate traffic and verify if the traffic observed bitrate matches the configured
-//
-// bitrate, restart pipelined and verify if Qos remains enforced
+//     bitrate, restart pipelined and verify if Qos remains enforced
 func testQosEnforcementRestart(t *testing.T, cfgCh chan string, restartCfg string) {
 	t.Skip("Temporarily skipping test due to CWF QOS issues")
 	tr := NewTestRunner(t)


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

This PR fixes formatting problems in CWF Go comments caused by the Go 1.19 formatter tool. The changes are now compatible with the new `gofmt` format and will not be modified on the next auto-format call. 

## Test Plan

## Additional Information
