### PR TITLE
fix(orc8r): pin postgres image version to 14

### DIFF
--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -50,7 +50,7 @@ services:
   # Non-core essential services
 
   postgres:
-    image: postgres
+    image: postgres:14
     # Default is 64mb
     # Ref: https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container
     shm_size: '256mb'


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The Postgres image version in orc8r is not pinned, with [Postgres 15](https://www.postgresql.org/about/news/postgresql-15-released-2526/) being released on October 13th. This version breaks the orc8r build and some certificates are not created. This PR pins the image version to 14.

## Test Plan

- Purge docker by stopping all containers and `docker system prune -a`.
- Delete the certificates in `magma/.cache/test_certs/`.
- Follow the [orc8r build instruction](https://magma.github.io/magma/docs/next/basics/quick_start_guide)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
