### PR TITLE
fix: packages are looked for in the correct folder

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -173,14 +173,14 @@ jobs:
           # Extract magma debian package version
           version_pattern="magma_([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-[a-z0-9]+)_amd64.deb"
           magma_version=""
-          for i in packages/*.deb; do
+          for i in *.deb; do
               if [[ $i =~ $version_pattern ]]; then
                   magma_version=${BASH_REMATCH[1]}
               fi
           done
           if [[ -z "$magma_version" ]]; then
               echo "No file found with a matching version pattern \"${version_pattern}\". Files in folder:"
-              ls -la packages
+              ls -la
               exit 1
           else
               echo "Exporting magma version \"${magma_version}\""


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In #14586 the double push to the magmacore artifactory was removed. Finding the created magma version was taken over from another workflow - that uses a different folder structure. This was not discovered during manual testing :(

See https://github.com/magma/magma/actions/runs/3593965714/jobs/6051613865 for failed run.

## Test Plan

CI - but only really on master

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
