### PR TITLE
fix(ci): Use correct URL for new artifactory 

### DIFF
--- a/.github/workflows/magma-build-3rd-party.yml
+++ b/.github/workflows/magma-build-3rd-party.yml
@@ -105,7 +105,7 @@ jobs:
         if: ${{ env.JF_USER != '' && env.JF_PASSWORD != '' }}
         uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
         env:
-          JF_URL: https://linuxfoundation.jfrog.io/artifactory
+          JF_URL: https://linuxfoundation.jfrog.io/
           JF_USER: ${{ secrets.LF_JFROG_USERNAME }}
           JF_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
 


### PR DESCRIPTION
## Summary

The login to the new artifactory fails on master after the changes from #14545:
https://github.com/magma/magma/actions/runs/3547567230/jobs/5957829084

## Test Plan
CI https://github.com/magma/magma/actions/runs/3548121469/jobs/5958986971#step:8:1