### PR TITLE
ci: github workflow builds and uploads ovs

### DIFF
--- a/.github/workflows/magma-build-openvswitch.yml
+++ b/.github/workflows/magma-build-openvswitch.yml
@@ -30,16 +30,6 @@ on:
     - cron: 36 4 * * 0
   workflow_dispatch:
     inputs:
-      production:
-        description: Is production build?
-        type: boolean
-        default: false
-      repository:
-        description: Repository to push to?
-        type: choice
-        default: magma-packages-test
-        options: [ magma-packages-test, magma-packages-prod ]
-        required: true
       distribution:
         description: Distribution to set?
         default: 'focal-ci'
@@ -51,7 +41,7 @@ jobs:
     env:
       MAGMA_ROOT: ${{ github.workspace }}
       DEST: ${{ github.workspace }}/deb_packages
-      repository: ${{ inputs.repository || 'magma-packages-test' }}
+      repository: magma-packages-test
       distribution: ${{ inputs.distribution || 'focal-ci' }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -67,22 +57,6 @@ jobs:
         run: |
             sudo pip install ovs==2.16.0
             sudo apt-get install --yes --allow-downgrades ./*.deb
-
-      - name: Set repository to debian-test if not workflow_dispatch
-        run: echo "repository=debian-test" >> $GITHUB_ENV
-        if: github.ref == 'refs/heads/master' && github.event_name != 'workflow_dispatch'
-
-      - name: Verify inputs
-        run: |
-          echo "You have chosen 'repository' ${{ env.repository }} and 'is production' ${{ inputs.production }}."
-          echo "ERROR: Production deployment is protected. Abort!"
-          exit 1
-        if: |
-          env.repository == 'magma-packages-prod' &&
-          ! (
-            inputs.production &&
-            contains('["maxhbr", "nstng", "jheidbrink", "lkreutzer", "Neudrino", "MoritzThomasHuebner", "tmdzk", "wolfseb"]', github.actor)
-          )
 
       - name: Setup JFrog CLI
         id: jfrog-setup

--- a/.github/workflows/magma-build-openvswitch.yml
+++ b/.github/workflows/magma-build-openvswitch.yml
@@ -58,6 +58,14 @@ jobs:
             sudo pip install ovs==2.16.0
             sudo apt-get install --yes --allow-downgrades ./*.deb
 
+      - name: Verify distribution
+        run: |
+          if [ ${{ env.distribution }} != 'focal-ci' ] && [[ ! ${{ env.distribution }} =~ ^focal-1\.[0-9]+\.[0-9]+$ ]]; then
+              echo "You have chosen 'distribution' ${{ env.distribution }} as input."
+              echo "ERROR: Distribution name format check fails. Only focal-1.x.y is allowed. Abort!"
+              exit 1
+          fi
+
       - name: Setup JFrog CLI
         id: jfrog-setup
         # Workaround because secrets are available in `env` but not in `if`
@@ -73,6 +81,7 @@ jobs:
         working-directory: ${{ env.DEST }}
         run: |
             for file in ./*.deb; do
+              file=${file:2}
               name=${file%%.deb}
               architecture=${name##*_}
               echo Architecture is ${architecture}

--- a/.github/workflows/magma-build-openvswitch.yml
+++ b/.github/workflows/magma-build-openvswitch.yml
@@ -1,0 +1,110 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Magma Build & Publish Open vSwitch Artifacts
+on:
+  push:
+    branches:
+      - master
+      - 'v1.*'
+    paths:
+      - third_party/gtp_ovs/ovs-gtp-patches/**
+      - .github/workflows/magma-build-openvswitch.yml
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+    branches:
+      - master
+      - 'v1.*'
+    paths:
+      - third_party/gtp_ovs/ovs-gtp-patches/**
+      - .github/workflows/magma-build-openvswitch.yml
+  schedule:
+    - cron: 36 4 * * 0
+  workflow_dispatch:
+    inputs:
+      production:
+        description: Is production build?
+        type: boolean
+        default: false
+      repository:
+        description: Repository to push to?
+        type: choice
+        default: magma-packages-test
+        options: [ magma-packages-test, magma-packages-prod ]
+        required: true
+      distribution:
+        description: Distribution to set?
+        default: 'focal-ci'
+        required: true
+
+jobs:
+  build-packages:
+    runs-on: ubuntu-20.04
+    env:
+      MAGMA_ROOT: ${{ github.workspace }}
+      DEST: ${{ github.workspace }}/deb_packages
+      repository: ${{ inputs.repository || 'magma-packages-test' }}
+      distribution: ${{ inputs.distribution || 'focal-ci' }}
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+      - name: Build openvswitch
+        working-directory: third_party/gtp_ovs/ovs-gtp-patches/2.15
+        run: |
+          mkdir ${{ env.DEST }}
+          ./build.sh ${{ env.DEST }}
+
+      - name: Test installability of the debian package
+        working-directory: ${{ env.DEST }}
+        run: |
+            sudo pip install ovs==2.16.0
+            sudo apt-get install --yes --allow-downgrades ./*.deb
+
+      - name: Set repository to debian-test if not workflow_dispatch
+        run: echo "repository=debian-test" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/master' && github.event_name != 'workflow_dispatch'
+
+      - name: Verify inputs
+        run: |
+          echo "You have chosen 'repository' ${{ env.repository }} and 'is production' ${{ inputs.production }}."
+          echo "ERROR: Production deployment is protected. Abort!"
+          exit 1
+        if: |
+          env.repository == 'magma-packages-prod' &&
+          ! (
+            inputs.production &&
+            contains('["maxhbr", "nstng", "jheidbrink", "lkreutzer", "Neudrino", "MoritzThomasHuebner", "tmdzk", "wolfseb"]', github.actor)
+          )
+
+      - name: Setup JFrog CLI
+        id: jfrog-setup
+        # Workaround because secrets are available in `env` but not in `if`
+        if: ${{ env.JF_USER != '' && env.JF_PASSWORD != '' }}
+        uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
+        env:
+          JF_URL: https://linuxfoundation.jfrog.io/
+          JF_USER: ${{ secrets.LF_JFROG_USERNAME }}
+          JF_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
+
+      - name: Publish debian packages
+        if: steps.jfrog-setup.conclusion == 'success' && github.event_name == 'workflow_dispatch'
+        working-directory: ${{ env.DEST }}
+        run: |
+            for file in ./*.deb; do
+              name=${file%%.deb}
+              architecture=${name##*_}
+              echo Architecture is ${architecture}
+              jf rt upload \
+                --recursive=false \
+                --detailed-summary \
+                --target-props="deb.component=main;deb.distribution=${{ env.distribution }};deb.architecture=${architecture}" \
+                "(${file})" ${{ env.repository }}/pool/${{ env.distribution }}/{1}
+            done

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.15/build.sh
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.15/build.sh
@@ -1,10 +1,22 @@
 #! /bin/bash
+#
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-set -ex
+set -euox pipefail
 OVS_VER='2.15'
 DIR="ovs-build"
 DEST=$1
 
+sudo apt update
 sudo apt install -y build-essential linux-headers-generic
 sudo apt install -y dh-make debhelper dh-python devscripts python3-dev
 sudo apt install -y graphviz libssl-dev python3-all python3-sphinx libunbound-dev libunwind-dev


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

The PR provides a Github workflow that builds and publish Open vSwitch artifacts in the CI similar to other 3rd party dependencies. 

 - [x] Open vSwitch artifacts are created (see [workflow run](https://github.com/ajahl/magma/actions/runs/3601995435/jobs/6068430080))
 - [x] Test generated artifacts
 - [x] Generated Debian packages are uploaded ([workflow run](https://github.com/magma/magma/actions/runs/3639085822/jobs/6142054202), [Artifactory](https://linuxfoundation.jfrog.io/ui/native/magma-packages-test/pool/focal-ci/))
 - [x] Uploaded artifacts are successfully installed in Magma VM 

## Test Plan
 - [x] Run Integ Tests
 - [x] Run Sudo Tests

## Additional Information

