### PR TITLE
chore(ci): Build MME for the OAI-MME variant with Bazel for RHEL

### DIFF
--- a/ci-scripts/docker/Dockerfile.mme.ci.rhel8
+++ b/ci-scripts/docker/Dockerfile.mme.ci.rhel8
@@ -18,15 +18,15 @@ COPY ./ $MAGMA_ROOT
 RUN export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig/ && \
     # Remove entitlements
     rm -Rf $MAGMA_ROOT/etc-pki-entitlement $MAGMA_ROOT/rhsm-conf $MAGMA_ROOT/rhsm-ca && \
-    cd $MAGMA_ROOT/lte/gateway && \
+    cd $MAGMA_ROOT && \
     echo $FEATURES && \
-    make build_oai && \
-    make build_sctpd && \
-    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme && \
+    bazel build //lte/gateway/c/core:mme_oai --define=disable_sentry_native=1 && \
+    bazel build //lte/gateway/c/sctpd/src:sctpd --define=disable_sentry_native=1 && \
+    mv $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/mme_oai $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
     echo 'Shared libraries for oai_mme' && \
-    ldd $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
     echo 'Shared libraries for sctpd' && \
-    ldd $C_BUILD/sctpd/src/sctpd
+    ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd
 
 # Prepare config file
 RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
@@ -115,9 +115,9 @@ COPY --from=magma-mme-builder \
     /usr/local/lib/libfdcore.so.6 \
     /usr/local/lib/libfdproto.so.6 \
 # From nettle/gnutls src build
-    /usr/local/lib/libgnutls.so.28 \
-    /usr/local/lib/libnettle.so.4 \
-    /usr/local/lib/libhogweed.so.2 \
+    /lib64/libgnutls.so.28 \
+    /lib/libnettle.so.4 \
+    /lib/libhogweed.so.2 \
     /lib64/
 
 # Copy all fdx files from freeDiameter installation
@@ -130,8 +130,8 @@ RUN ldconfig
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
 COPY --from=magma-mme-builder \
-    $C_BUILD/core/oai/oai_mme/oai_mme \
-    $C_BUILD/sctpd/src/sctpd \
+    $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme \
+    $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd \
     ./
 
 # Copy the configuration file templates and mean to modify/generate certificates

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -225,7 +225,7 @@ RUN tar -xf nettle-2.5.tar.gz && \
     cd nettle-2.5 && \
     mkdir _build && \
     cd _build/ && \
-    ../configure --libdir=/usr/local/lib && \
+    ../configure --libdir=/usr/lib && \
     make -j`nproc` && \
     make install && \
     ldconfig -v && \
@@ -234,7 +234,7 @@ RUN tar -xf nettle-2.5.tar.gz && \
     # Moved wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
     tar xf gnutls-3.1.23.tar.xz && \
     cd gnutls-3.1.23 && \
-    ./configure --with-libnettle-prefix=/usr/local && \
+    ./configure --with-libnettle-prefix=/usr --prefix=/usr && \
     sed -i -e "s#elif 0#elif 1#" gl/fseterr.c && \
     make -j`nproc` && \
     make install && \
@@ -302,6 +302,17 @@ RUN cd json && \
     cd ../ && rm -Rf _build && \
     ldconfig --verbose
 
+# Install bazel
+WORKDIR /usr/sbin
+RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
+    chmod +x bazelisk-linux-amd64 && \
+    ln -sf /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
+
+RUN mkdir -p /usr/lib/x86_64-linux-gnu/ && \
+    ln -s /lib64/libglog.so /usr/lib/x86_64-linux-gnu/libglog.so.0 && \
+    ln -s /lib64/libgnutls.so /usr/lib/libgnutls.so && \
+    ldconfig --verbose
+
 # Starting from here, we are building MAGMA services (sctpd and mme)
 FROM magma-mme-base as magma-mme-builder
 
@@ -312,15 +323,15 @@ COPY ./ $MAGMA_ROOT
 RUN export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig/ && \
     # Remove entitlements
     rm -Rf $MAGMA_ROOT/etc-pki-entitlement $MAGMA_ROOT/rhsm-conf $MAGMA_ROOT/rhsm-ca && \
-    cd $MAGMA_ROOT/lte/gateway && \
+    cd $MAGMA_ROOT && \
     echo $FEATURES && \
-    make build_oai && \
-    make build_sctpd && \
-    cp $C_BUILD/core/oai/oai_mme/mme $C_BUILD/core/oai/oai_mme/oai_mme && \
+    bazel build //lte/gateway/c/core:mme_oai --define=disable_sentry_native=1 && \
+    bazel build //lte/gateway/c/sctpd/src:sctpd --define=disable_sentry_native=1 && \
+    mv $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/mme_oai $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
     echo 'Shared libraries for oai_mme' && \
-    ldd $C_BUILD/core/oai/oai_mme/oai_mme && \
+    ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
     echo 'Shared libraries for sctpd' && \
-    ldd $C_BUILD/sctpd/src/sctpd
+    ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd
 
 # Prepare config file
 RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
@@ -354,8 +365,8 @@ FROM magma-mme-builder as magma-dev-mme
 
 # Copy the configuration file templates and mean to modify/generate certificates
 WORKDIR /magma-mme/bin
-RUN cp $C_BUILD/core/oai/oai_mme/mme oai_mme
-RUN cp $C_BUILD/sctpd/src/sctpd .
+RUN cp $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme .
+RUN cp $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd .
 WORKDIR /magma-mme/etc
 RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme.conf .
 RUN cp $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme_fd.conf .
@@ -441,9 +452,9 @@ COPY --from=magma-mme-builder \
     /usr/local/lib/libfdcore.so.6 \
     /usr/local/lib/libfdproto.so.6 \
 # From nettle/gnutls src build
-    /usr/local/lib/libgnutls.so.28 \
-    /usr/local/lib/libnettle.so.4 \
-    /usr/local/lib/libhogweed.so.2 \
+    /lib64/libgnutls.so.28 \
+    /lib/libnettle.so.4 \
+    /lib/libhogweed.so.2 \
     /lib64/
 
 # Copy all fdx files from freeDiameter installation
@@ -456,8 +467,8 @@ RUN ldconfig
 # Copy pre-built binaries for MME and SCTPD
 WORKDIR /magma-mme/bin
 COPY --from=magma-mme-builder \
-    $C_BUILD/core/oai/oai_mme/oai_mme \
-    $C_BUILD/sctpd/src/sctpd \
+    $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme \
+    $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd \
     ./
 
 # Copy the configuration file templates and mean to modify/generate certificates


### PR DESCRIPTION
Co-authored-by: Lars Kreutzer <lars.kreutzer@tngtech.com>
Co-authored-by: Krisztián Varga <krisztian.varga@tngtech.com>
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

MME and SCTPD are build with bazel. `--define=disable_sentry_native=1` is needed in order to disable Sentry, which has additional dependencies.

This closes #14414.

## Test Plan

OAI Jenkins CI.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
