### PR TITLE
chore: stabelize ul tests

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -380,11 +380,11 @@ def bazel_integ_test_post_build(
         env.hosts = [gateway_host]
 
 
-def _setup_vm(host, name, ansible_role, ansible_file, destroy_vm, provision_vm):
+def _setup_vm(host, name, ansible_role, ansible_file, destroy_vm, provision_vm, max_retries=1):
     ip = None
     if not host:
         host = vagrant_setup(
-            name, destroy_vm, force_provision=provision_vm,
+            name, destroy_vm, force_provision=provision_vm, max_retries=max_retries,
         )
     else:
         ansible_setup(host, ansible_role, ansible_file)
@@ -484,7 +484,7 @@ def integ_test_deb_installation(
 
     # Run the tests: use the provided test machine if given, else default to
     # the vagrant machine
-    _setup_vm(test_host, "magma_test", "test", "magma_test.yml", destroy_vm, provision_vm)
+    _setup_vm(test_host, "magma_test", "test", "magma_test.yml", destroy_vm, provision_vm, max_retries=3)
     execute(_make_integ_tests)
     execute(_run_integ_tests, gateway_ip)
 

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -122,7 +122,6 @@ s1aptests/test_attach_detach_setsessionrules_tcp_data.py
 
 PRECOMMIT_TESTS_IPV6 = \
 s1aptests/test_enable_ipv6_iface.py \
-s1aptests/test_ipv6_non_nat_dp_ul_tcp.py \
 s1aptests/test_disable_ipv6_iface.py
 
 PRECOMMIT_TESTS_NOT_CONTAINER = \
@@ -294,6 +293,7 @@ s1aptests/test_restore_config_after_non_sanity.py
 # s1aptests/test_ipv4v6_non_nat_ded_bearer_dl_tcp.py
 # s1aptests/test_ipv6_non_nat_ded_bearer_ul_tcp.py
 # s1aptests/test_ipv6_non_nat_ded_bearer_dl_tcp.py
+# s1aptests/test_ipv6_non_nat_dp_ul_tcp.py
 
 # Add the s1aptester integration tests with federation gateway
 FEDERATED_TESTS = s1aptests/test_attach_detach.py \

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -1298,7 +1298,6 @@ class MagmadUtil(object):
 
         systemd_only_magma_services = [
             'openvswitch-switch',
-            'magma_dp@envoy',
         ]
 
         docker_only_magma_services = [

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -399,7 +399,6 @@ class TestWrapper(object):
         Raises:
             ValueError: If no valid IP is found
         """
-        time.sleep(1)
         # Configure downlink route in TRF server
         assert self._trf_util.update_dl_route(self.TEST_IP_BLOCK)
 
@@ -434,7 +433,6 @@ class TestWrapper(object):
         Raises:
             ValueError: If no valid IP is found
         """
-        time.sleep(1)
         ips = self._getAddresses(*ues)
         for ip, ue in zip(ips, ues):
             if not ip:

--- a/orc8r/tools/fab/hosts.py
+++ b/orc8r/tools/fab/hosts.py
@@ -26,7 +26,7 @@ def split_hoststring(hoststring):
     return (user, ip, port)
 
 
-def vagrant_setup(host, destroy_vm, force_provision=False):
+def vagrant_setup(host, destroy_vm, force_provision=False, max_retries=1):
     """
     Setup the specified vagrant box
 
@@ -34,7 +34,7 @@ def vagrant_setup(host, destroy_vm, force_provision=False):
     """
     if destroy_vm:
         vagrant.teardown_vagrant(host)
-    vagrant.setup_env_vagrant(host, force_provision=force_provision)
+    vagrant.setup_env_vagrant(host, force_provision=force_provision, max_retries=max_retries)
     return env.hosts[0]
 
 


### PR DESCRIPTION
## Summary

This PR handles two problems - this was done in one PR in order to better see if the integration test runs succeed.

#### For ul integration tests often the iperf instances are not reachable - this was already mitigated in #13277, but still occurs in CI.
* The general waiting time is changed here to a wait for a barrier-point where all iperf instances are started.
* This is also guarded by a 10 second timeout.
* Note: this seems to be stable in various test runs - but it is still unclear to me why the previous approach had a similar effect. The general wait time was applied way before the iperf instances where started.

#### `test_ipv6_non_nat_dp_ul_tcp.py` often fails with harmful implications for follow-up tests.
* The test fails often during the attach phase
  * expected `UE_ATTACH_ACCEPT_IND = 12`, actually `UE_ATTACH_REJECT_IND = 23`
  * this seems to be related to `sessiond[389046]: I1204 18:31:06.951510 389046 LocalSessionManagerHandler.cpp:253] Rejecting requests since PipelineD is still setting up`
  * It is still unclear (to me) why this happens for the ipv6 case
* Now, in the flaky re-runs we often see a `segmentation fault`
  * It is unclear where this is coming from (no indication found in logging). Assumption: the s1aptester fails
  * This causes the test to stop - without clean-up -> the test tear-down is not called
  * nat is not enabled again (in the tear-down function)
* A follow-up test runs now still with the disabled nat setup
  * this makes calls to pipelined run into a 6h timeout - this call is started in s1ap-utils as a static init call
    * imho a static init call to pipelined is not a good pattern
    * this is not trivial to refactor
* Overall conclusion: the test should be disabled for now and in follow-up PRs ...
  * the static init call to pipelined should be refactored
  * to be discussed: tests should start with enabled nat

## Test Plan

#### general ul issues

* reproduce failures:
  * remove wait time in `s1ap_wrapper.py` (first commit), but do not change `traffic_server.py`
  * in local integ test setup run
    * repeatedly: `vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ test_attach_ul_udp_data_with_mobilityd_restart.py`
* compare results with runs where change to `traffic_server.py` is applied

#### reproduce `test_ipv6_non_nat_dp_ul_tcp.py` failures

* in local integ test setup run
  * once: `vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make selected_tests TESTS=s1aptests/test_enable_ipv6_iface.py` 
  * repeatedly: `vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make selected_tests TESTS=s1aptests/test_ipv6_non_nat_dp_ul_tcp.py`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
