### PR TITLE
fix(ci): apply correct test target for extended integ tests in contai…

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -186,5 +186,5 @@ jobs:
       digest_python: ${{ needs.build-containers.outputs.digest_python }}
       digest_go: ${{ needs.build-containers.outputs.digest_go }}
       registry: ${{ needs.build-containers.outputs.registry }}
-      test_targets: extended
+      test_targets: extended_tests
     secrets: inherit


### PR DESCRIPTION
…nerized test workflow

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The currently used `extended` test target for the containerized AGW integ tests (via the `AGW Build, Publish & Test Container`) does not exist in `lte/gateway/python/integ_tests/Makefile`. The respective tests are failing, see for example [here](https://github.com/magma/magma/actions/runs/3620935896/jobs/6104657356#step:13:2155). The [correct target in the Makefile is `extended_tests`](https://github.com/magma/magma/blob/7eaba24c9003733864cbb37e9bab61ba3d2edd4c/lte/gateway/python/integ_tests/Makefile#L75).
Part of #14162.

## Test Plan

- [CI run](https://github.com/mpfirrmann/magma/actions/runs/3628682063)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
