### PR TITLE
fix(ci): ubuntu runners are pinned to 20.04

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -35,7 +35,7 @@ jobs:
       digest_python: ${{ steps.docker-builder-python.outputs.digest }}
       digest_go: ${{ steps.docker-builder-go.outputs.digest }}
       registry: ${{ steps.set-registry.outputs.registry }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
 
@@ -97,7 +97,7 @@ jobs:
       - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
 
   build-containers-ghz:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-containers
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/agw-coverage.yml
+++ b/.github/workflows/agw-coverage.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -58,7 +58,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: C / C++ code coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Maximize build space
@@ -130,7 +130,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Python code coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Maximize build space

--- a/.github/workflows/agw-docker-load-test.yml
+++ b/.github/workflows/agw-docker-load-test.yml
@@ -26,7 +26,7 @@ concurrency: ${{ github.workflow }}
 jobs:
   docker-load-test:
     name: agw docker load tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       SHA: "${{ github.event.workflow_run.head_commit.id }}"
       MAGMA_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -47,7 +47,7 @@ jobs:
   lint-clang-format:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Check clang-format for orc8r/gateway/c
@@ -69,7 +69,7 @@ jobs:
 
   jsonlint-mconfig:
     name: jsonlint-mconfig
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -41,7 +41,7 @@ concurrency:
 
 jobs:
   AutoLabelPR:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   backport:
     name: Backport
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: >
       github.event.pull_request.merged
       && contains(join(github.event.pull_request.labels.*.name, ', '), 'apply-')

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       files_changed: ${{ steps.changes.outputs.files_changed }}
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
@@ -87,7 +87,7 @@ jobs:
           - bazel-config: "--config=production"
             bazel-target-rule: "cc_test"
     name: Bazel Build & Test Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Print variables
         run: |
@@ -231,7 +231,7 @@ jobs:
   if_bazel_build_and_test_success:
     name: Run when bazel successful
     needs: bazel_build_and_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: success() # Only run after all matrix jobs have passed
     # See https://github.com/magma/magma/wiki/How-to-set-up-a-required-matrix-workflow-on-GitHub-actions
     # or https://github.com/magma/magma/pull/13562 for more details.
@@ -244,7 +244,7 @@ jobs:
 
   report_result_bazel_build_and_test:
     name: Bazel build and test status
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: always()
     # This job always needs to run. It will be green if the bazel_build_and_test
     # job was successful in all matrix jobs or if the job was skipped.
@@ -280,7 +280,7 @@ jobs:
       needs.path_filter.outputs.files_changed == 'true' ||
       github.event_name == 'workflow_dispatch'
     name: Bazel Starlark Format Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
@@ -324,7 +324,7 @@ jobs:
       needs.path_filter.outputs.files_changed == 'true' ||
       github.event_name == 'workflow_dispatch'
     name: Bazel Python Import Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
@@ -385,7 +385,7 @@ jobs:
       needs.path_filter.outputs.files_changed == 'true' ||
       github.event_name == 'workflow_dispatch'
     name: Bazel Package Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
@@ -564,7 +564,7 @@ jobs:
 
   python_file_check:
     name: Check if there are not bazelified python files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -586,7 +586,7 @@ jobs:
 
   c_cpp_file_check:
     name: Check if there are non-bazelified c or c++ files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -37,7 +37,7 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       EVENT_NAME: "${{ github.event_name }}"
       ISSUE_NUMBER: "${{ github.event.number }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       # Version is github job run number when running on master
@@ -269,7 +269,7 @@ jobs:
       SENTRY_ORG: "lf-9c"
       PATH_TO_EXEC: "./executables"
       MAGMA_VERSION: ${{ needs.agw-build.outputs.magma_version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -323,7 +323,7 @@ jobs:
   orc8r-build:
     if: github.repository_owner == 'magma'
     name: orc8r build job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       artifacts: ${{ steps.publish_artifacts_lf.outputs.artifacts }}
     env:
@@ -416,7 +416,7 @@ jobs:
 
   cloud-upload:
     name: cloud upload job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' && github.repository_owner == 'magma'
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -462,7 +462,7 @@ jobs:
   cwag-deploy:
     if: github.repository_owner == 'magma'
     name: cwag deploy job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       artifacts: ${{ steps.publish_artifacts_lf.outputs.artifacts }}
     env:
@@ -589,7 +589,7 @@ jobs:
   cwf-operator-build:
     if: github.repository_owner == 'magma'
     name: cwf operator build job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -685,7 +685,7 @@ jobs:
   feg-build:
     if: github.repository_owner == 'magma'
     name: feg-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       artifacts: ${{ steps.publish_artifacts_lf.outputs.artifacts }}
     env:
@@ -797,7 +797,7 @@ jobs:
   nms-build:
     if: github.repository_owner == 'magma'
     name: nms-build job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       artifacts: ${{ steps.publish_artifacts_lf.outputs.artifacts }}
     env:
@@ -890,7 +890,7 @@ jobs:
   Publish_to_firebase:
     name: Publish to firebase
     if: always() && github.event_name == 'push' && github.repository_owner == 'magma'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       [
         agw-build,
@@ -924,7 +924,7 @@ jobs:
   domain-proxy-build:
     if: github.repository_owner == 'magma'
     name: domain proxy build job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       artifacts: ${{ steps.publish_artifacts_lf.outputs.artifacts }}
     env:
@@ -998,7 +998,7 @@ jobs:
           SLACK_FOOTER: ' '
   trigger-debian-integ-test:
     if: always() && github.event_name == 'push' && github.repository_owner == 'magma' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: agw-build
     steps:
       - name: Trigger debian integ test workflow

--- a/.github/workflows/check-rebase.yml
+++ b/.github/workflows/check-rebase.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   checkRebase:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       HEAD_FULL_NAME: "${{github.event.pull_request.head.repo.full_name}}"
       BASE_FULL_NAME: "${{github.event.pull_request.base.repo.full_name}}"

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -64,7 +64,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cloud-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
       GO111MODULE: 'on'

--- a/.github/workflows/codeowners-syntax.yml
+++ b/.github/workflows/codeowners-syntax.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   sanity:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Checks-out your repository, which is validated in the next step
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   skip_check:
     name: Job to check if the workflow ${{ github.event.workflow.name }} can be skipped
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event.workflow_run.event == 'pull_request' ||  github.event.workflow_run.event == 'pull_request_target'
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -71,7 +71,7 @@ jobs:
   comment_pr:
     name: Comment on PR for check ${{ github.event.workflow.name }}
     needs: skip_check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: needs.skip_check.outputs.should_skip == 'false'
     env:
       CHECK_GUIDELINE: "[Guide to the different CI checks and resolution guidelines](https://docs.magmacore.org/docs/next/contributing/contribute_ci_checks)"

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # Map a step output to a job output
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
@@ -46,7 +46,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwag pre-commit job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   docker-build:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Run docker compose

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # Map a step output to a job output
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
@@ -45,7 +45,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwf operator pre-commit job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   reverted-pr-check:
     name: Reverted PR Check Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PR_TITLE: "${{ github.event.pull_request.title }}"
     # Map a step output to a job output
@@ -55,7 +55,7 @@ jobs:
     needs: reverted-pr-check
     if: ${{ needs.reverted-pr-check.outputs.is_reverted_pr == 'false' }}
     name: DCO Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Get PR Commits
         id: 'get-pr-commits'

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   build_dockerfile_bazel_base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: ./.github/workflows/composite/docker-builder
@@ -54,7 +54,7 @@ jobs:
 
   build_dockerfile_devcontainer:
     needs: build_dockerfile_bazel_base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: ./.github/workflows/composite/docker-builder

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   build_dockerfile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: ./.github/workflows/composite/docker-builder

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   docker-promote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       BRANCH_TAG: ${{ inputs.branch_tag }}
       RELEASE_TAG: ${{ inputs.release_tag }}

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -58,7 +58,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Markdown lint check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -75,7 +75,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Markdown insync check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:

--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -17,7 +17,7 @@ on:
       - master
 jobs:
   docusaurus-build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Export vars

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       cc: ${{ steps.filter.outputs.cc }}
       rc: ${{ steps.filter.outputs.rc }}
@@ -89,7 +89,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.cc == 'true' }}
     name: "Configuration controller unit tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       COVERAGE_RCFILE: ${{ github.workspace }}/dp/.coveragerc
       PYTHONPATH: "${{ github.workspace }}"
@@ -134,7 +134,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.rc == 'true' }}
     name: "Radio controller unit tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       COVERAGE_RCFILE: ${{ github.workspace }}/dp/.coveragerc
       PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/build/gen"
@@ -210,7 +210,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.db == 'true' }}
     name: "Domain proxy db migration test"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     continue-on-error: false
     defaults:
       run:
@@ -252,7 +252,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.db == 'true' }}
     name: "DB service unit tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       COVERAGE_RCFILE: ${{ github.workspace }}/dp/.coveragerc
       PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/build/gen"
@@ -299,7 +299,7 @@ jobs:
 
   integration_tests_orc8r:
     name: "Domain proxy integration tests with orc8r"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: path_filter
     if: ${{ needs.path_filter.outputs.integration_tests_orc8r == 'true' }}
     continue-on-error: false
@@ -314,7 +314,7 @@ jobs:
     name: "Helm chart smoke tests"
     needs: path_filter
     if: ${{ needs.path_filter.outputs.helm == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: dp

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -22,7 +22,7 @@ jobs:
   # Build images on ubuntu which is faster than MacOs.
   docker-build-orc8r:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   docker-build-feg:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -56,7 +56,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: feg lint and precommit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/fossa-workflow.yml
+++ b/.github/workflows/fossa-workflow.yml
@@ -29,7 +29,7 @@ jobs:
   fossa-analyze:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Download fossa analyze script

--- a/.github/workflows/gcc-problems.yml
+++ b/.github/workflows/gcc-problems.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   path_filter:
     if: github.repository_owner == 'magma'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -61,7 +61,7 @@ jobs:
       - path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Build all Bazelified C/C++ targets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.

--- a/.github/workflows/golang-build-test.yml
+++ b/.github/workflows/golang-build-test.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   check_go_version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -39,7 +39,7 @@ jobs:
         run: ./.github/workflows/scripts/golang_check_version.sh
 
   pre_job_src_go_determinator:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.19.3]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.19.3]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
@@ -153,7 +153,7 @@ jobs:
       matrix:
         go-version: [1.19.3]
         arch: [386, arm, arm64]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
@@ -203,7 +203,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.19.3]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -33,7 +33,7 @@ jobs:
   check_helm_chart_dependencies:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Check dependency of helm chart ${{ matrix.charts[0] }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/helm-deploy-on-demand.yml
+++ b/.github/workflows/helm-deploy-on-demand.yml
@@ -24,7 +24,7 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       EVENT_NAME: "${{ github.event_name }}"
       ISSUE_NUMBER: "${{ github.event.number }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Launch build and publish script

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   helm-promote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_VERSION: ${{ inputs.magma_version }}
       MAGMA_ARTIFACTORY: https://artifactory.magmacore.org:443/artifactory

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   insync-checkin:
     name: insync checkin job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:

--- a/.github/workflows/magma-build-3rd-party.yml
+++ b/.github/workflows/magma-build-3rd-party.yml
@@ -47,7 +47,7 @@ on:
 
 jobs:
   build_dependencies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: ghcr.io/magma/magma/devcontainer:sha-385c134
     env:
       repository: ${{ inputs.repository || 'magma-packages-test' }}

--- a/.github/workflows/magma-push-dummy-package.yml
+++ b/.github/workflows/magma-push-dummy-package.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   build_dependencies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Download dummy debian package

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -58,7 +58,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-typescript job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: "${{ github.workspace }}/nms"
@@ -96,7 +96,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-eslint job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -143,7 +143,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-yarn-test job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -179,7 +179,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-e2e-test job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
       NMS_ROOT: "${{ github.workspace }}/nms"

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   # This job is a manual approximation of https://github.com/peter-evans/create-or-update-comment
   comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   pre_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
       files_changed: ${{ steps.changes.outputs.filesChanged_files }}
@@ -63,7 +63,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_not_skip == 'true' }}
     name: Python Format Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -26,7 +26,7 @@ concurrency:
 # github-pr-review: Adds lint as GitHub comments
 jobs:
   files_changed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       changed_cpp: ${{ steps.changes.outputs.cpp }}
       changed_go: ${{ steps.changes.outputs.go }}
@@ -67,7 +67,7 @@ jobs:
     #  For details on cpplint optinos see the detailed comments in
     #  https://github.com/google/styleguide/blob/gh-pages/cpplint/cpplint.py
     ##
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -91,7 +91,7 @@ jobs:
   golangci-lint:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_go == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -108,7 +108,7 @@ jobs:
 
   hadolint:
     name: dockerfile-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -129,7 +129,7 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_javascript == 'true' }}
     name: eslint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -154,7 +154,7 @@ jobs:
 
   markdownlint:
     name: markdownlint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -173,7 +173,7 @@ jobs:
 
   misspell:
     name: misspell
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -195,7 +195,7 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_python == 'true' }}
     name: mypy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -212,7 +212,7 @@ jobs:
 
   shellcheck:
     name: shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -231,7 +231,7 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_terraform == 'true' }}
     name: tflint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -251,7 +251,7 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_python == 'true' }}
     name: wemake-python-styleguide
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -268,7 +268,7 @@ jobs:
 
   yamllint:
     name: yamllint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   check-reverted-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PR_TITLE: "${{ github.event.pull_request.title }}"
     outputs:
@@ -46,7 +46,7 @@ jobs:
             }
 
   check-semantic-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: check-reverted-pr
     if: ${{ needs.check-reverted-pr.outputs.is_reverted_pr == 'false' }}
     steps:
@@ -134,7 +134,7 @@ jobs:
           validateSingleCommit: true
 
   comment-on-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: check-semantic-pr
     if: always()
     env:

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   skip_check:
     name: Job to retrieve the value in pr/skipped file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -66,7 +66,7 @@ jobs:
   unit-test-results:
     name: Upload unit test for ${{ github.event.workflow.name }}
     needs: skip_check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: >
       github.event.workflow_run.conclusion != 'skipped' &&
         github.event.workflow_run.head_repository.full_name != github.repository &&


### PR DESCRIPTION

Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

GH seems to have linked ubuntu-latest to 22.04.1 (20.04 before). The python setup is failing with this because 3.8.10 is not yet provided for that version. - more might fail in later steps.

See e.g., https://github.com/magma/magma/actions/runs/3584636792/jobs/6031655202

Here: pin version for now to 20.04

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
