### PR TITLE
fix(ci): Use internal networks for VMs

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -43,8 +43,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # 2. Any changes to the magma networking should be propagated to magma_deb
     magma.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
     # iperf3 trfserver routable IP.
-    magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
-    magma.vm.network "private_network", ip: "3001::10", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    # For IPv6 network,
+    # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
+    # - `netmask` specified to enforce correct mask when using internal network
+    magma.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: "ipv4_sgi"
+    magma.vm.network "private_network", ip: "3001::10", nic_type: "82540EM", virtualbox__intnet: "ipv6_network", type: "static6", netmask: "64"
 
 
     magma.vm.provider "virtualbox" do |vb|
@@ -74,8 +78,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # using a specific IP.
     magma_trfserver.vm.network "private_network", ip: "192.168.60.144", nic_type: "82540EM"
     # iperf3 server IP.
-    magma_trfserver.vm.network "private_network", ip: "192.168.129.42", nic_type: "82540EM"
-    magma_trfserver.vm.network "private_network", ip: "3001::2", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    # For IPv6 network,
+    # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
+    # - `netmask` specified to enforce correct mask when using internal network
+    magma_trfserver.vm.network "private_network", ip: "192.168.129.42", nic_type: "82540EM", virtualbox__intnet: "ipv4_sgi"
+    magma_trfserver.vm.network "private_network", ip: "3001::2", nic_type: "82540EM", virtualbox__intnet: "ipv6_network", type: "static6", netmask: "64"
 
     magma_trfserver.vm.provider "virtualbox" do |vb|
       vb.name = "magma-trfserver"
@@ -124,8 +132,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # using a specific IP.
     magma_test.vm.network "private_network", ip: "192.168.60.141", nic_type: "82540EM"
     # UE trfgen network
-    magma_test.vm.network "private_network", ip: "192.168.128.11", nic_type: "82540EM"
-    magma_test.vm.network "private_network", ip: "3001::3", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    # For IPv6 network,
+    # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
+    # - `netmask` specified to enforce correct mask when using internal network
+    magma_test.vm.network "private_network", ip: "192.168.128.11", nic_type: "82540EM", virtualbox__intnet: "ipv4_ue"
+    magma_test.vm.network "private_network", ip: "3001::3", nic_type: "82540EM", virtualbox__intnet: "ipv6_network", type: "static6", netmask: "64"
     config.ssh.forward_agent = true
 
     magma_test.vm.provider "virtualbox" do |vb|
@@ -214,8 +226,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # 2. Any changes to the magma networking should be propagated to magma_deb
     magma_deb.vm.network "private_network", ip: "192.168.60.142", nic_type: "82540EM"
     # iperf3 trfserver routable IP.
-    magma_deb.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM"
-    magma_deb.vm.network "private_network", ip: "3001::10", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    # For IPv6 network,
+    # - `type` specified due to https://github.com/hashicorp/vagrant/issues/12839
+    # - `netmask` specified to enforce correct mask when using internal network
+    magma_deb.vm.network "private_network", ip: "192.168.129.1", nic_type: "82540EM", virtualbox__intnet: "ipv4_sgi"
+    magma_deb.vm.network "private_network", ip: "3001::10", nic_type: "82540EM", virtualbox__intnet: "ipv6_network", type: "static6", netmask: "64"
 
     magma_deb.vm.provider "virtualbox" do |vb|
       vb.name = "magma_deb"

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1024,7 +1024,7 @@ class MagmadUtil(object):
         """Restart all magma services on magma_dev VM"""
         if self._init_system == InitMode.SYSTEMD:
             self.exec_command(
-                "sudo systemctl stop 'magma@*' 'sctpd' ;"
+                "sudo systemctl stop 'magma@*' ;"
                 "sudo systemctl start magma@magmad",
             )
             self._wait_for_pipelined_to_initialize()
@@ -1664,6 +1664,7 @@ class MagmadUtil(object):
         with open(mconfig_conf, "w") as json_file:
             json.dump(data, json_file, sort_keys=True, indent=2)
 
+        self.restart_services(['sctpd'], wait_time=30)
         self.restart_all_services()
 
     def _validate_non_nat_datapath(self, ip_version: int = 4):


### PR DESCRIPTION
## Summary

Closes https://github.com/magma/magma/issues/14312

I have opened this as a replacement for https://github.com/magma/magma/pull/14363 since some further work was needed on top of that to get the integration tests green.

This PR converts certain networks used on the VMs to internal networks to prevent undesired connections to the host being formed instead of between the VMs. It was found to be necessary to revert the sctpd restart behaviour modified in https://github.com/magma/magma/pull/14000 - without this, `test_attach_detach_rar_tcp_data` fails reproducibly both locally and in the CI.

## Test Plan
- [x] Verified locally that without this change, the traffic server connects to the vagrant host, while with this change, it connects to the magma VM. In particular, I ran `ip neigh` on the traffic server and saw that the MAC address of eth2 was that of vagrant host and then magma VM
- [x] Checked the modified interfaces before and after the changes to check that the netmasks remain the same
- [x] Integration tests run locally - green
- [x] Integration tests run in CI - one known flaky test failed on my fork (see [here](https://github.com/voisey/magma/actions/runs/3524307886))