### PR TITLE
fix(agw): Memory leak and corresponding corruption fix when restoring…

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_state_converter.cpp
@@ -247,12 +247,12 @@ void NasStateConverter::proto_to_pco_protocol_or_container_id(
       protocol_configuration_options_proto.proto_or_container_id();
   int i = 0;
   for (auto ptr = proto_pco_ids.begin(); ptr < proto_pco_ids.end(); ptr++) {
-    pco_protocol_or_container_id_t state_pco_protocol_or_container_id =
-        state_protocol_configuration_options->protocol_or_container_ids[i];
-    state_pco_protocol_or_container_id.id = ptr->id();
-    state_pco_protocol_or_container_id.length = ptr->length();
+    pco_protocol_or_container_id_t* state_pco_protocol_or_container_id =
+        &(state_protocol_configuration_options->protocol_or_container_ids[i]);
+    state_pco_protocol_or_container_id->id = ptr->id();
+    state_pco_protocol_or_container_id->length = ptr->length();
     if (ptr->contents().length()) {
-      state_pco_protocol_or_container_id.contents = bfromcstr_with_str_len(
+      state_pco_protocol_or_container_id->contents = bfromcstr_with_str_len(
           ptr->contents().c_str(), ptr->contents().length());
     }
     i++;


### PR DESCRIPTION
… context from database during mme restart

Signed-off-by: bhuvaneshne <bhuvaneshne@highway9networks.com>

## Summary

When reading from database and restoring context, the code accidentally restored into a local variable which is lost once control goes out of its scope.
Due to this, memory was leaking and context was not properly restored during MME restarts (When UE contexts are present)

## Test Plan

Run sanity tests.

## Additional Information

Fixes: https://github.com/magma/magma/issues/14542
