### PR TITLE
docs(lte): Update gateway VM bazel setup with convenience script

### DIFF
--- a/docs/readmes/lte/s1ap_tests.md
+++ b/docs/readmes/lte/s1ap_tests.md
@@ -46,12 +46,9 @@ at a time.
 Spin up and provision the gateway VM. From `magma/lte/gateway` on the host machine run
 `vagrant up magma && vagrant ssh magma`.
 
-Now build the services with bazel.
+Now build and run the services with bazel.
 
-1. Create links for cli scripts: `cd $MAGMA_ROOT && bazel/scripts/link_scripts_for_bazel_integ_tests.sh`
-2. Use bazel systemd unit files: `sudo cp $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/systemd_bazel/* /etc/systemd/system/ && sudo systemctl daemon-reload`
-3. Build the services: `cd $MAGMA_ROOT && magma-build-agw` (Note: this will take some time for the initial build, but will be fast for follow-up builds.)
-4. Start the access gateway: `magma-restart`
+`cd $MAGMA_ROOT && bazel/scripts/build_and_run_bazelified_agw.sh`
 
 #### Debian installation
 

--- a/docs/readmes/lte/setup.md
+++ b/docs/readmes/lte/setup.md
@@ -29,11 +29,8 @@ Vagrant will bring up the VM, then Ansible will provision the VM.
 
 ``HOST:magma/lte/gateway USER$ vagrant ssh magma``
 
-- Next follow the steps below to get the magma services running:
+- Next build and run the services with bazel:
 
-1. Create links for cli scripts: `cd $MAGMA_ROOT && bazel/scripts/link_scripts_for_bazel_integ_tests.sh`
-2. Use bazel systemd unit files: `sudo cp $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/systemd_bazel/* /etc/systemd/system/ && sudo systemctl daemon-reload`
-3. Build the services: `cd $MAGMA_ROOT && magma-build-agw` (Note: this will take some time for the initial build, but will be fast for follow-up builds.)
-4. Start the access gateway: `magma-restart`
+`cd $MAGMA_ROOT && bazel/scripts/build_and_run_bazelified_agw.sh`
 
 Once the Access Gateway VM is running successfully, proceed to attaching the eNodeB.


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This is a follow up for #14593.
Updating the documentation with the convenience bazel setup script.

## Test Plan

None.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
