### PR TITLE
chore: the lf artifactory is setup during vm full_provision-ing

### DIFF
--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -9,25 +9,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# TODO move to preburn
 - name: Remove all old registries
   become: yes
   ignore_errors: yes
   ansible.builtin.file:
     path: /etc/apt/sources.list.d/*.list
     state: absent
-  when: preburn
+  when: full_provision
 
-- name: Adding the key to agent
+# TODO move to preburn
+- name: Adding the key for the registry
   apt_key:
     url: https://linuxfoundation.jfrog.io/artifactory/api/security/keypair/magmaci/public
     state: present
-  when: preburn
+  when: full_provision
 
+# TODO move to preburn
 - name: Configuring the registry in sources.list.d
   shell: "echo 'deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main' > /etc/apt/sources.list.d/magma.list"
-  when: preburn
+  when: full_provision
 
 - name: Update apt
   apt:
     update_cache: yes
-  when: preburn
+  when: full_provision


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In this change the lf artifactory is configured for magma VMs (def, test, trfserver). See #14495 for the general migration issue.

The magmacore artifactory is currently pre-burned, i.e., as an intermediate step (before a new preburn image is created), we remove the magmacore artifactory and set-up the lf artifactory during full-provision.

Also: removed the preburn guard from `apt update` as an update here always makes sense.

## Test Plan

- [x] Create a magma VM and see that the lf artifactory is configured.
- [x] Build magma and run an integration test against the created VM

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
