### PR TITLE
chore: bazel debian artifacts are also pushed to the LF artifactory

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -297,26 +297,42 @@ jobs:
               echo "Exporting magma version \"${magma_version}\""
               echo "MAGMA_VERSION=${magma_version}" >> $GITHUB_ENV
           fi
+
       - name: Setup JFROG CLI
         uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
-        env:
-          JF_URL: https://artifactory.magmacore.org
-          JF_USER: ${{ secrets.JFROG_USERNAME }}
-          JF_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+
       - name: Set dry run environment variable
         if: ${{ ! ( github.event_name == 'push' && github.repository_owner == 'magma' && github.ref_name == 'master' ) }}
         run: |
           echo "IS_DRY=--dry-run" >> $GITHUB_ENV
-      - name: Publish debian packages
+
+      - name: Publish debian packages - magmacore
         env:
           DEBIAN_META_INFO: deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64
         run: |
           jf rt upload \
             --recursive=false \
             --detailed-summary \
+            --url https://artifactory.magmacore.org:443/artifactory/ \
+            --user ${{ secrets.JFROG_USERNAME }} \
+            --password ${{ secrets.JFROG_PASSWORD }} \
             ${{ env.IS_DRY }} \
             --target-props="${DEBIAN_META_INFO}" \
             "packages/(*).deb" debian-test/pool/focal-ci/{1}.deb
+
+      - name: Publish debian packages - linuxfoundation
+        env:
+          DEBIAN_META_INFO: deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64
+        run: |
+          jf rt upload \
+            --recursive=false \
+            --detailed-summary \
+            --url https://linuxfoundation.jfrog.io/artifactory/ \
+            --user ${{ secrets.LF_JFROG_USERNAME }} \
+            --password ${{ secrets.LF_JFROG_PASSWORD }} \
+            ${{ env.IS_DRY }} \
+            --target-props="${DEBIAN_META_INFO}" \
+            "packages/(*).deb" magma-packages-test/pool/focal-ci/{1}.deb
 
       - name: Trigger debian integ test workflow
         uses: peter-evans/repository-dispatch@f2696244ec00ed5c659a5cc77f7138ad0302dffb # pin@v2.1.0


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Reworked version of #14451 (reverted) - but at the end the previous used credentials were not working.

## Test Plan

On a test branch with a workflow definition with identical push logic the push was successful:
* run: https://github.com/magma/magma/actions/runs/3489318108/jobs/5839270079
* on https://linuxfoundation.jfrog.io/ui/native/magma-packages-test/pool/focal-ci/ find
```
magma-sctpd_1.9.0-1668697144-c0264c70_amd64.deb 17-11-22 15:59:18 +0100
magma_1.9.0-1668697144-c0264c70_amd64.deb 17-11-22 15:59:19 +0100
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
