### PR TITLE
chore: update devcontainer in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 		"ryuta46.multi-command",
 		"coolchyni.beyond-debug"
 	],
-	"image": "ghcr.io/magma/magma/devcontainer:sha-385c134",
+	"image": "ghcr.io/magma/magma/devcontainer:sha-84cfceb",
 	"settings": {
 		"search.followSymlinks": false,
 		"terminal.integrated.profiles.linux": {


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

This PR updates the devcontainer image version used in the `devcontainer.json` since the old version is linked to the magma artifactory.

## Test Plan

run `sudo apt update` in the devcontainer 

## Additional Information

- [ ] This change is backwards-breaking
