### PR TITLE
docs: Fix outdated footer #13746

### DIFF
--- a/docs/docusaurus/core/Footer.js
+++ b/docs/docusaurus/core/Footer.js
@@ -30,45 +30,6 @@ class Footer extends React.Component {
   render() {
     return (
       <footer className="nav-footer" id="footer">
-        <section className="sitemap">
-          <a href={this.props.config.baseUrl} className="nav-home">
-            {this.props.config.footerIcon && (
-              <img
-                src={this.props.config.baseUrl + this.props.config.footerIcon}
-                alt={this.props.config.title}
-                width="66"
-              />
-            )}
-          </a>
-          <div>
-            <h5>Docs</h5>
-            <a href="https://github.com/magma/magma/blob/master/docs/pdfs/Magma_Product_Overview.pdf">
-              Magma Product Overview
-            </a>
-            <a href="https://github.com/magma/magma/blob/master/docs/pdfs/Magma_Specs_FFWA_V1.1.pdf">
-              Magma Spec
-            </a>
-          </div>
-          <div>
-            <h5>Community</h5>
-            <a href="https://slack.magmacore.org">
-              Slack
-            </a>
-
-            <a
-              href="https://fb.me/magmadevsummit"
-              target="_blank"
-              rel="noreferrer noopener">
-              Magma Dev Summit
-            </a>
-          </div>
-          <div>
-            <h5>More</h5>
-            <a href="https://magmacore.org/blog/">Blog</a>
-            <a href="https://github.com/magma/magma">GitHub</a>
-          </div>
-        </section>
-
         <section className="copyright">{this.props.config.copyright}</section>
       </footer>
     );


### PR DESCRIPTION
This PR removes deprecated content from the documentation footer. It removes everything but the license information.

Signed-off-by: Alaitz Mendiola <amendiol@redhat.com>

## Summary

Removes everything but the license information from the file `docs/docusaurus/core/Footer.js`

## Test Plan

This is the output of `$ sudo make precommit`

```
make -C readmes precommit
make[1]: se entra en el directorio '/home/redhat/Development/magma/docs/readmes'
docker build -t magma_readmes .
Sending build context to Docker daemon  50.14MB
Step 1/4 : FROM node:14
 ---> 7a8bb5c30f83
Step 2/4 : RUN mkdir -p /readmes
 ---> Using cache
 ---> 4287fe577f94
Step 3/4 : WORKDIR /readmes
 ---> Using cache
 ---> 8e3e0db2ba46
Step 4/4 : RUN npm install --global markdownlint-cli
 ---> Using cache
 ---> 0377257e9d83
Successfully built 0377257e9d83
Successfully tagged magma_readmes:latest
docker compose run readmes markdownlint --ignore proposals/p010_vendor_neutral_dp.md --ignore proposals/p010_subscriber_scaling.md --ignore proposals/p015_tech_debt_week.md --ignore proposals/p018_control_network_metrics.md . && echo PASSED
[+] Running 1/1
 ⠿ Network readmes_default  Created                                                                                                                                                                     0.2s
PASSED
make[1]: se sale del directorio '/home/redhat/Development/magma/docs/readmes'
```
This is how the documentation page looks like:

![image](https://user-images.githubusercontent.com/5888238/203374387-4f05601f-6d60-427a-a61d-abac6a1f37d4.png)