### PR TITLE
chore(ci): Simplify FeG Lint & Test workflow

### DIFF
--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -73,19 +73,12 @@ jobs:
         if: always()
         id: feg-lint-init
         with:
-          command: cd ${MAGMA_ROOT}/cwf/gateway && go mod download
+          command: make -C ${MAGMA_ROOT}/feg/gateway download
           timeout_minutes: 10
-      - name: Go lint code
-        if: always() && steps.feg-lint-init.outcome=='success'
-        id: feg-lint
-        run: |
-          cd ${MAGMA_ROOT}/feg/gateway
-          make -C ${MAGMA_ROOT}/feg/gateway lint
       - name: Generate test coverage
         if: always() && steps.feg-lint.outcome=='success'
         id: feg-lint-cov
         run: |
-          cd ${MAGMA_ROOT}/feg/gateway
           make -C ${MAGMA_ROOT}/feg/gateway cover
       - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
         if: always()
@@ -93,12 +86,11 @@ jobs:
         with:
           files: '${{ env.MAGMA_ROOT}}/feg/gateway/coverage/feg.gocov'
           flags: feg-lint
-      - name: make feg precommit
+      - name: Run precommit steps
         if: always()
         id: feg-precommit
         run: |
           go install gotest.tools/gotestsum@v1.8.0
-          cd ${MAGMA_ROOT}/feg/gateway
           make -C ${MAGMA_ROOT}/feg/gateway precommit
       - name: Upload Test Results
         id: feg-precommit-upload


### PR DESCRIPTION
## Summary

- Removes the separate linting step because the linting is covered by the precommit step, see [here](https://github.com/magma/magma/blob/master/feg/gateway/Makefile#L71). This means it's being run twice on master
- Removes unnecessary directory changes before running make with the `-C` flag
- Uses `make download` for the `go mod download` step for consistency with how the other go commands are run. Note that on master this step is being done in `cwf/gateway`, not `feg/gateway`, which this also fixes
- Makes the name of the precommit step more consistent with the rest of the file

## Test Plan

- [CI run](https://github.com/magma/magma/actions/runs/3629648307/jobs/6122188097)