### PR TITLE
chore: install only llvm version 12 in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,17 +43,17 @@ RUN echo "Install general purpose packages" && \
     apt-get install -y --no-install-recommends \
         autoconf \
         automake \
-        clang-11 \
-        clang-format-11 \
-        clang-tidy-11 \
+        clang-12 \
+        clang-format-12 \
+        clang-tidy-12 \
         clangd-12 \
         g++-9 \
         gcc-9 \
         gdb \
         lcov \
-        libclang-11-dev \
-        lldb-11 \
-        llvm-11-dev \
+        libclang-12-dev \
+        lldb-12 \
+        llvm-12-dev \
         make \
         ninja-build \
         openjdk-8-jdk \
@@ -68,12 +68,7 @@ RUN echo "Install general purpose packages" && \
         software-properties-common \
         tzdata \
         virtualenv=20.0.17-1ubuntu0.4 && \
-    gem install fpm && \
-    update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-11/bin/clang 10 && \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-11/bin/clang++ 10 && \
-    update-alternatives --install /usr/bin/clang-format clang-format /usr/lib/llvm-11/bin/clang-format 10 && \
-    update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/lib/llvm-11/bin/clang-tidy 10 && \
-    update-alternatives --install /usr/bin/clang-apply-replacements clang-apply-replacements /usr/lib/llvm-11/bin/clang-apply-replacements 10
+    gem install fpm
 
 # Install golang
 WORKDIR /usr/local
@@ -160,13 +155,13 @@ RUN cd /usr/src/googletest && \
     ldconfig -v
 
 ###### Install Include What You Use for c/cpp header include fixup tooling
-# Tag 0.15 tracks Clang 11.0 per https://github.com/include-what-you-use/include-what-you-use/tags
+# Tag 0.15 tracks Clang 12.0 per https://github.com/include-what-you-use/include-what-you-use/tags
 RUN git clone https://github.com/include-what-you-use/include-what-you-use && \
     cd include-what-you-use && \
     git checkout 0.15 && \
     cd .. && \
     mkdir build_iwyu && cd build_iwyu && \
-    cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-11 ../include-what-you-use/ && \
+    cmake -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-12 ../include-what-you-use/ && \
     make && \
     make install && \
     cd .. && \

--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -42,7 +42,7 @@ RUN echo "Install general purpose packages" && \
         libsctp-dev `# dependency of sctpd` \
         libssl-dev \
         libsystemd-dev `# dependency of pip systemd` \
-        lld \
+        lld-12 \
         net-tools `# dependency of python services (e.g. magmad)` \
         netbase `# dependency of python services (e.g. pipelined)` \
         python${PYTHON_VERSION} \


### PR DESCRIPTION
## Summary

This PR upgrades the used `lld` in the bazel-base image and  the `llvm` version in the devcontainer to version 12.

## Test Plan

### CI
- [Bazel Base & DevContainer build](https://github.com/magma/magma/actions/runs/3478667056)
- [AGW-build](https://github.com/magma/magma/actions/runs/3478667071/jobs/5816299385)

### Build localy
### [Host] 
- build Bazel-base image and push it to a local registry:
```
export MAGMA_ROOT=PATH_TO_YOUR_MAGMA_REPO
cd .devcontainer/bazel-base
docker-compose build magma-builder
docker run -d --name registry --network=host registry:2
docker tag bazel-base-magma-builder localhost:5000/bazel-base-magma-builder
docker push localhost:5000/bazel-base-magma-builder
```

### [vscode] 
- modify `.devcontainer/devcontainer.json`:
	
```diff  
- "initializeCommand": "docker pull ghcr.io/magma/magma/devcontainer:latest",
- "image": "ghcr.io/magma/magma/devcontainer:latest",
+   "build": {
+       "dockerfile": "Dockerfile",
+        "context" : ".."
+    },
```

- modify `.devcontainer/Dockerfile`:
```diff 
- FROM ghcr.io/magma/magma/bazel-base:latest as devcontainer
+ FROM localhost:5000/bazel-base-magma-builder as devcontainer
```

- build and run devcontainer

### [devcontainer] 
- run `ncdu /`
   - search in `--- /usr/lib ---` for `llvm` installations

- build c++ services
  - `bazel build ...`
  - `cd lte/gateway && make build_oai`
  
## Additional Information

- [ ] This change is backwards-breaking
