### PR TITLE
feat(ci): lte-integ-test-magma-deb no longer publishes results to fir…

### DIFF
--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -82,23 +82,6 @@ jobs:
         working-directory: 'lte/gateway/'
         run: |
           fab get_test_logs:gateway_host_name=magma_deb,dst_path=./logs.tar.gz
-      - name: Upload test logs
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: always()
-        with:
-          name: test-logs
-          path: lte/gateway/logs.tar.gz
-      - name: Publish results to Firebase
-        if: always() && github.event_name == 'repository_dispatch'
-        env:
-          FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
-          REPORT_FILENAME: "lte_integ_test_magma_deb_${{ github.sha }}.html"
-        run: |
-          npm install -g xunit-viewer
-          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
-          [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
-          [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
-          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} make_debian_lte_integ_test --url $URL
       - name: Notify failure to slack
         if: failure() && github.repository_owner == 'magma'
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0

--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -68,13 +68,6 @@ def lte_integ_test(args):
     prepare_and_publish('lte_integ_test', args, 'test_status.txt')
 
 
-def make_debian_lte_integ_test(args):
-    """Prepare and publish LTE Integ Test report"""
-    prepare_and_publish(
-        'make_debian_lte_integ_test', args, 'test_status.txt',
-    )
-
-
 def debian_lte_integ_test(args):
     """Prepare and publish LTE Integ Test report"""
     prepare_and_publish('debian_lte_integ_test', args, 'test_status.txt')
@@ -139,7 +132,6 @@ tests = {
     'feg': feg_integ_test,
     'cwf': cwf_integ_test,
     'sudo_python_tests': sudo_python_tests,
-    'make_debian_lte_integ_test': make_debian_lte_integ_test,
     'debian_lte_integ_test': debian_lte_integ_test,
 }
 


### PR DESCRIPTION
…ebase

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
The switch from `make` to `bazel` as build tool needs to be reflected in the CI dashboard as well. Therefore, the dashboard should display the results of the LTE integ tests on the production-like Debian machine build with `bazel` instead of `make`. This requires 

1. The `bazel`-based workflow to publish the results to firebase.
2. Firebase to display these results and not the make-base ones.
3. The `make`-based workflow to not publish this anymore.

Since we operate across repositories here, three PRs seem the least invasive way to do this.

This PR disables the publishing of the LTE integration tests on the debian machine build with make to the firebase database.

Closes #14180. Merge only after #14488 and magma/ci-dashboard#19.

## Test Plan

 - Check if CI run no longer contains publishing step.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
