### PR TITLE
chore: Add support and wrapper script for tinder/bazel-diff

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
+load("@rules_java//java:defs.bzl", "java_binary")
 
 buildifier(
     name = "buildifier",
@@ -69,3 +70,9 @@ filegroup(
 # TODO: Remove when we move proto generation to bazel - this prevents gazelle from causing import issues in the meantime.
 # gazelle:exclude **/*.proto/
 gazelle(name = "gazelle")
+
+java_binary(
+    name = "bazel-diff",
+    main_class = "com.bazel_diff.Main",
+    runtime_deps = ["@bazel_diff//jar"],
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load("//bazel:third_party_repositories.bzl", "grpc")
 
 http_archive(
@@ -170,3 +170,9 @@ http_archive(
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
+
+http_jar(
+    name = "bazel_diff",
+    sha256 = "45761593a478d1e432e8cfa9629b9dbf08cd610bafd29b04305de77644470722",
+    urls = ["https://github.com/Tinder/bazel-diff/releases/download/4.1.0/bazel-diff_deploy.jar"],
+)

--- a/bazel/scripts/bazel_diff.sh
+++ b/bazel/scripts/bazel_diff.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+
+###############################################################################
+# FUNCTION DECLARATIONS
+###############################################################################
+
+generate_hashes() {
+    local GIT_COMMIT
+    GIT_COMMIT=$1
+    local HASHES_JSON
+    HASHES_JSON=$2
+
+    echo -e "${LOG_HEADER} Creating temporary directory to check out the commit $GIT_COMMIT ..." 1>&2
+    local WORKDIR
+    WORKDIR=$(mktemp --directory)
+    git clone "$MAGMA_ROOT" "$WORKDIR" --quiet
+
+    echo -e "${LOG_HEADER} Checking out the commit $GIT_COMMIT." 1>&2
+    git -C "$WORKDIR" checkout "$GIT_COMMIT" --quiet
+
+    echo -e "${LOG_HEADER} Generating the hashes for the commit $GIT_COMMIT" 1>&2
+    "$BAZEL_DIFF" generate-hashes --workspacePath "$WORKDIR" --bazelPath "$BAZEL_PATH" "$HASHES_JSON"
+
+    rm -rf "$WORKDIR"
+}
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+# ANSI escape sequences for log formatting.
+YELLOW='\033[0;33m'
+NO_FORMAT='\033[0m'
+LOG_HEADER="${YELLOW}BAZEL-DIFF INFO:${NO_FORMAT}"
+
+# BAZEL_PATH is needed for the generate-hashes --bazelPath argument.
+BAZEL_PATH=$(command -v bazel)
+BAZEL_DIFF="/tmp/bazel_diff"
+HASHES_PRE_JSON="/tmp/hashes_pre.json"
+HASHES_POST_JSON="/tmp/hashes_post.json"
+IMPACTED_TARGETS_FILE="/tmp/impacted_targets_bazel_diff.txt"
+
+# Git SHA of the previous commit.
+GIT_SHA_PRE=$1
+# Git SHA of the commit with the changes.
+GIT_SHA_POST=$2
+
+echo -e "${LOG_HEADER} Generating the bazel-diff script at $BAZEL_DIFF." 1>&2
+bazel run :bazel-diff --script_path="$BAZEL_DIFF"
+
+# Generate the JSON files containing the hashes.
+generate_hashes "$GIT_SHA_PRE" "$HASHES_PRE_JSON"
+generate_hashes "$GIT_SHA_POST" "$HASHES_POST_JSON"
+
+echo -e "${LOG_HEADER} Determining the impacted targets" 1>&2
+"$BAZEL_DIFF" get-impacted-targets --startingHashes "$HASHES_PRE_JSON" --finalHashes "$HASHES_POST_JSON" --output "$IMPACTED_TARGETS_FILE"
+
+# Check if the file containing the affected targets is empty.
+if [[ -s "$IMPACTED_TARGETS_FILE" ]];
+then
+    echo -e "${LOG_HEADER} The list of targets impacted by the changes between commits $GIT_SHA_PRE and $GIT_SHA_POST is:" 1>&2
+    cat "$IMPACTED_TARGETS_FILE"
+else
+    echo -e "${LOG_HEADER} No targets are impacted by the changes between commits $GIT_SHA_PRE and $GIT_SHA_POST." 1>&2
+fi

--- a/bazel/scripts/filter_test_targets.sh
+++ b/bazel/scripts/filter_test_targets.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+
+###############################################################################
+# FUNCTION DECLARATIONS
+###############################################################################
+
+create_bazel_test_query() {
+    # Write beginning of the bazel test query.
+    printf '%s' "kind(\"$BAZEL_FILTER_RULE\"," > "$BAZEL_QUERY_FILE"
+
+    # Append union of targets to the bazel test query.
+    while IFS="" read -r impacted_target
+    do
+        printf '%s ' "$impacted_target union" >> "$BAZEL_QUERY_FILE"
+    done < "$IMPACTED_TARGETS_FILE"
+
+    # Remove the last 'union ' in the list of targets and
+    # append the end of the bazel test query, which filters out manual test targets.
+    sed -i 's/union $/except attr(tags, manual, kind(.*_test, \/\/...)))/' "$BAZEL_QUERY_FILE"
+}
+
+run_bazel_query() {
+    # A query file is needed to avoid the bazel command line max args limit.
+    bazel query --query_file="$BAZEL_QUERY_FILE" > "$IMPACTED_TEST_TARGETS_FILE"
+}
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+# ANSI escape sequences for log formatting.
+YELLOW='\033[0;33m'
+NO_FORMAT='\033[0m'
+LOG_HEADER="${YELLOW}INFO:${NO_FORMAT}"
+
+IMPACTED_TARGETS_FILE="/tmp/impacted_targets_pre_filter.txt"
+rm -f "$IMPACTED_TARGETS_FILE"
+BAZEL_QUERY_FILE="/tmp/bazel_query_impacted_targets.txt"
+IMPACTED_TEST_TARGETS_FILE="/tmp/impacted_test_targets.txt"
+
+# Read stdin into IMPACTED_TARGETS_FILE.
+while IFS= read -r impacted_target
+do
+    echo "$impacted_target" >> "$IMPACTED_TARGETS_FILE"
+done
+
+# Optional script argument, e.g. 'cc_test' or 'py_test', default is all test rules.
+BAZEL_FILTER_RULE=${1:-".*_test"}
+
+create_bazel_test_query
+run_bazel_query
+
+# Check if the file containing the affected test targets is empty.
+if [[ -s "$IMPACTED_TEST_TARGETS_FILE" ]];
+then
+    echo -e "${LOG_HEADER} The impacted $BAZEL_FILTER_RULE targets are:" 1>&2
+    cat $IMPACTED_TEST_TARGETS_FILE
+else
+    echo -e "${LOG_HEADER} No $BAZEL_FILTER_RULE targets are impacted by the changes." 1>&2
+fi


### PR DESCRIPTION
## Summary

- Part of https://github.com/magma/magma/issues/14236
- Add [Tinder/bazel-diff](https://github.com/Tinder/bazel-diff) binary to the bazel setup
- Add two scripts:
  - `bazel_diff.sh`: A convenience wrapper for the Tinder/bazel-diff binary.
  -  `filter_test_targets.sh`: A wrapper for bazel query to filter a list of targets for non-manual test targets of a given rule type (optional). 
- The next step is to use these scripts in the `bazel.yml` to determine the minimum set of test targets to execute on PRs. 
 

## Test Plan
- `shellcheck ./bazel/scripts/bazel_diff.sh`
- `shellcheck ./bazel/scripts/filter_test_targets.sh`
- Manual testing:
  - Create file `list_of_targets.txt` with content [1]
  - Run e.g.
    - `./bazel/scripts/filter_test_targets.sh cc_test < list_of_targets.txt`
    - `./bazel/scripts/filter_test_targets.sh py_test < list_of_targets.txt`
    - `./bazel/scripts/filter_test_targets.sh go_test < list_of_targets.txt`
    - `./bazel/scripts/filter_test_targets.sh .*_test < list_of_targets.txt` 
    - `./bazel/scripts/filter_test_targets.sh  < list_of_targets.txt` 

[1]:
```
//lte/gateway/python/integ_tests/s1aptests:test_attach_detach_static_ip
//lte/gateway/python/integ_tests/s1aptests:test_attach_detach_after_ue_context_release
//lte/gateway/c/core/oai/test/amf:amf_algorithm_selection_test
//lte/gateway/c/core/oai/lib/bstr:bstrlib
//lte/gateway/python/magma/mobilityd/tests:test_dhcp_client
//feg/gateway/services/envoy_controller/servicers:envoy_controller_test
//bazel/python_utils:coverage_decorator
//lte/gateway/python/integ_tests/s1aptests:test_attach_detach_flaky_retry_success
//lte/gateway/python/integ_tests/s1aptests:test_attach_dl_udp_data
```
- Manual testing:
  - Run `./bazel/scripts/bazel_diff.sh COMMIT_BEFORE_CHANGES COMMIT_AFTER_CHANGES`
    - Where the commits are some changes that may or may not affect bazel targets.
    - The commit should be done after the commits that are added on this branch.  

## Additional Information

To get an idea of what the output might look like in CI see e.g. https://github.com/LKreutzer/magma/actions/runs/3524229419/jobs/5909363719

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
