### PR TITLE
feat(nms): Out-of order import of fileds in subscriber upload

### DIFF
--- a/nms/app/views/subscriber/SubscriberUpload.tsx
+++ b/nms/app/views/subscriber/SubscriberUpload.tsx
@@ -60,8 +60,8 @@ const useStyles = makeStyles(() => ({
     justifyContent: 'center',
   },
 }));
-const SUB_NAME_OFFSET = 0;
-const SUB_IMSI_OFFSET = 1;
+const SUB_IMSI_OFFSET = 0;
+const SUB_NAME_OFFSET = 1;
 const SUB_AUTH_KEY_OFFSET = 2;
 const SUB_AUTH_OPC_OFFSET = 3;
 const SUB_STATE_OFFSET = 4;


### PR DESCRIPTION
Fix
  Maps the fileds during subscriber addition in correct order.
  IMSI should be starting field followed by subscriber Name.
  Issue reported #14607.

Test
  Uploaded the file exported and all subscriber entries are reflected
  in NMS as well as AGW.

Signed-off-by: Yogesh Pandey <yogesh@wavelabs.ai>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
