### PR TITLE
docs: switch deployment path to the Github pages

### DIFF
--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -18,12 +18,11 @@ on:
 jobs:
   docusaurus-build-and-deploy:
     runs-on: ubuntu-latest
+    env:
+      DOCUSAURUS_URL: https://magma.github.io
+      DOCUSAURUS_BASE_URL: /
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - name: Export vars
-        run: |
-          echo "DOCUSAURUS_URL=https://magma.github.io" >> $GITHUB_ENV
-          echo "DOCUSAURUS_BASE_URL=/magma/" >> $GITHUB_ENV
       - name: Setup docusaurus expected directory structure
         run: |
           mv docs/docusaurus website/

--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
     <a href="https://www.magmacore.org/"><img src="https://raw.githubusercontent.com/magma/magma/master/docs/docusaurus/static/img/magma-logo-purple.svg" alt="Magma" width="550"></a>
 </h1>
 
-<h3 align="center">Connecting the Next Billion People</h3>
-
 <p align="center">
     <a href="https://github.com/magma/magma/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-BSD3clause-blue.svg" alt="License"></a>
     <a href="https://github.com/magma/magma/releases"><img src="https://img.shields.io/github/release/magma/magma" alt="GitHub Release"></a>
-    <a href="https://docs.magmacore.org/docs/next/contributing/contribute_workflow"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PR's Welcome"></a>
+    <a href="https://github.com/magma/magma/wiki/Contributing-Code"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PR's Welcome"></a>
     <a href="https://github.com/magma/magma/graphs/contributors"><img src="https://img.shields.io/github/contributors/magma/magma" alt="GitHub contributors"></a>
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/last-commit/magma/magma" alt="GitHub last commit"></a>
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/commit-activity/y/magma/magma" alt="GitHub commit activity the past week"></a>
@@ -40,7 +38,7 @@ Magma has three major components
 ## Documentation
 
 - [Magma Website](https://magmacore.org/): Project landing page
-- [Docs](https://docs.magmacore.org/): Deployment, configuration and usage information
+- [Docs](https://magma.github.io/): Deployment, configuration and usage information
 - [Code](https://github.com/magma): Source code
 - [Contributing](https://github.com/magma/magma/wiki/Contributor-Guide): Contributor Guide
 - [Wiki](https://wiki.magmacore.org/): Meeting notes and project team resources

--- a/README.md
+++ b/README.md
@@ -1,17 +1,13 @@
-<h1 align="center">
-    <a href="https://www.magmacore.org/"><img src="https://raw.githubusercontent.com/magma/magma/master/docs/docusaurus/static/img/magma-logo-purple.svg" alt="Magma" width="550"></a>
-</h1>
+# [![Magma](https://raw.githubusercontent.com/magma/magma/master/docs/docusaurus/static/img/magma-logo-purple.svg)](https://www.magmacore.org/)
 
-<p align="center">
-    <a href="https://github.com/magma/magma/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-BSD3clause-blue.svg" alt="License"></a>
-    <a href="https://github.com/magma/magma/releases"><img src="https://img.shields.io/github/release/magma/magma" alt="GitHub Release"></a>
-    <a href="https://github.com/magma/magma/wiki/Contributing-Code"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PR's Welcome"></a>
-    <a href="https://github.com/magma/magma/graphs/contributors"><img src="https://img.shields.io/github/contributors/magma/magma" alt="GitHub contributors"></a>
-    <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/last-commit/magma/magma" alt="GitHub last commit"></a>
-    <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/commit-activity/y/magma/magma" alt="GitHub commit activity the past week"></a>
-    <a href="https://codecov.io/gh/magma/magma"><img src="https://codecov.io/gh/magma/magma/branch/master/graph/badge.svg" alt="CodeCov"></a>
-    <a href="docs/readmes/lte/hil_tests.md"><img src="http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg" alt="HIL AGW tests"></a>
-</p>
+[![License](https://img.shields.io/badge/license-BSD3clause-blue.svg)](https://github.com/magma/magma/blob/master/LICENSE)
+[![GitHub Release](https://img.shields.io/github/release/magma/magma)](https://github.com/magma/magma/releases)
+[![PR's Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/magma/magma/wiki/Contributing-Code)
+[![GitHub contributors](https://img.shields.io/github/contributors/magma/magma)](https://github.com/magma/magma/graphs/contributors)
+[![GitHub last commit](https://img.shields.io/github/last-commit/magma/magma)](https://github.com/magma/magma/commits/master)
+[![GitHub commit activity the past week](https://img.shields.io/github/commit-activity/y/magma/magma)](https://github.com/magma/magma/commits/master)
+[![CodeCov](https://codecov.io/gh/magma/magma/branch/master/graph/badge.svg)](https://codecov.io/gh/magma/magma)
+[![HIL AGW tests](http://ens-spirent-test-summary.com.s3-us-west-1.amazonaws.com/sanity/hilsanityres.svg)](docs/readmes/lte/hil_tests.md)
 
 Magma is an open-source software platform that gives network operators an open, flexible and extendable mobile core network solution. Magma enables better connectivity by:
 

--- a/docs/docusaurus/siteConfig.js
+++ b/docs/docusaurus/siteConfig.js
@@ -13,7 +13,7 @@
 
 // Ref: https://v1.docusaurus.io/docs/en/site-config
 
-const url = process.env.DOCUSAURUS_URL || 'https://magmacore.org'
+const url = process.env.DOCUSAURUS_URL || 'https://magma.github.io'
 const baseUrl = process.env.DOCUSAURUS_BASE_URL || '/'
 
 const mermaid = require('remark-mermaid')
@@ -35,7 +35,7 @@ const siteConfig = {
     {label: ' | '},
     {href: 'https://github.com/magma', label: 'Code'},
     {label: ' | '},
-    {href: 'https://github.com/magma/magma/wiki/Contributor-Guide', label: 'Contributing'},
+    {href: 'https://github.com/magma/magma/wiki', label: 'Contributing'},
     {label: ' | '},
     {href: 'https://wiki.magmacore.org/', label: 'Wiki'},
   ],


### PR DESCRIPTION
## Summary

:information_source: Note, that the URL was only changed in two places, such that it is enough for testing.
A proper switchover needs to follow.

However, a proper switch over of the DNS entry by Linux Foundation might be desired in future anyway.

So this is to prepare for it and get it in shape on the still unused clone.

Second commit is to fix the linter warnings about html in markdown.

## Test Plan

![When we test, we test in production](https://i.imgflip.com/2uxn79.jpg)