### PR TITLE
chore: Change bazel target structure in bazel workflow

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -81,11 +81,11 @@ jobs:
       matrix:
         include:
           - bazel-config: ""
-            bazel-target: "//..."
+            bazel-target: ".*_test"
           - bazel-config: "--config=asan"
-            bazel-target: "`bazel query 'kind(cc.*, //...)'`"
+            bazel-target: "cc_test"
           - bazel-config: "--config=production"
-            bazel-target: "`bazel query 'kind(cc.*, //...)'`"
+            bazel-target: "cc_test"
     name: Bazel Build & Test Job
     runs-on: ubuntu-latest
     steps:
@@ -123,7 +123,7 @@ jobs:
             printf '\r%s\r' '###############################' 1>&2
             TEST_FAILED="false"
             bazel test \
-              ${{ matrix.bazel-target }} \
+              `bazel query 'kind(${{ matrix.bazel-target }}, //...) except attr("tags", "manual", //...)'` \
               ${{ matrix.bazel-config }} \
               --test_output=errors \
               --profile=Bazel_test_all_profile || TEST_FAILED="true"

--- a/bazel/test/BUILD.bazel
+++ b/bazel/test/BUILD.bazel
@@ -9,8 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel/test:runfiles_test.bzl", "runfiles_test_suite")
+load("//bazel/test:runfiles_test.bzl", "runfiles_test")
 
-runfiles_test_suite(
-    name = "runfiles_test_suite_target",
+runfiles_test(
+    name = "runfiles_test_target",
 )

--- a/bazel/test/runfiles_test.bzl
+++ b/bazel/test/runfiles_test.bzl
@@ -20,7 +20,7 @@ load("//bazel:runfiles.bzl", "expand_runfiles")
 
 # test suite
 
-def runfiles_test_suite(name):
+def runfiles_test(name):
     _setup_empty_targets_returns_empty_providers_test()
     _setup_targets_are_correctly_expanded_test()
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- As preparation for https://github.com/magma/magma/issues/14236 change the bazel targets to always run a query and use the same format.
- Rename the `runfiles_test_suite` to comply with the rule names of the standard bazel rules

## Test Plan

- Run the query:
  - `bazel query 'kind(.*_test, //...) except attr("tags", "manual", //...)'`
  - There are 195 tests that are reported.
  - This agrees with the current list of tests that is run for no config. 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
