### PR TITLE
fix(ci): update setup.cfg to adhere to flake8 6.0 rules (#14559) [backport to v1.8]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,70 +3,128 @@ max-complexity = 20
 strictness = short
 
 ignore =
-    W503, # line break before binary operator
-    W504, # line break occurred after a binary operator 
+    # line break before binary operator
+    W503,
+    # line break occurred after a binary operator 
+    W504,
     # wemake-python-styleguide warnings
     # See https://wemake-python-stylegui.de/en/latest/pages/usage/violations/index.html for doc
-    WPS102, # Found incorrect module name pattern
-    WPS110, # Found wrong variable name
-    WPS111, # Found too short name
-    WPS115, # Found upper-case constant in a class
-    WPS201, # Found module with too many imports
-    WPS202, # Found too many module members
-    WPS204, # Found overused expression
-    WPS210, # Found too many local variables
-    WPS211, # Found too many arguments
-    WPS212, # Found too many return statements
-    WPS213, # Found too many expressions
-    WPS214, # Found too many methods
-    WPS217, # Found too many await expressions
-    WPS221, # Found line with high Jones Complexity
-    WPS223, # Found too many `elif` branches
-    WPS226, # Found string constant over-use
-    WPS229, # Found too long try body length
-    WPS230, # Found too many public instance attributes
-    WPS231, # Found function with too much cognitive complexity
-    WPS232, # Found module cognitive complexity that is too high
-    WPS235, # Found too many imported names from a module
-    WPS238, # Found too many raises in a function
-    WPS220, # Found too deep nesting
-    WPS305, # Found `f` string
-    WPS317, # Found incorrect multi-line parameters
-    WPS318, # Found extra indentation
-    WPS319, # Found bracket in wrong position
-    WPS323, # Found percent string formatting
-    WPS326, # Found implicit string concatenation
-    WPS331, # Found variables that are only used for `return`
-    WPS336, # Found explicit string concatenation
-    WPS337, # Found multiline conditions
-    WPS338, # Found incorrect order of methods in a class
-    WPS348, # Found line starting with a dot
-    WPS352, # Found multiline loop
-    WPS414, # Found incorrect unpacking target
-    WPS420, # Found wrong keyword
-    WPS421, # Found wrong function
-    WPS428, # Found statement that has no effect
-    WPS430, # Found nested function
-    WPS432, # Found magic number
-    WPS437, # Found protected attribute usage
-    WPS440, # Found block variables overlap
-    WPS457, # Found an infinite while loop
-    WPS463, # Found a getter without a return value
-    WPS504, # Found negated condition
+    # Found incorrect module name pattern
+    WPS102,
+    # Found wrong variable name
+    WPS110,
+    # Found too short name
+    WPS111,
+    # Found upper-case constant in a class
+    WPS115,
+    # Found module with too many imports
+    WPS201,
+    # Found too many module members
+    WPS202,
+    # Found overused expression
+    WPS204,
+    # Found too many local variables
+    WPS210,
+    # Found too many arguments
+    WPS211,
+    # Found too many return statements
+    WPS212,
+    # Found too many expressions
+    WPS213,
+    # Found too many methods
+    WPS214,
+    # Found too many await expressions
+    WPS217,
+    # Found line with high Jones Complexity
+    WPS221,
+    # Found too many `elif` branches
+    WPS223,
+    # Found string constant over-use
+    WPS226,
+    # Found too long try body length
+    WPS229,
+    # Found too many public instance attributes
+    WPS230,
+    # Found function with too much cognitive complexity
+    WPS231,
+    # Found module cognitive complexity that is too high
+    WPS232,
+    # Found too many imported names from a module
+    WPS235,
+    # Found too many raises in a function
+    WPS238,
+    # Found too deep nesting
+    WPS220,
+    # Found `f` string
+    WPS305,
+    # Found incorrect multi-line parameters
+    WPS317,
+    # Found extra indentation
+    WPS318,
+    # Found bracket in wrong position
+    WPS319,
+    # Found percent string formatting
+    WPS323,
+    # Found implicit string concatenation
+    WPS326,
+    # Found variables that are only used for `return`
+    WPS331,
+    # Found explicit string concatenation
+    WPS336,
+    # Found multiline conditions
+    WPS337,
+    # Found incorrect order of methods in a class
+    WPS338,
+    # Found line starting with a dot
+    WPS348,
+    # Found multiline loop
+    WPS352,
+    # Found incorrect unpacking target
+    WPS414,
+    # Found wrong keyword
+    WPS420,
+    # Found wrong function
+    WPS421,
+    # Found statement that has no effect
+    WPS428,
+    # Found nested function
+    WPS430,
+    # Found magic number
+    WPS432,
+    # Found protected attribute usage
+    WPS437,
+    # Found block variables overlap
+    WPS440,
+    # Found an infinite while loop
+    WPS457,
+    # Found a getter without a return value
+    WPS463,
+    # Found negated condition
+    WPS504,
     # flake8-quotes warnings
-    Q000,   # Remove bad quotes
-    Q001,   # Remove bad quotes from multiline string
+    # Remove bad quotes
+    Q000,
+    # Remove bad quotes from multiline string
+    Q001,
     # Darglint warnings
-    DAR003, # Incorrect indentation
-    DAR102, # Excess parameter(s) in Docstring
-    DAR402, # Excess exception(s) in Raises section
+    # Incorrect indentation
+    DAR003,
+    # Excess parameter(s) in Docstring
+    DAR102,
+    # Excess exception(s) in Raises section
+    DAR402,
     # pydocstyle warnings
-    D107,   # Missing docstring in __init_
-    D2,     # White space formatting for doc strings
-    D400,   # First line should end with a period
+    # Missing docstring in __init_
+    D107,
+    # White space formatting for doc strings
+    D2,
+    # First line should end with a period
+    D400,
     # Others
-    N802,   # function name
-    N400,   # Found backslash that is used for line breaking
+    # function name
+    N802,
+    # Found backslash that is used for line breaking
+    N400,
     E501,
     S105,
     RST


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [fix(ci): update setup.cfg to adhere to flake8 6.0 rules (#14559)](https://github.com/magma/magma/pull/14559)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)