### PR TITLE
fix(ci): Avoid error creating folder twice

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -64,7 +64,7 @@ jobs:
           if [ "${GITHUB_REF##*/}" = "master" ] ;then
             orc8r/tools/helm/package.sh --deployment-type all --version $VERSION  --only-package
           elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ] ;then
-            mkdir charts
+            mkdir -p charts
             orc8r/tools/helm/package_lf.sh --deployment-type all --version $VERSION --only-package
           else
             orc8r/tools/helm/package_lf.sh --deployment-type all


### PR DESCRIPTION
## Summary

Fix for a bug introduced with the double push, see for example:
https://github.com/magma/magma/actions/runs/3536381120/jobs/5935359778

## Test Plan

Wait for CI.

## Additional Information

- [ ] This change is backwards-breaking