### PR TITLE
chore: Revert to old tagging scheme; Run on PRs

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -9,100 +9,157 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: AGW Build & Publish Container
+name: AGW Build, Publish & Test Container
 
 on:
+  workflow_dispatch:
+    inputs:
+      registry:
+        type: string
+        description: Overwrite registry (default agw-test.artifactory.magmacore.org).
   push:
     branches:
       - master
       - 'v1.*'
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened, synchronize ]
-    branches:
-      - master
-      - 'v1.*'
+
+env:
+  registry: ${{ inputs.registry || 'agw-test.artifactory.magmacore.org' }}
 
 jobs:
 
-  agw-collect-matrix-success:
-    runs-on: ubuntu-latest
-    if: success()
-    needs: build-containers
-    steps:
-      - run: echo "Successfully built AGW containers."
-
-  agw-check-matrix-success:
-    runs-on: ubuntu-latest
-    if: always()
-    needs: agw-collect-matrix-success
-    steps:
-      - name: Check completion of all build steps
-        run: |
-          if [ "${{ needs.agw-collect-matrix-success.result }}" = "success" ];
-          then
-            exit 0
-          else
-            echo "Exit status of some previous job(s) was ${{ needs.agw-collect-matrix-success.result }}"
-            exit 1
-          fi
-
   build-containers:
+    outputs:
+      digest_c: ${{ steps.docker-builder-c.outputs.digest }}
+      digest_python: ${{ steps.docker-builder-python.outputs.digest }}
+      digest_go: ${{ steps.docker-builder-go.outputs.digest }}
+      registry: ${{ steps.set-registry.outputs.registry }}
     runs-on: ubuntu-latest
-    env:
-      DOCKER_REGISTRY: agw-ci.artifactory.magmacore.org
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - DOCKER_IMAGE: gateway_go
-            DOCKER_FILE: feg/gateway/docker/go/Dockerfile
-          - DOCKER_IMAGE: agw_gateway_python
-            DOCKER_FILE: lte/gateway/docker/services/python/Dockerfile
-          - DOCKER_IMAGE: agw_gateway_c
-            DOCKER_FILE: lte/gateway/docker/services/c/Dockerfile
-
     steps:
-      - run: echo "DOCKER_REGISTRY=agw-test.artifactory.magmacore.org" >> $GITHUB_ENV
-        if: github.ref == 'refs/heads/master'
-
-      - run: echo "Publishing images to ${{ env.DOCKER_REGISTRY }}"
-
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
 
+      - id: set-registry
+        name: Set registry and image_prefix
+        run: |
+          echo ${{ env.registry }}
+          echo registry=${{ env.registry }} >> $GITHUB_OUTPUT
+          if [ ${{ env.registry }} = docker.io ]
+          then
+            echo image_prefix=${{ secrets.JFROG_USERNAME }}/ >> $GITHUB_OUTPUT  # dockerhub image URLs have the form docker.io/<username>/image
+          fi
+
+      - name: verify registry output
+        run: |
+          echo Registry is ${{ steps.set-registry.outputs.registry }}
+          echo Image prefix is ${{ steps.set-registry.outputs.image_prefix }}
+
+      - id: get-short-git-sha
+        name: Set short git sha output
+        run: |
+          echo ${GITHUB_SHA:0:8}
+          echo sha=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT
+
+      - name: verify git sha output
+        run: echo git sha is ${{ steps.get-short-git-sha.outputs.sha }}
+
       - uses: ./.github/workflows/composite/docker-builder-agw
+        id: docker-builder-c
         with:
           REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
-          REGISTRY: ${{ env.DOCKER_REGISTRY }}
-          IMAGE: ${{ matrix.DOCKER_IMAGE }}
-          FILE: ${{ matrix.DOCKER_FILE }}
+          REGISTRY: ${{ env.registry }}
+          FILE: lte/gateway/docker/services/c/Dockerfile
+          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_c:${{ steps.get-short-git-sha.outputs.sha }}
+      - run: echo "C container image digest is ${{ steps.docker-builder-c.outputs.digest }}"
+      - run: echo "docker-builder-c conclusion = ${{ steps.docker-builder-c.conclusion }}"
+
+      - uses: ./.github/workflows/composite/docker-builder-agw
+        id: docker-builder-python
+        with:
+          REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+          REGISTRY: ${{ env.registry }}
+          FILE: lte/gateway/docker/services/python/Dockerfile
+          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_python:${{ steps.get-short-git-sha.outputs.sha }}
+      - run: echo "Python container image digest is ${{ steps.docker-builder-python.outputs.digest }}"
+      - run: echo "docker-builder-python conclusion = ${{ steps.docker-builder-python.conclusion }}"
+
+      - uses: ./.github/workflows/composite/docker-builder-agw
+        id: docker-builder-go
+        with:
+          REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+          REGISTRY: ${{ env.registry }}
+          FILE: feg/gateway/docker/go/Dockerfile
+          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}gateway_go:${{ steps.get-short-git-sha.outputs.sha }}
+      - run: echo "Go container image digest is ${{ steps.docker-builder-go.outputs.digest }}"
+      - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
 
   build-containers-ghz:
     runs-on: ubuntu-latest
     needs: build-containers
-    env:
-      DOCKER_REGISTRY: agw-ci.artifactory.magmacore.org
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - DOCKER_IMAGE: ghz_gateway_python
-            DOCKER_CONTEXT: lte/gateway/docker/ghz
-          - DOCKER_IMAGE: ghz_gateway_c
-            DOCKER_CONTEXT: lte/gateway/docker/ghz
-
     steps:
-      - run: echo "DOCKER_REGISTRY=agw-test.artifactory.magmacore.org" >> $GITHUB_ENV
-        if: github.ref == 'refs/heads/master'
-
-      - run: echo "Publishing images to ${{ env.DOCKER_REGISTRY }}"
-
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+      - id: set-registry
+        name: Set registry and image_prefix
+        run: |
+          echo ${{ env.registry }}
+          echo registry=${{ env.registry }} >> $GITHUB_OUTPUT
+          if [ ${{ env.registry }} = docker.io ]
+          then
+            echo image_prefix=${{ secrets.JFROG_USERNAME }}/ >> $GITHUB_OUTPUT  # dockerhub image URLs have the form docker.io/<username>/image
+          fi
+
+      - name: verify registry output
+        run: |
+          echo Registry is ${{ steps.set-registry.outputs.registry }}
+          echo Image prefix is ${{ steps.set-registry.outputs.image_prefix }}
+
+      - id: get-short-git-sha
+        run: echo sha=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT
 
       - uses: ./.github/workflows/composite/docker-builder-agw
         with:
           REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
-          REGISTRY: ${{ env.DOCKER_REGISTRY }}
-          IMAGE: ${{ matrix.DOCKER_IMAGE }}
-          CONTEXT: ${{ matrix.DOCKER_CONTEXT }}
+          REGISTRY: ${{ env.registry }}
+          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_c:${{ steps.get-short-git-sha.outputs.sha }}
+          CONTEXT: lte/gateway/docker/ghz
+
+      - uses: ./.github/workflows/composite/docker-builder-agw
+        with:
+          REGISTRY_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+          REGISTRY: ${{ env.registry }}
+          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_python:${{ steps.get-short-git-sha.outputs.sha }}
+          CONTEXT: lte/gateway/docker/ghz
+
+  test-containers-precommit:
+    needs: build-containers
+    # We only want to trigger the tests if the build-containers job uploaded the images.
+    # The following condition is a crude heuristic for this limitation.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/lte-integ-test-containerized.yml
+    with:
+      digest_c: ${{ needs.build-containers.outputs.digest_c }}
+      digest_python: ${{ needs.build-containers.outputs.digest_python }}
+      digest_go: ${{ needs.build-containers.outputs.digest_go }}
+      registry: ${{ needs.build-containers.outputs.registry }}
+      test_targets: precommit
+    secrets: inherit
+
+  test-containers-extended:
+    needs: build-containers
+    # We only want to trigger the tests if the build-containers job uploaded the images.
+    # The following condition is a crude heuristic for this limitation.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/lte-integ-test-containerized.yml
+    with:
+      digest_c: ${{ needs.build-containers.outputs.digest_c }}
+      digest_python: ${{ needs.build-containers.outputs.digest_python }}
+      digest_go: ${{ needs.build-containers.outputs.digest_go }}
+      registry: ${{ needs.build-containers.outputs.registry }}
+      test_targets: extended
+    secrets: inherit

--- a/.github/workflows/composite/docker-builder-agw/action.yml
+++ b/.github/workflows/composite/docker-builder-agw/action.yml
@@ -22,12 +22,9 @@ inputs:
   REGISTRY:
     description: Docker registry
     required: true
-  IMAGE:
-    description: Docker image stream name
+  TAGS:
+    description: Docker image stream tags
     required: true
-  TAG:
-    description: Docker image stream tag
-    default: latest
   FILE:
     description: Docker file
     required: false
@@ -35,10 +32,6 @@ inputs:
   CONTEXT:
     description: Docker context
     default: .
-  PUSH:
-    description: Push to registry?
-    default: true
-    type: boolean
 
 outputs:
   digest:
@@ -48,7 +41,12 @@ outputs:
 runs:
   using: composite
   steps:
-    - run: echo "Publishing images to ${{ inputs.REGISTRY }}"
+    - name: Show Inputs
+      run: |
+        echo "Registry:   ${{ inputs.REGISTRY }}"
+        echo "Tags:       ${{ inputs.TAGS }}"
+        echo "Dockerfile: ${{ inputs.FILE }}"
+        echo "Context:    ${{ inputs.CONTEXT }}"
       shell: bash
 
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -58,34 +56,22 @@ runs:
     - name: Login to Docker Hub
       id: docker-login
       # See unresolved bug https://github.com/actions/runner/issues/1483
-      if: ${{ inputs.PUSH == 'true' && inputs.REGISTRY_USERNAME != '' && inputs.REGISTRY_PASSWORD != '' }}
+      if: ${{ inputs.REGISTRY_USERNAME != '' && inputs.REGISTRY_PASSWORD != '' }}
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin@v2.1.0
       with:
         registry: ${{ inputs.REGISTRY }}
         username: ${{ inputs.REGISTRY_USERNAME }}
         password: ${{ inputs.REGISTRY_PASSWORD }}
 
-    - name: Build and push docker image ${{ inputs.IMAGE }}
+    - name: Build and push docker image ${{ inputs.TAGS }}
       id: build-docker
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # pin@v3.2.0
       with:
         context: ${{ inputs.CONTEXT }}
         file: ${{ inputs.CONTEXT }}/${{ inputs.FILE }}
-        tags: ${{ inputs.REGISTRY }}/${{ inputs.IMAGE }}:${{ inputs.TAG }}
+        tags: ${{ inputs.TAGS }}
         push: ${{ steps.docker-login.conclusion == 'success' }}
 
-    # The workaround with uploaded files is necessary, because the repository_dispatch cannot be issued from forked PRs,
-    # as those will never acquire write permissions.
-    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
-    # The workaround is suggested in the documentation.
-    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
-    - run: echo ${{ steps.build-docker.outputs.digest }} > ./${{ inputs.IMAGE }}.digest
-      shell: bash
-    - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3.1.1
-      with:
-        path: ./${{ inputs.IMAGE }}.digest
-      if: steps.docker-login.conclusion == 'success'
-
-    - run: echo "Image digest for \`${{ inputs.IMAGE }}\` is \`${{ steps.build-docker.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+    - run: echo "Image digest for \`${{ inputs.TAGS }}\` is \`${{ steps.build-docker.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
       shell: bash
       if: steps.docker-login.conclusion == 'success'

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -12,22 +12,71 @@
 name: AGW Test LTE Integration With Make Containerized Build
 
 on:
-  workflow_dispatch: null
-  workflow_run:
-    workflows:
-      - AGW Build & Publish Container
-    types:
-      - completed
+  workflow_dispatch:
+    inputs:
+      digest_c:
+        type: string
+        required: true
+      digest_python:
+        type: string
+        required: true
+      digest_go:
+        type: string
+        required: true
+      registry:
+        type: string
+        required: true
+      test_targets:
+        type: choice
+        options: [ precommit, extended_tests ]
+        required: true
+  workflow_call:
+    inputs:
+      digest_c:
+        type: string
+        required: true
+      digest_python:
+        type: string
+        required: true
+      digest_go:
+        type: string
+        required: true
+      registry:
+        type: string
+        required: true
+      test_targets:
+        type: string  # It seems we cannot define a choice with options in workflow_call
+        required: true
 
 jobs:
   lte-integ-test-containerized:
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: macos-12
-    strategy:
-      fail-fast: false
-      matrix:
-        test_targets: [ "precommit", "extended_tests" ]
     steps:
+      - name: Show inputs
+        run: |
+          echo Docker image digest C      ${{ inputs.digest_c }}
+          echo Docker image digest Python ${{ inputs.digest_python }}
+          echo Docker image digest Go     ${{ inputs.digest_go }}
+          echo Docker registry            ${{ inputs.registry }}
+          echo test targets               ${{ inputs.test_targets }}
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - id: set-registry
+        name: Set registry and image_prefix
+        run: |
+          echo ${{ inputs.registry }}
+          echo registry=${{ inputs.registry }} >> $GITHUB_OUTPUT
+          if [ ${{ inputs.registry }} = docker.io ]
+          then
+            echo image_prefix=${{ secrets.JFROG_USERNAME }}/ >> $GITHUB_OUTPUT  # dockerhub image URLs have the form docker.io/<username>/image
+          fi
+      - name: Write image digest to docker-compose.yaml
+        working-directory: lte/gateway/docker
+        run: |
+          sed -i '' "s#image:.*agw_gateway_c.*#image: ${{ inputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_c@${{ inputs.digest_c }}#" docker-compose.yaml
+          sed -i '' "s#image:.*agw_gateway_python.*#image: ${{ inputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_python@${{ inputs.digest_python }}#" docker-compose.yaml
+          sed -i '' "s#image:.*gateway_go.*#image: ${{ inputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}gateway_go@${{ inputs.digest_go }}#" docker-compose.yaml
+      - name: Show docker-compose yaml to verify correct docker images hashes
+        run: cat lte/gateway/docker/docker-compose.yaml
       - name: Cache magma-dev-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
@@ -56,37 +105,13 @@ jobs:
           sudo mkdir -p /etc/vbox/
           echo '* 192.168.0.0/16' | sudo tee /etc/vbox/networks.conf
           echo '* 3001::/64' | sudo tee -a /etc/vbox/networks.conf
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - name: Get docker image hashes from builder workflow
-        uses: dawidd6/action-download-artifact@e6e25ac3a2b93187502a8be1ef9e9603afc34925 # pin@2.24.2
-        with:
-          run_id: ${{ github.event.workflow_run.id }}
-      - name: Save docker image hashes to environment variables
-        run: |
-          echo "digest-c=$(cat artifact/agw_gateway_c.digest)" >> $GITHUB_ENV
-          echo "digest-python=$(cat artifact/agw_gateway_python.digest)" >> $GITHUB_ENV
-          echo "digest-go=$(cat artifact/gateway_go.digest)" >> $GITHUB_ENV
-      - name: Show docker images to be used
-        run: |
-          echo Docker image digest C      ${{ env.digest-c }}
-          echo Docker image digest Python ${{ env.digest-python }}
-          echo Docker image digest Go     ${{ env.digest-go }}
-      - name: Write image digest to docker-compose.yaml
-        working-directory: lte/gateway/docker
-        run: |
-          sed -i s/agw_gateway_c\${OPTIONAL_ARCH_POSTFIX}:\${IMAGE_VERSION}/agw_gateway_c:${{ env.digest-c }}/g docker-compose.yaml
-          sed -i s/agw_gateway_python\${OPTIONAL_ARCH_POSTFIX}:\${IMAGE_VERSION}/agw_gateway_python:${{ env.digest-python }}/g docker-compose.yaml
-          sed -i s/gateway_go\${OPTIONAL_ARCH_POSTFIX}:\${IMAGE_VERSION}/gateway_go:${{ env.digest-go }}/g docker-compose.yaml
-      - name: Show docker-compose yaml to verify correct docker images hashes
-        run: cat lte/gateway/docker/docker-compose.yaml
       - name: Run the integration test
         env:
-          DOCKER_REGISTRY: docker-ci.artifactory.magmacore.org/
           MAGMA_DEV_CPUS: 3
           MAGMA_DEV_MEMORY_MB: 9216
         working-directory: lte/gateway
-        run: |
-          fab --show=debug --set DOCKER_REGISTRY=${DOCKER_REGISTRY} integ_test_containerized:test_mode=${{ matrix.test_targets }}
+        # the image is directly concatenated to the registry, so we need the slash as delimiter
+        run: fab --show=debug --set DOCKER_REGISTRY=${{ inputs.registry }}/ integ_test_containerized:test_mode=${{ inputs.test_targets }}
       - name: Get test results
         if: always()
         working-directory: lte/gateway


### PR DESCRIPTION
in the scope of #14505 

## Summary

### No longer uploads docker images to agw-ci.artifactory.magmacore.org

The Linuxfoundation artifactory won't have a registry corresponding to agw-ci, so we need to stop uploading to it. See the "Additional Information" section below for details.

### Fixes the execution of the containerized LTE Integration tests

This reverts the docker image tags to the scheme from before #14389. Previously, most images were tagged with the Git commit hash, and on release branches they were tagged with the release version number. #14389 changed that scheme and tagged all images with `latest`. This does not make sense when building both on master and on release branches, because `latest` can then randomly point to images built from both branches. The latest tag also breaks the integration tests, because when an image is uploaded with the latest tag, the image previously tagged with latest is discarded from the registry and thus no longer available for the integration tests.

### Enable building the container images on PRs, upload less images

Since #14389 containers are no longer triggered by the `pull_request` event, but by the `pull_request_target` event. Workflows triggered by `pull_request_target` are not executed on the PR, but on the branch they are based on. Those branches are already covered by the `push` trigger. This PR reverts the trigger to `pull_request` so that the container build is tested on PRs.

This change also implies that for each commit on `master`/`v1.*`, only one image is built and uploaded. Previously the `pull_request_target` would cause multiple builds and uploads for the same commit on the base branch.

### Enables testing the LTE Integration tests on forks

This makes the Docker registry an input variable, so that the workflow can be tested on a fork with a custom registry.

### Use workflow_call to pass the image digest parameters

Previously we would pass the image digest via uploading and downloading artifacts. Passing them as parameters makes the dependency easier visible. As a side effect, while the workflow definitions remain separate, the build workflow run now also includes the test jobs.

## Test Plan

ongoing:

Run on push: https://github.com/jheidbrink/magma/actions/runs/3546594494/jobs/5956428347
Run on PR: https://github.com/jheidbrink/magma/actions/runs/3542062135

 For the PR, I used a second Github user to open a PR against my fork.


## Additional Information

container images were / are / will be uploaded to these locations:

#### Before #14389

* docker images built on master are tagged with Git Hash  and uploaded to agw-test
* docker images built on v1.*   are tagged with 1.x       and uploaded to agw-test
* docker images built on PRs    are tagged with PR number and uploaded to agw-ci

#### After #14389 

* docker images built on master are tagged with latest and uploaded to agw-test or agw-ci
* docker images on non-master are tagged with latest and uploaded to agw-ci
* docker images are not built on PRs

#### After this PR

* docker images built on any branch are tagged with Git Hash and uploaded to agw-test
* docker images are built on PRs but not uploaded

So the situation after this PR is not exactly like before #14389 where we tag version branches differently, but I think it's good enough for now. We might want to improve upon this later, but i see that out of scope of this PR.