### PR TITLE
chore: bazel debian artifacts are pushed to lf artifactory

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -282,6 +282,7 @@ jobs:
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the bazel base image!"
+
       - name: Build .deb Packages
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
@@ -312,23 +313,39 @@ jobs:
               echo "Exporting magma version \"${magma_version}\""
               echo "MAGMA_VERSION=${magma_version}" >> $GITHUB_ENV
           fi
-      - name: Setup JFROG CLI
-        uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
-        env:
-          JF_URL: https://artifactory.magmacore.org
-          JF_USER: ${{ secrets.JFROG_USERNAME }}
-          JF_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+
       - name: Set dry run environment variable
         if: ${{ ! ( github.event_name == 'push' && github.repository_owner == 'magma' && github.ref_name == 'master' ) }}
         run: |
           echo "IS_DRY=--dry-run" >> $GITHUB_ENV
-      - name: Publish debian packages
+
+      - name: Setup JFROG CLI - linuxfoundation
+        uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
+        env:
+          JF_URL: https://linuxfoundation.jfrog.io
+          JF_USER: ${{ secrets.LF_JFROG_USERNAME }}
+          JF_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
+      - name: Publish debian packages - linuxfoundation
         env:
           DEBIAN_META_INFO: deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64
         run: |
           jf rt upload \
             --recursive=false \
             --detailed-summary \
+            ${{ env.IS_DRY }} \
+            --target-props="${DEBIAN_META_INFO}" \
+            "packages/(*).deb" debian-test/pool/focal-ci/{1}.deb
+
+      - name: Publish debian packages - magmacore
+        env:
+          DEBIAN_META_INFO: deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64
+        run: |
+          jf rt upload \
+            --recursive=false \
+            --detailed-summary \
+            --url https://artifactory.magmacore.org:443/artifactory/ \
+            --user ${{ secrets.JFROG_USERNAME }} \
+            --password ${{ secrets.JFROG_PASSWORD }} \
             ${{ env.IS_DRY }} \
             --target-props="${DEBIAN_META_INFO}" \
             "packages/(*).deb" debian-test/pool/focal-ci/{1}.deb


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In this change magma and sctpd artifacts created with bazel are pushed to the LF artifactory.

### Notes

* This can only be really tested on master runs.
* I did not find a way in the documentation to configure two artifactories with `jfrog/setup-jfrog-cli` if username and password are used for authentication in a DRY way - it is possible if config tokens are used, but we are not doing this for the magmacore artifactory.
  * on the plus side, the non-DRY way allows to just delete `Publish debian packages - magmacore` step when artifacts are not pushed to the magmacore artif. anymore.

## Test Plan

### Dry run on fork:

https://github.com/magma/magma/actions/runs/3478260996/jobs/5815413934

#### to linuxfoundation artif.:
```
{
  "status": "success",
  "totals": {
    "success": 2,
    "failure": 0
  },
  "files": [
    {
      "source": "packages/magma-sctpd_1.9.0-1668593206-d1c7f369_amd64.deb",
      "target": "https://linuxfoundation.jfrog.io/artifactory/debian-test/pool/focal-ci/magma-sctpd_1.9.0-1668593206-d1c7f369_amd64.deb",
      "sha256": ""
    },
    {
      "source": "packages/magma_1.9.0-1668593206-d1c7f369_amd64.deb",
      "target": "https://linuxfoundation.jfrog.io/artifactory/debian-test/pool/focal-ci/magma_1.9.0-1668593206-d1c7f369_amd64.deb",
      "sha256": ""
    }
  ]
}
```

#### to magmacore artif.:
```
{
  "status": "success",
  "totals": {
    "success": 2,
    "failure": 0
  },
  "files": [
    {
      "source": "packages/magma-sctpd_1.9.0-1668593206-d1c7f369_amd64.deb",
      "target": "[https://artifactory.magmacore.org:443/artifactory/debian-test/pool/focal-ci/magma-sctpd_1.9.0-1668593206-d1c7f369_amd64.deb](https://artifactory.magmacore.org/artifactory/debian-test/pool/focal-ci/magma-sctpd_1.9.0-1668593206-d1c7f369_amd64.deb)",
      "sha256": ""
    },
    {
      "source": "packages/magma_1.9.0-1668593206-d1c7f369_amd64.deb",
      "target": "[https://artifactory.magmacore.org:443/artifactory/debian-test/pool/focal-ci/magma_1.9.0-1668593206-d1c7f369_amd64.deb](https://artifactory.magmacore.org/artifactory/debian-test/pool/focal-ci/magma_1.9.0-1668593206-d1c7f369_amd64.deb)",
      "sha256": ""
    }
  ]
}
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
