### PR TITLE
feat(ci): lte-integ-test-bazel-magma-deb publishes results to firebase

### DIFF
--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install pre requisites
         run: |
           pip3 install --upgrade pip
-          pip3 install ansible fabric3 jsonpickle requests PyYAML
+          pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
           vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
       - name: Open up network interfaces for VM
         run: |
@@ -57,6 +57,7 @@ jobs:
         env:
           MAGMA_DEV_CPUS: 3
           MAGMA_DEV_MEMORY_MB: 9216
+        working-directory: 'lte/gateway/'
         run: |
           if [[ -z "${{ github.event.client_payload.magma_version }}" ]]; then
             export MAGMA_PACKAGE=magma
@@ -64,13 +65,12 @@ jobs:
             export MAGMA_PACKAGE=magma=${{ github.event.client_payload.magma_version }}
           fi
           echo "Starting integration tests using magma artifact \"${MAGMA_PACKAGE}\"."
-          cd lte/gateway
           fab integ_test_deb_installation
 
       - name: Get test results
         if: always()
+        working-directory: 'lte/gateway/'
         run: |
-          cd lte/gateway
           fab get_test_summaries:dst_path="test-results",sudo_tests=False,dev_vm_name="magma_deb"
           ls -R
       - name: Upload test results
@@ -98,6 +98,25 @@ jobs:
         with:
           name: test-logs
           path: lte/gateway/logs.tar.gz
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-logs
+          path: lte/gateway/logs.tar.gz
+
+      - name: Publish results to Firebase
+        if: always() && github.event_name == 'repository_dispatch'
+        env:
+          FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
+          REPORT_FILENAME: "lte_integ_test_magma_deb_${{ github.sha }}.html"
+        run: |
+          npm install -g xunit-viewer
+          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
+          [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
+          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} debian_lte_integ_test --url $URL
 
       - name: Notify failure to slack
         if: failure() && github.repository_owner == 'magma'

--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -75,6 +75,11 @@ def make_debian_lte_integ_test(args):
     )
 
 
+def debian_lte_integ_test(args):
+    """Prepare and publish LTE Integ Test report"""
+    prepare_and_publish('debian_lte_integ_test', args, 'test_status.txt')
+
+
 def feg_integ_test(args):
     """Prepare and publish FEG Integ Test report"""
     prepare_and_publish('feg_integ_test', args, 'test_status.txt')
@@ -135,6 +140,7 @@ tests = {
     'cwf': cwf_integ_test,
     'sudo_python_tests': sudo_python_tests,
     'make_debian_lte_integ_test': make_debian_lte_integ_test,
+    'debian_lte_integ_test': debian_lte_integ_test,
 }
 
 for key, value in tests.items():


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The switch from `make` to `bazel` as build tool needs to be reflected in the CI dashboard as well. Therefore, the dashboard should display the results of the LTE integ tests on the production-like Debian machine build with `bazel` instead of `make`. This requires 

1. The `bazel`-based workflow to publish the results to firebase.
2. Firebase to display these results and not the make-base ones.
3. The `make`-based workflow to not publish this anymore.

Since we operate across repositories here, three PRs seem the least invasive way to do this.

This PR enables the publishing of the LTE integration tests on the debian machine build with bazel to the firebase database.

Part of #14180.

## Test Plan

 - Wait for CI run.
 - Check in firebase if the reports are there.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
