### PR TITLE
fix(agw): Fix type hints of restart_services function

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1087,7 +1087,7 @@ class MagmadUtil(object):
             time.sleep(self.WAIT_INTERVAL_SECONDS)
             wait_time_seconds += self.WAIT_INTERVAL_SECONDS
 
-    def restart_services(self, services: str, wait_time: int = 0):
+    def restart_services(self, services: List[str], wait_time: int = 0):
         """
         Restart a list of magmad services.
         Hint:


### PR DESCRIPTION
## Summary

mypy complained [here](https://github.com/magma/magma/pull/14516#discussion_r1030126538) that the first parameters of `restart_services` should be a string rather than a list of strings, but this isn't right. As stated [here](https://github.com/magma/magma/blob/master/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py#L1099), the function expects a list of strings. This PR fixes the type hint. 

## Test Plan

- [x] I ran mypy on the branch in this [PR](https://github.com/magma/magma/pull/14516) and verified that the error goes away with this change.
