### PR TITLE
fix: update property call for github_action/github-script

### DIFF
--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -49,7 +49,7 @@ jobs:
             let newCompLbls = new Set(); // Set of new label strings
 
             // Fetch files modified in the PR
-            const pulledFiles = await github.pulls.listFiles({
+            const pulledFiles = await github.rest.pulls.listFiles({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

This PR fixes an error ([ci job](https://github.com/magma/magma/actions/runs/3522729736/jobs/5906044740) fails) occurred using github_action/github-script. The updated version, merged with #14487, includes breaking changes. Methods are now available via github.rest.*.

## Test Plan

## Additional Information

- [ ] This change is backwards-breaking

