### PR TITLE
fix(ci): only workflow names work as trigger specifications

### DIFF
--- a/.github/workflows/agw-docker-load-test.yml
+++ b/.github/workflows/agw-docker-load-test.yml
@@ -14,7 +14,7 @@ name: AGW Test Load Docker AMI
 on:
   workflow_run:
     workflows:
-      - build-all
+      - Magma Build & Publish
     branches:
       - master
       - 'v1.*'

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -13,9 +13,9 @@ name: PR Generate Comment On Workflow Failure
 on:
   workflow_run:
     workflows:
-      - dco-check
-      - python-workflow
-      - docs-workflow
+      - PR Check DCO
+      - AGW Build & Format Python
+      - Docs Lint & Check Generated Files In Sync
     types:
       - completed
 

--- a/.github/workflows/deploy-build-from-pr.yml
+++ b/.github/workflows/deploy-build-from-pr.yml
@@ -13,7 +13,7 @@ name: Magma Publish Artifacts
 on:
   workflow_run:
     workflows:
-      - build-all
+      - Magma Build & Publish
     types:
       - completed
 # Replace registries with new test registries reserved for PR builds

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -14,8 +14,10 @@ name: AGW Test LTE Integration With Make Containerized Build
 on:
   workflow_dispatch: null
   workflow_run:
-    workflows: [ agw-build-publish-container ]
-    types: [ completed ]
+    workflows:
+      - AGW Build & Publish Container
+    types:
+      - completed
 
 jobs:
   lte-integ-test-containerized:

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -13,11 +13,11 @@ name: PR Generate Unit Test Results
 on:
   workflow_run:
     workflows:
-      - cloud-workflow
-      - feg-workflow
-      - golang-build-test
-      - nms-workflow
-      - dp-workflow
+      - Orc8r Lint & Test
+      - FeG Lint & Test
+      - AGW Build & Test Experimental Go Code
+      - NMS Lint & Test
+      - DP Lint & Test
     types:
       - completed
 


### PR DESCRIPTION
## Summary

- Fixes #14462 
  - This was probably because of the misconception raised in #14325, that the file name of the workflow would be valid input name, while it is not. [The documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) does not actually hint to anything else than the workflow name. 
- Follow up to the un-fixing in
  - https://github.com/magma/magma/pull/14229
  - https://github.com/magma/magma/pull/14411

## Test plan

- We will see if that is working again, once merged. :wink: It cannot get more broken and testing is only possible from master branch anyway.