### PR TITLE
chore(ci): Block cache usage for large Bazel targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,11 @@ build --color=yes
 build:production --config=lsan --copt=-O3
 build:production --define=production=1
 
+# experimental_allow_tags_propagation means that tags will be propagated from
+# a target to the actions' execution requirements.
+# See https://github.com/bazelbuild/bazel/issues/8830 for details.
+common --experimental_allow_tags_propagation
+
 # C/C++ CONFIGS
 build --cxxopt=-std=c++14
 # Create debug information only for magma binaries (not for external dependencies).
@@ -41,7 +46,7 @@ common:disk_cache --repository_cache=/var/cache/bazel-cache-repo
 # REMOTE CACHING READ-ONLY CONFIGS
 # The file bazel/bazelrcs/remote_caching_ro.bazelrc is templated in CI
 # The full config is then written to bazel/bazelrcs/cache.bazelrc
-build:remote_caching_ro --remote_upload_local_results=false 
+build:remote_caching_ro --remote_upload_local_results=false
 
 # REMOTE DOWNLOAD OPTIMIZATION
 build:remote_download_optimization --remote_download_minimal

--- a/feg/gateway/services/envoy_controller/BUILD.bazel
+++ b/feg/gateway/services/envoy_controller/BUILD.bazel
@@ -30,6 +30,6 @@ go_library(
 go_binary(
     name = "envoy_controller",
     embed = [":envoy_controller_lib"],
-    tags = TAG_SERVICE,
+    tags = TAG_SERVICE + ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
 )

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -15,7 +15,7 @@ load("//bazel:test_constants.bzl", "TAG_SERVICE")
 cc_binary(
     name = "connectiond",
     srcs = ["main.cpp"],
-    tags = TAG_SERVICE,
+    tags = TAG_SERVICE + ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":event_tracker",

--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1184,7 +1184,7 @@ cc_binary(
     srcs = ["oai/oai_mme/oai_mme.c"],
     copts = ["-DEMBEDDED_SGW=1"],
     linkstatic = True,
-    tags = TAG_SERVICE,
+    tags = TAG_SERVICE + ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
     deps = [":lib_agw_of"],
 )
@@ -1194,7 +1194,7 @@ cc_binary(
     srcs = ["oai/oai_mme/oai_mme.c"],
     copts = ["-DEMBEDDED_SGW=0"],
     linkstatic = True,
-    tags = TAG_SERVICE,
+    tags = TAG_SERVICE + ["no-cache"],
     deps = [":lib_mme_oai"],
 )
 

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -17,7 +17,7 @@ package(default_visibility = ["//lte/gateway/c/li_agent/src:__subpackages__"])
 cc_binary(
     name = "liagentd",
     srcs = ["main.cpp"],
-    tags = TAG_SERVICE,
+    tags = TAG_SERVICE + ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":interface_monitor",

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -428,7 +428,7 @@ cc_binary(
     # From bazel doc: this flag makes it so all user libraries are linked statically (if a static version is available),
     #                 but where system libraries (excluding C/C++ runtime libraries) are linked dynamically
     linkstatic = True,
-    tags = TAG_SERVICE,
+    tags = TAG_SERVICE + ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
     deps = [
         ":operational_states_handler",


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

## Summary

In order to reduce cache usage large targets were given the `no-cache` tag, which prevents them from using the caches.
The detailed analysis about which targets to ignore can be read [here](#14444).
This closes #14444.

A new [GitHub Wiki page](https://github.com/magma/magma/wiki/Bazel-cache-analysis) was created to document how to debug cache related issues.

## Test Plan

CI.

All 5 Bazel test runs can be found [here](https://github.com/magma/magma/actions/runs/3525583867/jobs/5930229990).
The runtimes are ranging from under 2 minutes to over 11 minutes, which is similar to what we currently have in the CI.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
