### PR TITLE
chore(ci): bump `manusa/actions-setup-minikube` to use Node 16 as def…

### DIFF
--- a/.github/workflows/composite/dp-integ-tests/action.yml
+++ b/.github/workflows/composite/dp-integ-tests/action.yml
@@ -32,7 +32,7 @@ runs:
         echo "MINIKUBE_DP_MAX_MEMORY=$(grep MemTotal /proc/meminfo | awk '{printf "%dm",$2/1024 - 1}')" >> $GITHUB_ENV
 
     - name: Install Minikube
-      uses: manusa/actions-setup-minikube@cdef63c020a1c7b3d4787f30b3787ca1095ed9a7 # pin@v2.4.1
+      uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9 # pin@v2.7.1
       with:
         minikube version: 'v1.21.0'
         kubernetes version: 'v1.20.7'

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -325,7 +325,7 @@ jobs:
           echo "MINIKUBE_DP_MAX_MEMORY=$(grep MemTotal /proc/meminfo | awk '{printf "%dm",$2/1024 - 1}')" >> $GITHUB_ENV
 
       - name: Install Minikube
-        uses: manusa/actions-setup-minikube@cdef63c020a1c7b3d4787f30b3787ca1095ed9a7 # pin@v2.4.1
+        uses: manusa/actions-setup-minikube@4582844dcacbf482729f8d7ef696f515d2141bb9 # pin@v2.7.1
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.20.7'


### PR DESCRIPTION
…ault

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR bumps `manusa/actions-setup-minikube` from version 2.4.1 to version 2.7.1 which uses [Node 16 as a default](https://github.com/manusa/actions-setup-minikube/releases). 
Part of #12209.

## Test Plan

- Check in CI.

## Additional Information

- The failing `Helm chart smoke test` is red on master as well, see #14521.

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
