### PR TITLE
chore(ci): Deactivate Git advice for detached HEAD in Bazel workflow

### DIFF
--- a/bazel/scripts/bazel_diff.sh
+++ b/bazel/scripts/bazel_diff.sh
@@ -28,10 +28,10 @@ generate_hashes() {
     echo -e "${LOG_HEADER} Creating temporary directory to check out the commit $GIT_COMMIT ..." 1>&2
     local WORKDIR
     WORKDIR=$(mktemp --directory)
-    git clone "$MAGMA_ROOT" "$WORKDIR" --quiet
+    git -c advice.detachedHead=false clone "$MAGMA_ROOT" "$WORKDIR" --quiet
 
     echo -e "${LOG_HEADER} Checking out the commit $GIT_COMMIT." 1>&2
-    git -C "$WORKDIR" checkout "$GIT_COMMIT" --quiet
+    git -C "$WORKDIR" -c advice.detachedHead=false checkout "$GIT_COMMIT" --quiet
 
     echo -e "${LOG_HEADER} Generating the hashes for the commit $GIT_COMMIT" 1>&2
     "$BAZEL_DIFF" generate-hashes --workspacePath "$WORKDIR" --bazelPath "$BAZEL_PATH" "$HASHES_JSON"


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Deactivate Git advice for detached HEAD in Bazel workflow

## Test Plan

- Test run https://github.com/LKreutzer/magma/actions/runs/3541321851/jobs/5945458294

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
