### PR TITLE
docs: remove inactive HIL lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/last-commit/magma/magma" alt="GitHub last commit"></a>
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/commit-activity/y/magma/magma" alt="GitHub commit activity the past week"></a>
     <a href="https://codecov.io/gh/magma/magma"><img src="https://codecov.io/gh/magma/magma/branch/master/graph/badge.svg" alt="CodeCov"></a>
-    <a href="docs/readmes/lte/hil_tests.md"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL AGW tests"></a>
 </p>
 
 Magma is an open-source software platform that gives network operators an open, flexible and extendable mobile core network solution. Magma enables better connectivity by:


### PR DESCRIPTION
Because it is inactive and broken:
![grafik](https://user-images.githubusercontent.com/13189449/201711216-298a4474-0d81-46aa-bea6-8c4f2be85ca7.png)
