### PR TITLE
chore: Make name of restart function clearer

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1020,7 +1020,7 @@ class MagmadUtil(object):
         self.exec_command(MAGTIVATE_CMD + " && " + state_corrupt_cmd)
         print(f"Corrupted {key} on redis")
 
-    def restart_all_services(self):
+    def restart_magma_services(self):
         """Restart all magma services on magma_dev VM"""
         if self._init_system == InitMode.SYSTEMD:
             self.exec_command(
@@ -1665,7 +1665,7 @@ class MagmadUtil(object):
             json.dump(data, json_file, sort_keys=True, indent=2)
 
         self.restart_services(['sctpd'], wait_time=30)
-        self.restart_all_services()
+        self.restart_magma_services()
 
     def _validate_non_nat_datapath(self, ip_version: int = 4):
         # validate SGi interface is part of uplink-bridge.

--- a/lte/gateway/python/integ_tests/s1aptests/test_modify_config_for_non_sanity.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_modify_config_for_non_sanity.py
@@ -48,7 +48,7 @@ class TestModifyConfigForNonSanity(unittest.TestCase):
         )
 
         print("Restarting services to apply configuration change")
-        self._magmad_util.restart_all_services()
+        self._magmad_util.restart_magma_services()
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_modify_mme_config_for_sanity.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_modify_mme_config_for_sanity.py
@@ -35,7 +35,7 @@ class TestModifyMMEConfigForSanity(unittest.TestCase):
         )
 
         print("Restarting services to apply configuration change")
-        self._magmad_util.restart_all_services()
+        self._magmad_util.restart_magma_services()
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_restore_config_after_non_sanity.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_restore_config_after_non_sanity.py
@@ -49,7 +49,7 @@ class TestRestoreConfigAfterNonSanity(unittest.TestCase):
         )
 
         print("Restarting services to apply configuration change")
-        self._magmad_util.restart_all_services()
+        self._magmad_util.restart_magma_services()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

In light of the reversion in the behaviour of `restart_all_services` in https://github.com/magma/magma/pull/14516, the function name is a bit misleading, since it only restarts the magma services and not all of them (sctpd etc.). This change should make that clearer.

## Test Plan

N/A