### PR TITLE
ci: update devcontainer image version

### DIFF
--- a/.github/workflows/magma-build-3rd-party.yml
+++ b/.github/workflows/magma-build-3rd-party.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   build_dependencies:
     runs-on: ubuntu-20.04
-    container: ghcr.io/magma/magma/devcontainer:sha-385c134
+    container: ghcr.io/magma/magma/devcontainer:sha-84cfceb
     env:
       repository: ${{ inputs.repository || 'magma-packages-test' }}
       distribution: ${{ inputs.distribution || 'focal-ci' }}


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

This PR updates the devcontainer version used in the `Magma Build & Publish 3rd Party Dependencies` [Github workflow](https://github.com/magma/magma/actions/runs/3622548066/jobs/6107390189) since the old version is linked to the outdated magma artifactory.
