### PR TITLE
chore(ci): Create separate buildifier and python import check jobs for Bazel

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -102,7 +102,7 @@ jobs:
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
             echo "Pulled the bazel base image!"
-      - name: Run bazel build, test, starlark format check & python import check
+      - name: Run bazel build and test
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
           image: ${{ env.BAZEL_BASE_IMAGE }}
@@ -137,22 +137,6 @@ jobs:
               cp "${TEST_REPORT_PATH}" "bazel_unit_test_results/test_result_${UNIQUE_FILENAME_INDEX}.xml"
               UNIQUE_FILENAME_INDEX=$((UNIQUE_FILENAME_INDEX + 1))
             done
-
-            if [ -z "${{ matrix.bazel-config }}" ];
-            then
-              printf '\r%s\r' '###############################' 1>&2
-              printf '\r%s\r' 'Executing starlark format check.' 1>&2
-              printf '\r%s\r' '###############################' 1>&2
-              bazel run //:check_starlark_format;
-            fi
-
-            if [ -z "${{ matrix.bazel-config }}" ];
-            then
-              printf '\r%s\r' '###############################' 1>&2
-              printf '\r%s\r' 'Executing python import bazelification check.' 1>&2
-              printf '\r%s\r' '###############################' 1>&2
-              bazel/scripts/test_python_service_imports.sh;
-            fi
 
             if [[ "${TEST_FAILED}" == "true" ]];
             then
@@ -242,6 +226,111 @@ jobs:
             echo "Bazel build and test job failed"
             exit 1
           fi
+
+  buildifier:
+    needs: path_filter
+    # Only run workflow if this is a push to the magma repository,
+    # if the workflow has been triggered manually or if it is a pull_request.
+    if: |
+      (github.event_name == 'push' && github.repository_owner == 'magma') ||
+      needs.path_filter.outputs.files_changed == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    name: Bazel Starlark Format Job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        # This is necessary for overlays into the Docker container below.
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - name: Setup Bazel Base Image
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the bazel base image!"
+      - name: Run starlark format check
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          shell: bash
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma
+            bazel run //:check_starlark_format
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: "Bazel starlark format check"
+          SLACK_USERNAME: ${{ github.workflow }}
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
+
+  python_import_check:
+    needs: path_filter
+    # Only run workflow if this is a push to the magma repository,
+    # if the workflow has been triggered manually or if it is a pull_request.
+    if: |
+      (github.event_name == 'push' && github.repository_owner == 'magma') ||
+      needs.path_filter.outputs.files_changed == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    name: Bazel Python Import Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        # This is necessary for overlays into the Docker container below.
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - name: Maximize build space
+        uses: ./.github/workflows/composite/maximize-build-space
+      - name: Setup Bazel Base Image
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the bazel base image!"
+      - name: Run Python Import Check
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          shell: bash
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma
+            set -euo pipefail
+
+            printf '\r%s\r' '###############################' 1>&2
+            printf '\r%s\r' 'Configuring bazel remote cache.' 1>&2
+            printf '\r%s\r\r' '###############################' 1>&2
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+
+            printf '\r%s\r' '###############################' 1>&2
+            printf '\r%s\r' 'Executing python import bazelification check.' 1>&2
+            printf '\r%s\r' '###############################' 1>&2
+            bazel/scripts/test_python_service_imports.sh;
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: "Bazel Python Import Check"
+          SLACK_USERNAME: ${{ github.workflow }}
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
 
   bazel_package:
     needs: path_filter


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The buildifier and bazel python import checks are moved into separate jobs
- Resolves #14473

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
