### PR TITLE
fix(ci): Use internal networks for CWF dev VMs

### DIFF
--- a/cwf/gateway/Vagrantfile
+++ b/cwf/gateway/Vagrantfile
@@ -26,7 +26,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cwag.vbguest.auto_update = false
     cwag.vm.hostname = "cwag-dev"
     cwag.vm.network "private_network", ip: "192.168.70.101", nic_type: "82540EM"
-    cwag.vm.network "private_network", ip: "192.168.129.23", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    cwag.vm.network "private_network", ip: "192.168.129.23", nic_type: "82540EM", virtualbox__intnet: "ipv4_sgi"
     cwag.vm.network "private_network", ip: "192.168.40.11", nic_type: "82540EM"
     cwag.ssh.password = "vagrant"
     cwag.ssh.insert_key = true
@@ -80,7 +81,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cwag_centos7.vbguest.auto_update = false
     cwag_centos7.vm.hostname = "cwag-dev-centos7"
     cwag_centos7.vm.network "private_network", ip: "192.168.70.101", nic_type: "82540EM"
-    cwag_centos7.vm.network "private_network", ip: "192.168.129.23", nic_type: "82540EM"
+    # Set to an internal network to prevent possible connection to vagrant host instead of other VM
+    cwag_centos7.vm.network "private_network", ip: "192.168.129.23", nic_type: "82540EM", virtualbox__intnet: "ipv4_sgi"
     cwag_centos7.vm.network "private_network", ip: "192.168.40.11", nic_type: "82540EM"
 #    cwag_centos7.ssh.password = "vagrant"
     cwag_centos7.ssh.insert_key = true


### PR DESCRIPTION
## Summary

https://github.com/magma/magma/pull/14516 broke the CWF integration test, see e.g. [here](https://github.com/magma/magma/actions/runs/3539541764). This is because the tests use the magma traffic server, whose networks were modified in that PR, but the corresponding modifications were not made to the CWF dev VMs. This meant that the traffic could now flow between the traffic server and the CWF dev VM. This PR makes the relevant networks in the CWF dev VMs internal too. 

## Test Plan

- [x] [CI integration test run](https://github.com/voisey/magma/actions/runs/3547042056) - green with exception of flaky test