### PR TITLE
ci: upgrade docker/setup-buildx-action

### DIFF
--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -45,7 +45,7 @@ runs:
         flavor: latest=true
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # pin@v2.2.1
     - name: Login to GHCR
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin v2.1.0
       with:


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>


## Summary

Several github actions are deprecated because they use Node 12.
This PR upgrades the github action `docker/setup-buildx-action`.

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking
