### PR TITLE
chore(ci): Fix permission issue for bazel-base cache

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,8 +15,6 @@ ARG USE_MOBY="true"
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your
 # own dependencies. A user of "automatic" attempts to reuse an user ID if one already exists.
 ARG USERNAME=automatic
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
 RUN apt-get update \
     && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \

--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -7,6 +7,9 @@ ARG DEB_PORT=amd64
 
 ARG PYTHON_VERSION=3.8
 
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Building bazel inside the basel-baze container corrupted the cache permissions. With this change this is no longer the case. This closes #14402.

## Test Plan

1. Build the bazel-base container
2. Run the bazel-base container
3. Build something with bazel in the bazel-base container
4. Try building something with bazel in the Magma VM

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
