### PR TITLE
chore(ci): Build docker containers with bazel cache in CI

### DIFF
--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -28,6 +28,12 @@ inputs:
       type=ref,event=pr
   DOCKERFILE:
     required: true
+  PUSH_TO_REGISTRY:
+    required: true
+  BUILD_ARG_1:
+    default: ''
+  BUILD_ARG_2:
+    default: ''
 
 runs:
   using: composite
@@ -52,7 +58,7 @@ runs:
         registry: ${{ inputs.REGISTRY }}
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
-      if: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}
+      if: ${{ inputs.PUSH_TO_REGISTRY == 'true' }}
     - name: Build and push Docker image
       id: docker_build
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # pin@v3.2.0
@@ -62,4 +68,7 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         # without docker/metadata-action will only be accessible by hash
-        push: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}
+        push: ${{ inputs.PUSH_TO_REGISTRY == 'true' }}
+        build-args: |
+          ${{ inputs.BUILD_ARG_1 }}
+          ${{ inputs.BUILD_ARG_2 }}

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -15,6 +15,7 @@ on:
     branches:
       - master
     paths:
+      - bazel/docker/Dockerfile.bazel.cache
       - .devcontainer/bazel-base/Dockerfile
       - .devcontainer/Dockerfile
       - .github/workflows/docker-builder-devcontainer.yml
@@ -25,12 +26,13 @@ on:
       - reopened
       - synchronize
     paths:
+      - bazel/docker/Dockerfile.bazel.cache
       - .devcontainer/bazel-base/Dockerfile
       - .devcontainer/Dockerfile
       - .github/workflows/docker-builder-devcontainer.yml
       - .github/workflows/composite/**
   schedule:
-    - cron: '13 3 * * *'
+    - cron: '17 4 * * 6' # At 04:17 on Saturday
 
 env:
   REGISTRY: ghcr.io
@@ -39,6 +41,10 @@ env:
   DOCKERFILE_BAZEL_BASE: .devcontainer/bazel-base/Dockerfile
   IMAGE_STREAM_DEVCONTAINER: ${{ github.repository }}/devcontainer
   DOCKERFILE_DEVCONTAINER: .devcontainer/Dockerfile
+  IMAGE_STREAM_BAZEL_CACHE_ASAN: ${{ github.repository }}/bazel-cache-asan
+  IMAGE_STREAM_BAZEL_CACHE_PLAIN: ${{ github.repository }}/bazel-cache-plain
+  IMAGE_STREAM_BAZEL_CACHE_PROD: ${{ github.repository }}/bazel-cache-prod
+  DOCKERFILE_BAZEL_CACHE: bazel/docker/Dockerfile.bazel.cache
 
 jobs:
   build_dockerfile_bazel_base:
@@ -51,6 +57,7 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM_BAZEL_BASE }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE_BAZEL_BASE }}
+          PUSH_TO_REGISTRY: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}
 
   build_dockerfile_devcontainer:
     needs: build_dockerfile_bazel_base
@@ -63,3 +70,60 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM_DEVCONTAINER }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE_DEVCONTAINER }}
+          PUSH_TO_REGISTRY: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}
+
+  build_dockerfile_bazel_cache_asan:
+    needs: build_dockerfile_bazel_base
+    if: |
+      (github.event_name == 'push' || github.event_name == 'schedule') &&
+      github.ref_name == 'master' &&
+      github.repository_owner == 'magma'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: ./.github/workflows/composite/docker-builder
+        with:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_STREAM: ${{ env.IMAGE_STREAM_BAZEL_CACHE_ASAN }}
+          IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
+          DOCKERFILE: ${{ env.DOCKERFILE_BAZEL_CACHE }}
+          BUILD_ARG_1: "BAZEL_TARGET_RULE=cc_test"
+          BUILD_ARG_2: "BAZEL_CONFIG=--config=asan"
+          PUSH_TO_REGISTRY: "true"
+
+  build_dockerfile_bazel_cache_plain:
+    needs: build_dockerfile_bazel_base
+    if: |
+      (github.event_name == 'push' || github.event_name == 'schedule') &&
+      github.ref_name == 'master' &&
+      github.repository_owner == 'magma'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: ./.github/workflows/composite/docker-builder
+        with:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_STREAM: ${{ env.IMAGE_STREAM_BAZEL_CACHE_PLAIN }}
+          IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
+          DOCKERFILE: ${{ env.DOCKERFILE_BAZEL_CACHE }}
+          BUILD_ARG_1: "BAZEL_TARGET_RULE=.*_test"
+          PUSH_TO_REGISTRY: "true"
+
+  build_dockerfile_bazel_cache_prod:
+    needs: build_dockerfile_bazel_base
+    if: |
+      (github.event_name == 'push' || github.event_name == 'schedule') &&
+      github.ref_name == 'master' &&
+      github.repository_owner == 'magma'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: ./.github/workflows/composite/docker-builder
+        with:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_STREAM: ${{ env.IMAGE_STREAM_BAZEL_CACHE_PROD }}
+          IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
+          DOCKERFILE: ${{ env.DOCKERFILE_BAZEL_CACHE }}
+          BUILD_ARG_1: "BAZEL_TARGET_RULE=cc_test"
+          BUILD_ARG_2: "BAZEL_CONFIG=--config=production"
+          PUSH_TO_REGISTRY: "true"

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -47,3 +47,4 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE }}
+          PUSH_TO_REGISTRY: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}

--- a/bazel/docker/Dockerfile.bazel.cache
+++ b/bazel/docker/Dockerfile.bazel.cache
@@ -1,0 +1,63 @@
+##########################################################
+# Build the bazel cache for all configs
+##########################################################
+# hadolint ignore=DL3007
+FROM ghcr.io/magma/magma/bazel-base:latest as bazel_builder_cache
+
+ENV MAGMA_ROOT=/workspaces/magma
+
+# The bazel target rule and config are inputs via '--build-arg'.
+ARG BAZEL_TARGET_RULE='.*_test'
+# BAZEL-CONFIG needs to be of the form '--config=config_name'.
+ARG BAZEL_CONFIG=''
+
+# Copy Magma repository into the builder.
+COPY ./ $MAGMA_ROOT
+COPY ./lte/gateway/configs /etc/magma
+
+# Remove sym-links to cache folders and create directories.
+# Build the caches by running the bazel tests.
+# --flaky_test_attempts is set to avoid build failures due
+# to flaky unit tests.
+# --test_tag_filters=-manual is needed to avoid running
+# integration and Python sudo tests.
+# hadolint ignore=SC2006,DL3003
+RUN rm /var/cache/bazel-cache && \
+    rm /var/cache/bazel-cache-repo && \
+    mkdir -p /var/cache/bazel-cache && \
+    mkdir -p /var/cache/bazel-cache-repo && \
+    cd $MAGMA_ROOT && \
+    echo "Running Bazel test on all '${BAZEL_TARGET_RULE}' targets with config '${BAZEL_CONFIG}' ..." && \
+    bazel test ${BAZEL_CONFIG} --flaky_test_attempts=5 --test_tag_filters=-manual `bazel query "kind(${BAZEL_TARGET_RULE}, //...)"` && \
+    echo "Running Bazel build //:bazel-diff" && \
+    bazel build //:bazel-diff && \
+    echo "The size of the /var/cache/bazel-cache* folders is:" && \
+    du -sh /var/cache/bazel-cache*
+
+##########################################################
+# Copy the cache into a clean new image to be used in CI
+##########################################################
+# hadolint ignore=DL3007
+FROM ghcr.io/magma/magma/bazel-base:latest as bazel_cache
+
+ENV MAGMA_ROOT=/workspaces/magma
+
+# Remove sym-links to cache folders and create directories.
+RUN rm /var/cache/bazel-cache && \
+    rm /var/cache/bazel-cache-repo && \
+    mkdir -p /var/cache/bazel-cache && \
+    mkdir -p /var/cache/bazel-cache-repo
+
+# Copy the caches from the builder image to the final image.
+COPY --from=bazel_builder_cache \
+    /var/cache/bazel-cache \
+    /var/cache/bazel-cache
+
+# Copy the caches from the builder image to the final image.
+COPY --from=bazel_builder_cache \
+    /var/cache/bazel-cache-repo \
+    /var/cache/bazel-cache-repo
+
+# Print volume of the caches for debugging.
+RUN echo "The size of the /var/cache/bazel-cache* folders is:" && \
+    du -sh /var/cache/bazel-cache*


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Build docker images with bazel cache for all configs in CI workflow.
- There is one Dockerfile for all configs, the config is determined by the build args.
- The three docker images are build after bazel-base is build.
  - In contrast to bazel-base the cache images are always pushed to ghcr, even when running on schedule.
  - The scheduled build happens once a week.
- Part I of https://github.com/magma/magma/issues/14562
- Workflow takes ca 1h.

## Test Plan

- [Run on fork](https://github.com/LKreutzer/magma/actions/runs/3584008588)
  - Pushed to the fork packages: https://github.com/LKreutzer?tab=packages&repo_name=magma
- Download the containers, see that without mounting the caches exist at `/var/cache/bazel-cache*`
- Download the containers, see that when mounting the repo, everything can be build and is taken from cache
- [Run on fork](https://github.com/LKreutzer/magma/actions/runs/3591334362) (skipped due to if condition)
- [Run on fork with if condition removed for testing](https://github.com/LKreutzer/magma/actions/runs/3591354590)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
