### PR TITLE
feat(orc8r): upgrade orchestrator docker base image

### DIFF
--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -175,7 +175,7 @@ else ifeq ($(OS_NAME),Darwin)
 endif
 
 nms_prereqs_ubuntu:
-	curl -sL https://deb.nodesource.com/setup_17.x | bash -
+	curl -sL https://deb.nodesource.com/setup_18.x | bash -
 	apt install -y nodejs
 	npm install --global yarn
 	yarn

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -14,6 +14,8 @@ ENV PATH ${PATH}:${GOBIN}:${GOPATH}/bin
 ENV MAGMA_ROOT /src/magma
 
 # Apt runtime deps
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=UTC
 RUN apt-get update && apt-get install -y \
   bzr \
   curl \

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 ARG PLATFORM=linux/amd64
 
-FROM --platform=$PLATFORM ubuntu:xenial as base
+FROM --platform=$PLATFORM ubuntu:bionic as base
 
 ENV GO111MODULE on
 ENV GOPATH ${USER}/go
@@ -86,7 +86,7 @@ RUN . /etc/profile.d/env.sh && make build
 # ------------------------------------------------------------------------------
 # Production
 # ------------------------------------------------------------------------------
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 # Apt runtime deps
 RUN apt-get update && apt-get install -y \

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 ARG PLATFORM=linux/amd64
 
-FROM --platform=$PLATFORM ubuntu:bionic as base
+FROM --platform=$PLATFORM ubuntu:focal as base
 
 ENV GO111MODULE on
 ENV GOPATH ${USER}/go
@@ -88,7 +88,7 @@ RUN . /etc/profile.d/env.sh && make build
 # ------------------------------------------------------------------------------
 # Production
 # ------------------------------------------------------------------------------
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # Apt runtime deps
 RUN apt-get update && apt-get install -y \
@@ -126,7 +126,7 @@ COPY --from=builder /build/bin /var/opt/magma/bin
 # Supervisor configs
 ARG CNTLR_FILES=src/magma/orc8r/cloud/docker/controller
 COPY ${CNTLR_FILES}/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY ${CNTLR_FILES}/supervisor_logger.py /usr/local/lib/python2.7/dist-packages/supervisor_logger.py
+COPY ${CNTLR_FILES}/supervisor_logger.py /usr/local/lib/python3.8/dist-packages/supervisor_logger.py
 
 # Scripts for dev mode
 COPY ${CNTLR_FILES}/create_test_controller_certs /usr/local/bin/create_test_controller_certs

--- a/orc8r/cloud/docker/controller/supervisor_logger.py
+++ b/orc8r/cloud/docker/controller/supervisor_logger.py
@@ -24,11 +24,6 @@ def write_stdout(s):
     sys.stdout.flush()
 
 
-def write_stderr(s):
-    sys.stderr.write(s)
-    sys.stderr.flush()
-
-
 def main():
     while 1:
         # transition from ACKNOWLEDGED to READY
@@ -42,18 +37,14 @@ def main():
         data = sys.stdin.read(int(headers['len']))
 
         # transition from READY to ACKNOWLEDGED
-        write_stdout('RESULT %s\n%s' % (len(data), data))
+        write_stdout('RESULT 2\nOK')
 
 
-def result_handler(event, response):
-    # Parse the headers
-    line, data = response.split('\n', 1)
-    headers = dict(x.split(':') for x in line.split())
-
-    # Get the log lines and prefix the process name and stdout/stderr
-    lines = data.rstrip().split('\n')
-    prefix = '%s %s | ' % (headers['processname'], headers['channel'])
-    print('\n'.join([prefix + l for l in lines]))
+def result_handler(event, _):
+    print(
+        f"{event.process.config.name} {event.channel} | "
+        f"{event.data.decode('utf-8').rstrip()}"
+    )
 
 
 if __name__ == '__main__':

--- a/orc8r/cloud/docker/controller/supervisor_logger.py
+++ b/orc8r/cloud/docker/controller/supervisor_logger.py
@@ -43,7 +43,7 @@ def main():
 def result_handler(event, _):
     print(
         f"{event.process.config.name} {event.channel} | "
-        f"{event.data.decode('utf-8').rstrip()}"
+        f"{event.data.decode('utf-8').rstrip()}",
     )
 
 

--- a/orc8r/cloud/docker/controller/supervisord.conf
+++ b/orc8r/cloud/docker/controller/supervisord.conf
@@ -1,8 +1,9 @@
 [supervisord]
 nodaemon=true
+user=root
 
 [eventlistener:stdout]
-command=python -m supervisor_logger
+command=python3 -m supervisor_logger
 buffer_size=500
 events=PROCESS_LOG
 result_handler=supervisor_logger:result_handler

--- a/orc8r/cloud/docker/nginx/Dockerfile
+++ b/orc8r/cloud/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21
+FROM nginx:1.23
 
 RUN apt-get update && \
   apt-get install -y python3-pip daemontools


### PR DESCRIPTION
## Summary

- Closes #14344
- Upgrade the orchestrator base image to **focal** LTS
- Upgrade nginx base image to latest minor

## Test Plan

- CI: https://github.com/magma/magma/actions/workflows/build_all.yml?query=branch%3Aorc8r%2Fdocker-base-image-version-upgrade

## Additional Information

- fluentd was already at the newest version in https://github.com/magma/magma/pull/12940
- An upgrade to `jammy` seems not easily possible, due to a very weird bug.
  - In the dp-workflow, one will get error when trying to install openjdk-8-jre-headless.
    ```
    # There is insufficient memory for the Java Runtime Environment to continue.
    # Cannot create GC thread. Out of system resources.
    ```
  - This error is not seen, when using focal.
  - This error is not seen, when building in build-all.
  - This error is not seen, when installing this package locally in and `ubuntu:jammy` docker image.
  - So something must be very brittle in the setup of dp-workflow together with the Github action runners.
  - Strange enough, directly before
    ```
    free -h
                  total        used        free      shared  buff/cache   available
    Mem:          6.8Gi       1.3Gi       363Mi        21Mi       5.1Gi       5.2Gi
    Swap:         4.0Gi       0.0Ki       4.0Gi
    ```