### PR TITLE
chore(ci): optimizing the OAI Ubuntu18 build pipeline stage

### DIFF
--- a/ci-scripts/JenkinsFile-OAI-Container-GitHub
+++ b/ci-scripts/JenkinsFile-OAI-Container-GitHub
@@ -29,10 +29,6 @@ def nodeExecutor = params.nodeExecutor
 // lock mechanism
 def cn_ci_resource = params.MagmaDockerResources
 
-// We are using a base image to speed up CI build.
-// This base image is potentially subject to changes over time.
-def MAGMA_U18_BASE_IMAGE_TAG = params.MagmaBaseImageTag
-
 // Name of the DsTester child pipeline
 def dsTesterPipelineName = params.dsTesterPipelineName
 // Name of the DsTester child pipeline HTML report file
@@ -103,7 +99,7 @@ pipeline {
               steps {
                 script {
                   try {
-                    sh('docker image inspect --format="Size = {{.Size}} bytes" magma-dev-mme:' + MAGMA_U18_BASE_IMAGE_TAG)
+                    sh('docker image inspect --format="Size = {{.Size}} bytes" magma-dev-mme:ci-base-image')
                   } catch (Exception e) {
                     currentBuild.result = 'FAILURE'
                     echo '\u26D4 \u001B[31mUbuntu18 Base Image does not exist\u001B[0m'
@@ -120,10 +116,8 @@ pipeline {
                   if (params.REGRESSION_TEST) {
                     branch = 'master'
                     u18_image_tag = 'master'
-                    u18_docker_file = 'lte/gateway/docker/mme/Dockerfile.ubuntu18.04'
                   } else {
                     branch = sha1
-                    u18_docker_file = 'ci-scripts/docker/Dockerfile.mme.ci.ubuntu18'
                   }
                   checkout(
                     changelog: false,
@@ -162,17 +156,11 @@ pipeline {
               steps {
                 script {
                   echo '\u2705 \u001B[32mBuild Ubuntu18 Target Image to Test\u001B[0m'
-                  if (!params.REGRESSION_TEST) {
-                    try {
-                      // Checking if the CI Base image is still there.
-                      // If the inspect command fails, it's not there. If it passes, let remove tag.
-                      sh('docker image inspect magma-dev-mme:ci-base-image > /dev/null 2>&1')
-                      sh('docker rmi magma-dev-mme:ci-base-image')
-                    } catch (Exception e) {
-                      echo 'No need to remove the CI base image'
-                    }
-                    // "ci-base-image" is the tag used in the docker file.
-                    sh('docker image tag magma-dev-mme:' + MAGMA_U18_BASE_IMAGE_TAG + ' magma-dev-mme:ci-base-image')
+                  // On the daily regression build, we will regenerate the base image and the master image
+                  // Making sure that if the build fails for any reason we can go back to the previous versions
+                  if (params.REGRESSION_TEST) {
+                    sh('docker image tag magma-dev-mme:ci-base-image magma-dev-mme:ci-base-image-prev')
+                    sh('docker image tag magma-dev-mme:master magma-dev-mme:master-prev')
                   }
 
                   // Removing the .dockerignore file (troublesome for us)
@@ -187,9 +175,16 @@ pipeline {
                   // Create the image to use
                   // Once again, we are not using the full dockerfile from scratch: too long --> when it is a pull request
                   // On the daily master build, we are doing from scratch
-                  sh('docker build --no-cache --target magma-mme --tag magma-mme:' + u18_image_tag + ' --file ' + u18_docker_file + ' . > archives/build_magma_mme.log 2>&1')
+                  sh('export DOCKER_BUILDKIT=1')
+                  if (params.REGRESSION_TEST) {
+                    u18_docker_file = 'lte/gateway/docker/mme/docker-compose-build-ubuntu18.04.yaml'
+                    sh('export COMPOSE_DOCKER_CLI_BUILD=1')
+                    sh('docker compose -f ' + u18_docker_file + ' build --no-cache > archives/build_magma_mme.log 2>&1')
+                  } else {
+                    u18_docker_file = 'ci-scripts/docker/Dockerfile.mme.ci.ubuntu18'
+                    sh('docker build --no-cache --target magma-mme --tag magma-mme:' + u18_image_tag + ' --file ' + u18_docker_file + ' . > archives/build_magma_mme.log 2>&1')
+                  }
                   sh('wget --quiet https://raw.githubusercontent.com/' + trustedGHuser + '/magma/' + trustedBranch + '/ci-scripts/flatten_image.py -O ci-scripts/ci-flatten_image.py')
-                  sh('python3 ./ci-scripts/ci-flatten_image.py --tag magma-mme:' + u18_image_tag)
                   sh('docker image prune --force > /dev/null 2>&1')
                   sh('docker image ls >> archives/build_magma_mme.log')
                 }
@@ -198,6 +193,8 @@ pipeline {
                 success {
                   script {
                     sh 'echo "MAGMA-OAI-MME DOCKER IMAGE BUILD: OK" >> archives/build_magma_mme.log'
+                    // Removing the previous versions
+                    sh('docker rmi magma-dev-mme:ci-base-image-prev magma-dev-mme:master-prev')
                   }
                 }
                 unsuccessful {
@@ -206,6 +203,10 @@ pipeline {
                     // Remove any (at least the last one) dangling build container and any dangling image
                     sh 'docker ps --quiet --filter "status=exited" -n1 | xargs docker rm -f || true'
                     sh('docker image prune --force > /dev/null 2>&1')
+                    // Putting back the previous versions
+                    sh('docker image tag magma-dev-mme:ci-base-image-prev magma-dev-mme:ci-base-image')
+                    sh('docker image tag magma-dev-mme:master-prev magma-dev-mme:master')
+                    sh('docker rmi magma-dev-mme:ci-base-image-prev magma-dev-mme:master-prev')
                   }
                 }
               }
@@ -506,8 +507,6 @@ pipeline {
           sh('docker image prune --force > /dev/null 2>&1')
           // Delete image only in case of pull requests
           if (!params.REGRESSION_TEST) {
-            // Remove CI Base image tag
-            sh('docker rmi magma-dev-mme:ci-base-image')
             try {
               sh('docker image rm magma-mme:' + u18_image_tag + ' > /dev/null 2>&1')
             } catch (Exception e) {

--- a/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
+++ b/ci-scripts/docker/Dockerfile.mme.ci.ubuntu18
@@ -20,7 +20,9 @@ RUN cd $MAGMA_ROOT && \
     bazel build //lte/gateway/c/core:mme_oai --define=disable_sentry_native=1 && \
     bazel build //lte/gateway/c/sctpd/src:sctpd --define=disable_sentry_native=1 && \
     mv $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/mme_oai $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
+    echo 'Shared libraries for oai_mme' && \
     ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
+    echo 'Shared libraries for sctpd' && \
     ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd
 
 # Prepare config file
@@ -54,7 +56,6 @@ RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
 # Target Image
 ################################################################
 FROM ubuntu:bionic as magma-mme
-
 ENV MAGMA_ROOT=/magma
 ENV C_BUILD=/build/c
 
@@ -128,7 +129,9 @@ WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml && \
     openssl rand -out /root/.rnd 128 && \
+    echo 'Shared libraries for oai_mme' && \
     ldd /magma-mme/bin/oai_mme && \
+    echo 'Shared libraries for sctpd' && \
     ldd /magma-mme/bin/sctpd
 
 WORKDIR /etc/magma
@@ -137,9 +140,9 @@ COPY --from=magma-mme-builder \
     $MAGMA_ROOT/lte/gateway/configs/redis.yml \
     $MAGMA_ROOT/lte/gateway/configs/service_registry.yml \
     $MAGMA_ROOT/lte/gateway/configs/sctpd.yml \
-    ./
+    /etc/magma/
 
-# Scripts to re-generate certificates
+# Adding means to re-generate certificates
 WORKDIR /magma-mme/scripts
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/c/core/oai/test/check_mme_s6a_certificate .
 RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" \

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -123,10 +123,10 @@ RUN yum install -y \
 
 # Add Converged MME sources to the container
 WORKDIR /patches
-COPY  lte/gateway/c/core/oai/patches/0001-opencoord.org.freeDiameter.patch .
-COPY  lte/gateway/c/core/oai/patches/0002-opencoord.org.freeDiameter.patch .
+COPY  lte/gateway/c/core/oai/patches/0001-opencoord.org.freeDiameter.patch /patches
+COPY  lte/gateway/c/core/oai/patches/0002-opencoord.org.freeDiameter.patch /patches
 
-# All works will be done from root of file system
+# All works will be done from the root of the file system
 WORKDIR /
 
 # git clone may fail on our OC cluster (could not resolve github.com, other sites
@@ -143,7 +143,7 @@ RUN  git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
      git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
      git clone https://github.com/nlohmann/json.git
 
-##### GRPC and it's dependencies
+##### GRPC and its dependencies
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local-lib.conf && \
     echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local-lib.conf && \
     # Moved git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
@@ -193,7 +193,7 @@ RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local-lib.conf && \
         .. && \
     make -j`nproc` && \
     make install && \
-    cd .. && rm -Rf _build
+    cd .. && rm -R --interactive=never _build
 
 
 ##### Prometheus CPP
@@ -206,7 +206,7 @@ RUN cd prometheus-cpp && \
     cmake .. && \
     make -j`nproc` && \
     make install && \
-    cd .. && rm -Rf _build
+    cd .. && rm -R --interactive=never _build
 
 ##### Redis CPP
 RUN cd cpp_redis && \
@@ -217,7 +217,7 @@ RUN cd cpp_redis && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make -j`nproc` && \
     make install && \
-    cd .. && rm -Rf _build
+    cd .. && rm -R --interactive=never _build
 
 ##### NETTLE / gnutls
 RUN tar -xf nettle-2.5.tar.gz && \
@@ -230,7 +230,7 @@ RUN tar -xf nettle-2.5.tar.gz && \
     make install && \
     ldconfig -v && \
     cd / && \
-    rm -Rf nettle-2.5.tar.gz nettle-2.5/_build && \
+    rm -R --interactive=never nettle-2.5.tar.gz nettle-2.5/_build && \
     # Moved wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
     tar xf gnutls-3.1.23.tar.xz && \
     cd gnutls-3.1.23 && \
@@ -240,7 +240,7 @@ RUN tar -xf nettle-2.5.tar.gz && \
     make install && \
     make clean 2>&1 > /dev/null && \
     cd / && \
-    rm -Rf gnutls-3.1.23.tar.xz && \
+    rm -R --interactive=never gnutls-3.1.23.tar.xz && \
     ldconfig -v
 
 ##### liblfds
@@ -270,7 +270,7 @@ RUN cd asn1c && \
     ./configure && \
     make -j`nproc` && \
     make install && \
-    make clean 2>&1 > /dev/null
+    git clean -x -d -ff -q
 
 ##### FreeDiameter
 RUN cd freediameter && \
@@ -288,7 +288,7 @@ RUN cd freediameter && \
     grep DISABLE_SCTP CMakeCache.txt && \
     make -j`nproc` && \
     make install && \
-    cd ../ && rm -Rf _build
+    cd ../ && rm -R --interactive=never _build
 
 ##### lib nlohmann json
 RUN cd json && \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -1,7 +1,7 @@
 ################################################################
 # Builder Image (can also be used as developer's image)
 ################################################################
-FROM ubuntu:bionic as magma-mme-builder
+FROM ubuntu:bionic as magma-mme-base
 
 ENV FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
@@ -52,48 +52,55 @@ RUN echo "Install 3rd party dependencies" && \
     apt-get install -y libsystemd-dev && \
     ln -s /usr/bin/python2.7 /usr/local/bin/python
 
-##### NETTLE
-RUN wget --quiet https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
-    tar -xf nettle-2.5.tar.gz && \
-    cd nettle-2.5 && \
-    mkdir build && \
-    cd build/ && \
-    ../configure --disable-openssl --enable-shared --libdir=/usr/lib && \
-    make -j`nproc` && \
-    make install && \
-    ldconfig -v && \
-    cd / && \
-    wget --quiet https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
-    tar xf gnutls-3.1.23.tar.xz && \
-    cd gnutls-3.1.23 && \
-    ./configure --with-libnettle-prefix=/usr --prefix=/usr && \
-    make -j`nproc` && \
-    make install && \
-    ldconfig -v
+RUN apt-get install -y python3-pip && \
+    pip3 install jinja2-cli
 
-##### GRPC and it's dependencies
-RUN git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
+# Add Converged MME sources to the container
+WORKDIR /patches
+COPY  lte/gateway/c/core/oai/patches/0001-opencoord.org.freeDiameter.patch /patches
+COPY  lte/gateway/c/core/oai/patches/0002-opencoord.org.freeDiameter.patch /patches
+
+# All works will be done from the root of the file system
+WORKDIR /
+
+# git clone may fail on our OC cluster (could not resolve github.com, other sites
+# may happen), we may have to tweak some limits...
+# Prefer to fail as soon as possible if it has to happen
+RUN  git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
+     git clone https://github.com/jupp0r/prometheus-cpp.git && \
+     git clone https://github.com/cpp-redis/cpp_redis.git && \
+     wget https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
+     wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
+     git clone https://github.com/liblfds/liblfds.git && \
+     git clone https://git.osmocom.org/libgtpnl && \
+     git clone https://github.com/OPENAIRINTERFACE/asn1c.git && \
+     git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
+     git clone https://github.com/nlohmann/json.git
+
+##### GRPC and its dependencies
+RUN echo "GRPC and its dependencies" && \
+    # Moved git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
     echo "Install c-ares" && \
-    cd grpc && \
+    cd /grpc && \
     cd third_party/cares/cares && \
     git fetch origin && \
     git checkout cares-1_13_0 && \
-    mkdir -p cmake/build && \
-    cd cmake/build && \
-    cmake -DCMAKE_BUILD_TYPE=Release ../.. && \
+    mkdir -p _build && \
+    cd _build && \
+    cmake -Wno-dev -DCMAKE_BUILD_TYPE=Release .. && \
     make -j`nproc` && \
     make install && \
-    cd ../../../../.. && \
-    rm -rf third_party/cares/cares && \
+    cd /grpc && \
+    rm -rf third_party/cares/cares/_build && \
     echo "Install zlib" && \
     cd third_party/zlib && \
-    mkdir -p cmake/build && \
-    cd cmake/build && \
-    cmake -DCMAKE_BUILD_TYPE=Release ../.. && \
+    mkdir -p _build && \
+    cd _build && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
     make -j`nproc` && \
     make install && \
-    cd ../../../.. && \
-    rm -rf third_party/zlib && \
+    cd /grpc && \
+    rm -rf third_party/zlib/_build && \
     echo "Install protobuf" && \
     cd third_party/protobuf && \
     git submodule update --init --recursive  && \
@@ -101,12 +108,12 @@ RUN git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
     ./configure  && \
     make -j`nproc` && \
     make install && \
-    cd ../.. && \
-    rm -rf third_party/protobuf && \
+    git clean -x -d -ff -q && \
+    cd /grpc && \
     ldconfig && \
     echo "Install GRPC" && \
-    mkdir -p cmake/build && \
-    cd cmake/build && \
+    mkdir -p _build && \
+    cd _build && \
     cmake \
         -DgRPC_INSTALL=ON \
         -DBUILD_SHARED_LIBS=ON \
@@ -116,74 +123,105 @@ RUN git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
         -DgRPC_CARES_PROVIDER=package \
         -DgRPC_SSL_PROVIDER=package \
         -DCMAKE_BUILD_TYPE=Release \
-        ../.. && \
+        .. && \
     make -j`nproc` && \
-    make install
+    make install && \
+    cd .. && rm -R --interactive=never _build
+
 
 ##### Prometheus CPP
-RUN git clone https://github.com/jupp0r/prometheus-cpp.git && \
-    cd prometheus-cpp && \
+RUN cd prometheus-cpp && \
+    # Moved git clone https://github.com/jupp0r/prometheus-cpp.git && \
     git checkout d8326b2bba945a435f299e7526c403d7a1f68c1f && \
     git submodule init && git submodule update && \
     mkdir _build && \
     cd _build/ && \
     cmake .. && \
     make -j`nproc` && \
-    make install
+    make install && \
+    cd .. && rm -R --interactive=never _build
 
 ##### Redis CPP
-RUN git clone https://github.com/cpp-redis/cpp_redis.git && \
-    cd cpp_redis && \
+RUN cd cpp_redis && \
+    # Moved git clone https://github.com/cpp-redis/cpp_redis.git && \
     git checkout bbe38a7f83de943ffcc90271092d689ae02b3489 && \
     git submodule init && git submodule update && \
-    mkdir build && cd build && \
+    mkdir _build && cd _build && \
     cmake .. -DCMAKE_BUILD_TYPE=Release && \
     make -j`nproc` && \
-    make install
+    make install && \
+    cd .. && rm -R --interactive=never _build
+
+##### NETTLE / gnutls
+RUN tar -xf nettle-2.5.tar.gz && \
+    # Moved wget https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
+    cd nettle-2.5 && \
+    mkdir _build && \
+    cd _build/ && \
+    ../configure --disable-openssl --enable-shared --libdir=/usr/lib && \
+    make -j`nproc` && \
+    make install && \
+    ldconfig -v && \
+    cd / && \
+    rm -R --interactive=never nettle-2.5.tar.gz nettle-2.5/_build && \
+    # Moved wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
+    tar xf gnutls-3.1.23.tar.xz && \
+    cd gnutls-3.1.23 && \
+    ./configure --with-libnettle-prefix=/usr --prefix=/usr && \
+    make -j`nproc` && \
+    make install && \
+    make clean 2>&1 > /dev/null && \
+    cd / && \
+    rm -R --interactive=never gnutls-3.1.23.tar.xz && \
+    ldconfig -v
 
 ##### liblfds
 # https://www.liblfds.org/mediawiki/index.php?title=r7.1.0:Building_Guide_(liblfds)
-RUN git clone https://github.com/liblfds/liblfds.git && \
-    cd liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
+RUN cd /liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake/ && \
     make -j`nproc` && \
-    make ar_install
+    make ar_install && \
+    make clean
 
 ##### libgtpnl
 # review https://github.com/OPENAIRINTERFACE/openair-cn/blob/master/build/tools/build_helper.gtpnl
-RUN git clone https://git.osmocom.org/libgtpnl && \
-    cd libgtpnl && \
+RUN cd libgtpnl && \
+    # Moved git clone https://git.osmocom.org/libgtpnl && \
     git reset --hard 345d687 && \
     autoreconf -fi && \
     ./configure && \
     make -j`nproc` && \
     make install && \
+    make clean 2>&1 > /dev/null && \
     ldconfig
 
 #####  asn1c
-RUN git clone https://gitlab.eurecom.fr/oai/asn1c.git && \
-    cd asn1c && \
+RUN cd asn1c && \
+    # Moved git clone https://github.com/OPENAIRINTERFACE/asn1c.git && \
     git checkout f12568d617dbf48497588f8e227d70388fa217c9 && \
     autoreconf -iv && \
     ./configure && \
     make -j`nproc` && \
     make install && \
-    ldconfig
-
-
-# Add Converged MME sources to the container
-COPY ./ $MAGMA_ROOT
+    git clean -x -d -ff -q
 
 ##### FreeDiameter
-RUN git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
-    cd freediameter && \
-    patch -p1 < $MAGMA_ROOT/lte/gateway/c/core/oai/patches/0001-opencoord.org.freeDiameter.patch && \
-    patch -p1 < $MAGMA_ROOT/lte/gateway/c/core/oai/patches/0002-opencoord.org.freeDiameter.patch && \
-    mkdir build && \
-    cd build && \
-    cmake ../ && \
+RUN cd freediameter && \
+    # Moved git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
+    git pull origin master && \
+    git log -n1 && \
+    echo "Patching dict_S6as6d" && \
+    patch -p1 < /patches/0001-opencoord.org.freeDiameter.patch && \
+    patch -p1 < /patches/0002-opencoord.org.freeDiameter.patch && \
+    mkdir _build && \
+    cd _build && \
+    cmake -DBUILD_TESTING=false ../ && \
+    grep DISABLE_SCTP CMakeCache.txt && \
     awk '{if (/^DISABLE_SCTP/) gsub(/OFF/, "ON"); print}' CMakeCache.txt > tmp && mv tmp CMakeCache.txt && \
+    grep DISABLE_SCTP CMakeCache.txt && \
     make -j`nproc` && \
-    make install
+    make install && \
+    cd ../ && rm -R --interactive=never _build && \
+    ldconfig --verbose
 
 # Install bazel
 WORKDIR /usr/sbin
@@ -191,19 +229,25 @@ RUN wget --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/dow
     chmod +x bazelisk-linux-amd64 && \
     ln -sf /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
 
+# Starting from here, we are building MAGMA services (sctpd and mme)
+FROM magma-mme-base as magma-mme-builder
+
+# Add Converged MME sources to the container
+COPY ./ $MAGMA_ROOT
+
 # Build MME executables
 RUN cd $MAGMA_ROOT && \
     echo $FEATURES && \
     bazel build //lte/gateway/c/core:mme_oai --define=disable_sentry_native=1 && \
     bazel build //lte/gateway/c/sctpd/src:sctpd --define=disable_sentry_native=1 && \
     mv $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/mme_oai $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
+    echo 'Shared libraries for oai_mme' && \
     ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme && \
+    echo 'Shared libraries for sctpd' && \
     ldd $MAGMA_ROOT/bazel-bin/lte/gateway/c/sctpd/src/sctpd
 
 # Prepare config file
-RUN apt-get install -y python3-pip && \
-    pip3 install jinja2-cli && \
-    cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
+RUN cd $MAGMA_ROOT/lte/gateway/docker/mme/configs/ && \
     echo '{ \n' \
     '"realm": "magma.com",	 \n'\
     '"use_stateless": "", \n'\
@@ -230,6 +274,8 @@ RUN apt-get install -y python3-pip && \
     jinja2 ../../../configs/templates/mme.conf.template mme_vars.json --format=json  > mme.conf
 
 # For developer's to have the same run env as in target image to debug
+FROM magma-mme-builder as magma-dev-mme
+
 # Copy the configuration file templates and mean to modify/generate certificates
 WORKDIR /magma-mme/bin
 RUN cp $MAGMA_ROOT/bazel-bin/lte/gateway/c/core/oai_mme .
@@ -263,7 +309,6 @@ RUN openssl rand -out /root/.rnd 128
 # Target Image
 ################################################################
 FROM ubuntu:bionic as magma-mme
-
 ENV MAGMA_ROOT=/magma
 ENV C_BUILD=/build/c
 
@@ -334,14 +379,16 @@ WORKDIR /magma-mme/etc
 COPY --from=magma-mme-builder \
     $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme.conf \
     $MAGMA_ROOT/lte/gateway/docker/mme/configs/mme_fd.conf \
-    ./
+    /magma-mme/etc/
 
 # Create running dirs
 WORKDIR /var/opt/magma/configs
 # Adding mme configuration for stateful run
 RUN echo "use_stateless: false" > mme.yml && \
     openssl rand -out /root/.rnd 128 && \
+    echo 'Shared libraries for oai_mme' && \
     ldd /magma-mme/bin/oai_mme && \
+    echo 'Shared libraries for sctpd' && \
     ldd /magma-mme/bin/sctpd
 
 WORKDIR /etc/magma
@@ -350,9 +397,9 @@ COPY --from=magma-mme-builder \
     $MAGMA_ROOT/lte/gateway/configs/redis.yml \
     $MAGMA_ROOT/lte/gateway/configs/service_registry.yml \
     $MAGMA_ROOT/lte/gateway/configs/sctpd.yml \
-    ./
+    /etc/magma/
 
-# Scripts to re-generate certificates
+# Adding means to re-generate certificates
 WORKDIR /magma-mme/scripts
 COPY --from=magma-mme-builder $MAGMA_ROOT/lte/gateway/c/core/oai/test/check_mme_s6a_certificate .
 RUN sed -i -e "s@^.*THIS_SCRIPT_PATH@#@" \

--- a/lte/gateway/docker/mme/docker-compose-build-ubuntu18.04.yaml
+++ b/lte/gateway/docker/mme/docker-compose-build-ubuntu18.04.yaml
@@ -1,0 +1,16 @@
+version: "3.8"
+services:
+  magma-mme-base-image:
+    image: magma-dev-mme:ci-base-image
+    build:
+      context: ../../../..
+      target: magma-dev-mme
+      dockerfile: lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+  magma-mme-target-image:
+    image: magma-mme:master
+    depends_on:
+      - magma-mme-base-image
+    build:
+      context: ../../../..
+      target: magma-mme
+      dockerfile: lte/gateway/docker/mme/Dockerfile.ubuntu18.04


### PR DESCRIPTION
## Summary

Following the `bazel` update on the `Ubuntu18` part of the OAI CI pipeline:
The build from scratch was taking `44` minutes and CI-runs could take up to `26` minutes.

I first moved the U18 part to a brand new CI server --> build from scratch is now down to `12` minutes.
 
This PR contains the following improvements:

  * aligning dockerfile cleanups from RHEL8 one
  * the base inage will now regenerated everyday in order to update bazel cache often
  * a docker-compose strategy is used and the buildx BUILDKIT is used
  * in case of build failure, we have to make sure the previous base image is still present
  * found a little typo in asn1c cleanup step

## Test Plan

May need fixing once it lands on `master` but it should be OK.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
