### PR TITLE
fix(amf): config support for pcscf address

### DIFF
--- a/lte/gateway/c/core/oai/include/amf_config.hpp
+++ b/lte/gateway/c/core/oai/include/amf_config.hpp
@@ -36,6 +36,8 @@
 
 #define AMF_CONFIG_STRING_AMF_CONFIG "AMF"
 #define AMF_CONFIG_STRING_DEFAULT_DNS_IPV4_ADDRESS "DEFAULT_DNS_IPV4_ADDRESS"
+#define AMF_CONFIG_STRING_DEFAULT_PCSCF_IPV4_ADDRESS "P_CSCF_IPV4_ADDRESS"
+#define AMF_CONFIG_STRING_DEFAULT_PCSCF_IPV6_ADDRESS "P_CSCF_IPV6_ADDRESS"
 #define AMF_CONFIG_STRING_DEFAULT_DNS_SEC_IPV4_ADDRESS \
   "DEFAULT_DNS_SEC_IPV4_ADDRESS"
 #define AMF_CONFIG_PLMN_SUPPORT_MCC "mcc"
@@ -184,6 +186,10 @@ typedef struct amf_config_s {
     struct in_addr default_dns;
     struct in_addr default_dns_sec;
   } ipv4;
+  struct {
+    struct in_addr ipv4;
+  } pcscf_addr;
+
   bstring amf_name;
   bstring default_dnn;
   uint32_t auth_retry_interval;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -204,6 +204,7 @@ int amf_config_parse_file(amf_config_t* config_pP,
   const char* set_id = NULL;
   const char* pointer = NULL;
   const char* default_dns = NULL;
+  const char* default_pcscf = NULL;
   const char* default_dns_sec = NULL;
   const char* set_sst = NULL;
   const char* set_sd = NULL;
@@ -235,13 +236,20 @@ int amf_config_parse_file(amf_config_t* config_pP,
     if (config_setting_lookup_string(setting_amf,
                                      AMF_CONFIG_STRING_DEFAULT_DNS_IPV4_ADDRESS,
                                      (const char**)&default_dns) &&
-        config_setting_lookup_string(setting_amf,
-                                     AMF_CONFIG_STRING_DEFAULT_DNS_IPV4_ADDRESS,
-                                     (const char**)&default_dns_sec)) {
+        config_setting_lookup_string(
+            setting_amf, AMF_CONFIG_STRING_DEFAULT_DNS_SEC_IPV4_ADDRESS,
+            (const char**)&default_dns_sec)) {
       IPV4_STR_ADDR_TO_INADDR(default_dns, config_pP->ipv4.default_dns,
                               "BAD IPv4 ADDRESS FORMAT FOR DEFAULT DNS !\n");
       IPV4_STR_ADDR_TO_INADDR(default_dns_sec, config_pP->ipv4.default_dns_sec,
                               "BAD IPv4 ADDRESS FORMAT FOR DEFAULT DNS SEC!\n");
+    }
+
+    if (config_setting_lookup_string(
+            setting_amf, AMF_CONFIG_STRING_DEFAULT_PCSCF_IPV4_ADDRESS,
+            (const char**)&default_pcscf)) {
+      IPV4_STR_ADDR_TO_INADDR(default_pcscf, config_pP->pcscf_addr.ipv4,
+                              "BAD IPv4 ADDRESS FORMAT FOR DEFAULT PCSCF !\n");
     }
 
     // AMF NAME

--- a/lte/gateway/c/core/oai/tasks/amf/amf_session_manager_pco.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_session_manager_pco.cpp
@@ -120,21 +120,21 @@ uint16_t sm_process_pco_dns_server_request(
 uint16_t sm_process_pco_p_cscf_address_request(
     protocol_configuration_options_t* const pco_resp) {
   OAILOG_FUNC_IN(LOG_AMF_APP);
-  in_addr_t ipcp_out_dns_prim_ipv4_addr = INADDR_NONE;
+  in_addr_t pcscf_prim_ipv4_addr = INADDR_NONE;
   pco_protocol_or_container_id_t poc_id_resp = {0};
-  uint8_t dns_array[4];
+  uint8_t pcscf_array[4];
 
   amf_config_read_lock(&amf_config);
-  ipcp_out_dns_prim_ipv4_addr = amf_config.ipv4.default_dns.s_addr;
+  pcscf_prim_ipv4_addr = amf_config.pcscf_addr.ipv4.s_addr;
   amf_config_unlock(&amf_config);
 
   poc_id_resp.id = PCO_CI_P_CSCF_IPV4_ADDRESS_REQUEST;
   poc_id_resp.length = 4;
-  dns_array[0] = (uint8_t)(ipcp_out_dns_prim_ipv4_addr & 0x000000FF);
-  dns_array[1] = (uint8_t)((ipcp_out_dns_prim_ipv4_addr >> 8) & 0x000000FF);
-  dns_array[2] = (uint8_t)((ipcp_out_dns_prim_ipv4_addr >> 16) & 0x000000FF);
-  dns_array[3] = (uint8_t)((ipcp_out_dns_prim_ipv4_addr >> 24) & 0x000000FF);
-  poc_id_resp.contents = blk2bstr(dns_array, sizeof(dns_array));
+  pcscf_array[0] = (uint8_t)(pcscf_prim_ipv4_addr & 0x000000FF);
+  pcscf_array[1] = (uint8_t)((pcscf_prim_ipv4_addr >> 8) & 0x000000FF);
+  pcscf_array[2] = (uint8_t)((pcscf_prim_ipv4_addr >> 16) & 0x000000FF);
+  pcscf_array[3] = (uint8_t)((pcscf_prim_ipv4_addr >> 24) & 0x000000FF);
+  poc_id_resp.contents = blk2bstr(pcscf_array, sizeof(pcscf_array));
 
   sm_pco_push_protocol_or_container_id(pco_resp, &poc_id_resp);
 

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -341,6 +341,8 @@ AMF :
     # DNS address communicated to UEs
     DEFAULT_DNS_IPV4_ADDRESS     = "{{ ipv4_dns }}";
     DEFAULT_DNS_SEC_IPV4_ADDRESS = "{{ ipv4_sec_dns }}";
+    P_CSCF_IPV4_ADDRESS          = "{{ ipv4_p_cscf_address }}";
+
     AMF_NAME = "{{ amf_name }}";
     DEFAULT_DNN = "{{ default_dnn }}";
     AUTHENTICATION_MAX_RETRY = "{{ auth_retry_max_count }}";


### PR DESCRIPTION
Signed-off-by: ganeshg87 <ganesh.gedela@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
fix(amf): config support for pcscf address


## Test Plan
 Basic Sanity with UERANSIM and verified PDU Accept with PCSCF address from config.

![image](https://user-images.githubusercontent.com/83060027/204510057-fd6efd31-0f41-40fc-ab05-0ef569c760f8.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
