### PR TITLE
fix(ci): Fix working directory for dummy package

### DIFF
--- a/.github/workflows/magma-push-dummy-package.yml
+++ b/.github/workflows/magma-push-dummy-package.yml
@@ -44,7 +44,6 @@ jobs:
 
       - name: Publish debian package
         if: steps.jfrog-setup.conclusion == 'success' && github.event_name == 'workflow_dispatch'
-        working-directory: third_party/build
         run: |
           jf rt upload \
             --recursive=false \


### PR DESCRIPTION
## Summary

Fix non-existing directory error

## Test Plan

- [x] Run CI on branch.
  - Result: https://linuxfoundation.jfrog.io/artifactory/magma-packages-test/pool/focal-ci/hello_2.10-2ubuntu2_amd64.deb
  - https://github.com/magma/magma/actions/runs/3573691114

## Additional Information

- [ ] This change is backwards-breaking