### PR TITLE
feat(ci): pin devcontainer version by hash

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,8 +29,7 @@
 		"ryuta46.multi-command",
 		"coolchyni.beyond-debug"
 	],
-	"initializeCommand": "docker pull ghcr.io/magma/magma/devcontainer:latest",
-	"image": "ghcr.io/magma/magma/devcontainer:latest",
+	"image": "ghcr.io/magma/magma/devcontainer:sha-385c134",
 	"settings": {
 		"search.followSymlinks": false,
 		"terminal.integrated.profiles.linux": {

--- a/.github/workflows/magma-build-3rd-party.yml
+++ b/.github/workflows/magma-build-3rd-party.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   build_dependencies:
     runs-on: ubuntu-latest
-    container: ghcr.io/magma/magma/devcontainer:latest
+    container: ghcr.io/magma/magma/devcontainer:sha-385c134
     env:
       repository: ${{ inputs.repository || 'debian-ci' }}
       distribution: ${{ inputs.distribution || 'focal-ci' }}


### PR DESCRIPTION
## Summary

- Closes https://github.com/magma/magma/issues/11928.

## Test Plan

- CI: https://github.com/magma/magma/actions/runs/3471936427/jobs/5802086458#step:2:129

## Additional Information

- The same could be done for the basel-base container, however, I am not sure if this is any use, as only used in CI anyway.