### PR TITLE
fix(ci): Double naming  for id in build job

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -749,7 +749,7 @@ jobs:
           ARTIFACTS="{\"packages\":[\"$DOCKER_REGISTRY/gateway_go:${TAG}\", \"$DOCKER_REGISTRY/gateway_python:${TAG}\"],\"valid\":true}"
           echo "artifacts=$(echo $ARTIFACTS)" >> $GITHUB_OUTPUT
       - name: Tag and push to Jfrog Registry
-        id: publish_artifacts_lf
+        id: publish_artifacts
         if: github.event_name == 'push'
         env:
           DOCKER_REGISTRY: "feg-test.artifactory.magmacore.org"


### PR DESCRIPTION
Signed-off-by: tmdzk <timodzik@gmail.com>
UNBREAK CI 
fix(ci): Double naming  for id in build job

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
