### PR TITLE
fix: https://github.com/magma/security/issues/140

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_config.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_config.cpp
@@ -1498,6 +1498,9 @@ int mme_config_parse_string(const char* config_string,
 
       if (subsetting != NULL) {
         num = config_setting_length(subsetting);
+        AssertFatal(num > 0,
+                    "ORDERED_SUPPORTED_INTEGRITY_ALGORITHM_LIST must have at "
+                    "least one element\n");
 
         if (num <= 8) {
           for (i = 0; i < num; i++) {
@@ -1513,12 +1516,16 @@ int mme_config_parse_string(const char* config_string,
               config_pP->nas_config.prefered_integrity_algorithm[i] =
                   EIA2_128_ALG_ID;
             else
-              config_pP->nas_config.prefered_integrity_algorithm[i] =
-                  EIA0_ALG_ID;
+              Fatal(
+                  "Unrecognized algorithm in "
+                  "ORDERED_SUPPORTED_INTEGRITY_ALGORITHM_LIST\n");
           }
 
+          char default_integrity_algorithm =
+              config_pP->nas_config.prefered_integrity_algorithm[num - 1];
           for (i = num; i < 8; i++) {
-            config_pP->nas_config.prefered_integrity_algorithm[i] = EIA0_ALG_ID;
+            config_pP->nas_config.prefered_integrity_algorithm[i] =
+                default_integrity_algorithm;
           }
         }
       }


### PR DESCRIPTION
bug: https://github.com/magma/security/issues/140

If ORDERED_SUPPORTED_INTEGRITY_ALGORITHM_LIST is empty, throw an error instead of inserting EIA0.

If ORDERED_SUPPORTED_INTEGRITY_ALGORITHM_LIST contains an invalid setting, throw an error instead of replacing with EIA0.

If ORDERED_SUPPORTED_INTEGRITY_ALGORITHM_LIST contains < 8 items, pad by repeating the last-place item rather than assuming EIA0.

Throw error if ORDERED_SUPPORTED_INTEGRITY_ALGORITHM_LIST contains an unrecognized setting.

Signed-off-by: Lucas Gonze <lucas@gonze.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
