### PR TITLE
chore(ci): Use bazel-diff in bazel.yml

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -81,17 +81,21 @@ jobs:
       matrix:
         include:
           - bazel-config: ""
-            bazel-target: ".*_test"
+            bazel-target-rule: ".*_test"
           - bazel-config: "--config=asan"
-            bazel-target: "cc_test"
+            bazel-target-rule: "cc_test"
           - bazel-config: "--config=production"
-            bazel-target: "cc_test"
+            bazel-target-rule: "cc_test"
     name: Bazel Build & Test Job
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
+        # The value of fetch-depth needs to exceed the maximum number of commits
+        # on all PRs. This is needed for bazel-diff to check out the merge-base.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        with:
+          fetch-depth: 100
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Setup Bazel Base Image
@@ -113,20 +117,54 @@ jobs:
             cd /workspaces/magma
             set -euo pipefail
 
+            # Required for bazel-diff to perform git checkout.
+            git config --global --add safe.directory /workspaces/magma
+
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Configuring bazel remote cache.' 1>&2
             printf '\r%s\r\r' '###############################' 1>&2
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
 
             printf '\r%s\r' '###############################' 1>&2
-            printf '\r%s\r' 'Executing bazel test ${{ matrix.bazel-config }}' 1>&2
+            printf '\r%s\r' 'Determining bazel test targets.' 1>&2
+            printf '\r%s\r' '###############################' 1>&2
+            # Check that the workflow is run on a PR and that the .bazelrc and WORKSPACE files have not been affected.
+            if [[ ("${{ github.event_name }}" == "pull_request") && \
+                  ! $(git diff-tree --no-commit-id --name-only -r "${{ github.event.pull_request.base.sha }}" "${{ github.SHA }}" | \
+                    grep -E '(.bazelrc|WORKSPACE.bazel)') \
+                ]];
+            then
+              printf '\r%s\r' 'Determining targets via bazel-diff ...' 1>&2
+              IMPACTED_TARGETS_FILE="/tmp/impacted_targets.txt"
+              bazel/scripts/bazel_diff.sh "${{ github.event.pull_request.base.sha }}"  "${{ github.SHA }}" | tee "$IMPACTED_TARGETS_FILE"
+
+              printf '\r%s\r' 'Determining impacted test targets ...' 1>&2
+              # Choose all impacted test targets of type 'matrix.bazel-target-rule' that are not tagged as manual.
+              TEST_TARGETS=$(bazel/scripts/filter_test_targets.sh "${{ matrix.bazel-target-rule }}" < "$IMPACTED_TARGETS_FILE")
+              printf '\r%s\r' "$TEST_TARGETS" 1>&2
+            else
+              printf '\r%s\r' 'Running all unit test targets of type ${{ matrix.bazel-target-rule }}.' 1>&2
+              TEST_TARGETS="$(bazel query 'kind(${{ matrix.bazel-target-rule }}, //...) except attr(tags, manual, //...)')"
+              printf '\r%s\r' "$TEST_TARGETS" 1>&2
+            fi
+
+            printf '\r%s\r' '###############################' 1>&2
+            printf '\r%s\r' 'Executing bazel test ${{ matrix.bazel-config }}.' 1>&2
             printf '\r%s\r' '###############################' 1>&2
             TEST_FAILED="false"
-            bazel test \
-              `bazel query 'kind(${{ matrix.bazel-target }}, //...) except attr("tags", "manual", //...)'` \
-              ${{ matrix.bazel-config }} \
-              --test_output=errors \
-              --profile=Bazel_test_all_profile || TEST_FAILED="true"
+
+            if [[ -n "$TEST_TARGETS" ]];
+            then
+              bazel test \
+                $TEST_TARGETS \
+                ${{ matrix.bazel-config }} \
+                --test_output=errors \
+                --profile=Bazel_test_all_profile || TEST_FAILED="true"
+            else
+              printf '\r%s\r' 'No test targets of type ${{ matrix.bazel-target-rule }} were impacted by the changes.' 1>&2
+              printf '\r%s\r' 'No tests will be executed.' 1>&2
+            fi
+
             # Create Bazel unit-test results
             # Can't be a separate step, because the container's '/tmp' folder is not preserved between steps
             mkdir bazel_unit_test_results/


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Run only the bazel unit test targets that are really needed on PRs.
  - To achieve this use wrapper script for [Tinder/bazel-diff](https://github.com/Tinder/bazel-diff) and filter results for tests that are not tagged as manual (i.e. integ tests etc.).
  - On push or workflow dispatch run all unit tests.
  - Applies to all three configs (asan, production and native).
  - If the `WORKFLOW` or `.bazelrc` files are modified run all tests. 
- Resolves https://github.com/magma/magma/issues/14236
- Follow up to:
  - https://github.com/magma/magma/pull/14509
  - https://github.com/magma/magma/pull/14504 

## Test Plan

- [x] [CI on this PR](https://github.com/magma/magma/actions/runs/3533381572/jobs/5928931350) is a run without relevant changes.
![Screenshot from 2022-11-24 11-22-54](https://user-images.githubusercontent.com/34488763/203760044-d57837a4-32c3-4620-a8a9-ff7a9e6d5c3b.png)

- [x] [Manual workflow run](https://github.com/LKreutzer/magma/actions/runs/3539650375) - tinder-diff is skipped and all tests are run
![Screenshot from 2022-11-24 11-24-31](https://user-images.githubusercontent.com/34488763/203760408-94452917-c94d-42eb-81bb-bf9dacf50626.png)


- [x] https://github.com/LKreutzer/magma/pull/6
![Screenshot from 2022-11-24 11-21-50](https://user-images.githubusercontent.com/34488763/203759844-c6dfbc33-df6d-4b14-be1e-25f0fe4e059e.png)

- [x] https://github.com/LKreutzer/magma/pull/7
![Screenshot from 2022-11-24 11-23-48](https://user-images.githubusercontent.com/34488763/203760216-52a6e1c9-2a5f-4daa-86ba-2e09a193430e.png)

- [x] https://github.com/LKreutzer/magma/pull/8
![Screenshot from 2022-11-24 11-33-47](https://user-images.githubusercontent.com/34488763/203762451-4f3c84ef-557d-44d3-820c-9d6f928deb71.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
