### PR TITLE
chore(ci): Centralize the bazel-diff call in a new job

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -67,14 +67,154 @@ jobs:
               - '**/*.bzl'
               - '.bazelrc'
 
-  bazel_build_and_test:
+  bazel_diff:
     needs: path_filter
-    # Only run workflow if this is a push to the magma repository,
-    # if the workflow has been triggered manually or if it is a pull_request.
+    name: Bazel-Diff Job
+    runs-on: ubuntu-20.04
+    outputs:
+      bazel_diff_ran: ${{ steps.bazel_diff_outputs.outputs.bazel_diff_ran }}
+      run_package_job: ${{ steps.bazel_diff_outputs.outputs.run_package_job }}
+      all_unit_test_targets: ${{ steps.bazel_diff_outputs.outputs.all_unit_test_targets }}
+      cc_unit_test_targets: ${{ steps.bazel_diff_outputs.outputs.cc_unit_test_targets }}
+      py_service_targets: ${{ steps.bazel_diff_outputs.outputs.py_service_targets }}
+    steps:
+      - name: Check Out Repo
+        # This if condition is placed on the step level instead of
+        # the job level, because otherwise 'success()' does not return
+        # 'true' for later jobs if the bazel_diff job is skipped.
+        if: needs.path_filter.outputs.files_changed == 'true'
+        # This is necessary for overlays into the Docker container below.
+        # The value of fetch-depth needs to exceed the maximum number of commits
+        # on all PRs. This is needed for bazel-diff to check out the merge-base.
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        with:
+          fetch-depth: 100
+      - name: Setup Bazel Base Image
+        if: needs.path_filter.outputs.files_changed == 'true'
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the bazel base image!"
+      - name: Run bazel-diff
+        if: needs.path_filter.outputs.files_changed == 'true'
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          shell: bash
+          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            cd /workspaces/magma
+            set -euo pipefail
+
+            # Required for bazel-diff to perform git checkout.
+            git config --global --add safe.directory /workspaces/magma
+
+            printf '\r%s\r' '###############################' 1>&2
+            printf '\r%s\r' 'Configuring bazel remote cache.' 1>&2
+            printf '\r%s\r\r' '###############################' 1>&2
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
+
+            printf '\r%s\r' '###############################' 1>&2
+            printf '\r%s\r' 'Bazel-diff.' 1>&2
+            printf '\r%s\r' '###############################' 1>&2
+            # Check if the workflow is run on a PR and whether the .bazelrc and WORKSPACE files have been affected.
+            IMPACTED_TARGETS_FILE="/tmp/impacted_targets.txt"
+            if [[ ("${{ github.event_name }}" == "pull_request") && \
+                  ! $(git diff-tree --no-commit-id --name-only -r "${{ github.event.pull_request.base.sha }}" "${{ github.SHA }}" | \
+                    grep -E '(.bazelrc|WORKSPACE.bazel)') \
+                ]];
+            then
+              printf '\r%s\r' 'Running bazel-diff...' 1>&2
+              bazel/scripts/bazel_diff.sh "${{ github.event.pull_request.base.sha }}"  "${{ github.SHA }}" | tee "$IMPACTED_TARGETS_FILE"
+              printf "bazel_diff_ran=true" > /workspaces/magma/bazel_diff_ran.txt
+            else
+              printf '\r%s\r' 'WORKSPACE or .bazelrc files have been modified or trigger is not a pull-request.' 1>&2
+              printf '\r%s\r' 'Skipping bazel-diff ...' 1>&2
+              printf "bazel_diff_ran=false" > /workspaces/magma/bazel_diff_ran.txt
+              exit 0
+            fi
+
+            # Check if impacted_targets.txt is empty, if yes skip all jobs.
+            if [[ ! -s "$IMPACTED_TARGETS_FILE" ]];
+            then
+              printf '\r%s\r' 'No relevant bazel targets are impacted, skipping all jobs.' 1>&2
+              printf "run_package_job=false" > /workspaces/magma/run_package_job.txt
+              printf "" > /workspaces/magma/all_unit_test_targets.txt
+              printf "" > /workspaces/magma/cc_unit_test_targets.txt
+              printf "" > /workspaces/magma/py_service_targets.txt
+              exit 0
+            fi
+
+            # Determine if the release is contained in the impacted targets list.
+            if ! grep --quiet '//lte/gateway/release:release_build' "$IMPACTED_TARGETS_FILE";
+            then
+              printf '\r%s\r' 'Skipping release build, the packages are not affected by the changes.' 1>&2
+              printf "run_package_job=false" > /workspaces/magma/run_package_job.txt
+            else
+              printf '\r%s\r' 'The packages are affected by the changes, the release needs to be build.' 1>&2
+              printf "run_package_job=true" > /workspaces/magma/run_package_job.txt
+            fi
+
+            # Determine all impacted test targets of rule type '.*_test' that are not tagged as manual.
+            bazel/scripts/filter_test_targets.sh ".*_test" < "$IMPACTED_TARGETS_FILE" | tee "/workspaces/magma/all_unit_test_targets.txt"
+
+            # Determine all impacted cc_test targets that are not tagged as manual.
+            bazel/scripts/filter_test_targets.sh "cc_test" < "$IMPACTED_TARGETS_FILE" | tee "/workspaces/magma/cc_unit_test_targets.txt"
+
+            # Determine all impacted py_binary targets that are tagged as service.
+            bazel/scripts/filter_test_targets.sh "py_binary" "service" < "$IMPACTED_TARGETS_FILE" | tee "/workspaces/magma/py_service_targets.txt"
+      - name: Set job output values
+        if: needs.path_filter.outputs.files_changed == 'true'
+        shell: bash
+        id: bazel_diff_outputs
+        # This is necessary because the addnab/docker-run-action
+        # does not allow setting outputs from inside the container.
+        run: |
+          BAZEL_DIFF_RAN="$(cat bazel_diff_ran.txt)"
+          echo "BAZEL_DIFF_RAN: $BAZEL_DIFF_RAN"
+          echo "$BAZEL_DIFF_RAN" >> $GITHUB_OUTPUT
+
+          if [[ "$BAZEL_DIFF_RAN" == "bazel_diff_ran=true" ]];
+          then
+            RUN_PACKAGE_JOB="$(cat run_package_job.txt)"
+            echo "RUN_PACKAGE_JOB: $RUN_PACKAGE_JOB"
+            echo "$RUN_PACKAGE_JOB" >> $GITHUB_OUTPUT
+
+            ALL_UNIT_TEST_TARGETS="all_unit_test_targets=$(cat all_unit_test_targets.txt | tr '\n' ' ')"
+            echo "ALL_UNIT_TEST_TARGETS: $ALL_UNIT_TEST_TARGETS"
+            echo "$ALL_UNIT_TEST_TARGETS" >> $GITHUB_OUTPUT
+
+            CC_UNIT_TEST_TARGETS="cc_unit_test_targets=$(cat cc_unit_test_targets.txt | tr '\n' ' ')"
+            echo "CC_UNIT_TEST_TARGETS: $CC_UNIT_TEST_TARGETS"
+            echo "$CC_UNIT_TEST_TARGETS" >> $GITHUB_OUTPUT
+
+            PY_SERVICE_TARGETS="py_service_targets=$(cat py_service_targets.txt | tr '\n' ' ')"
+            echo "PY_SERVICE_TARGETS: $PY_SERVICE_TARGETS"
+            echo "$PY_SERVICE_TARGETS" >> $GITHUB_OUTPUT
+          fi
+      - name: Notify failure to slack
+        if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
+        uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: "Bazel-Diff Job"
+          SLACK_USERNAME: ${{ github.workflow }}
+          SLACK_ICON_EMOJI: ":boom:"
+          SLACK_COLOR: "#FF0000"
+          SLACK_FOOTER: ' '
+          MSG_MINIMAL: actions url,commit
+
+  bazel_build_and_test:
+    needs: bazel_diff
     if: |
       (github.event_name == 'push' && github.repository_owner == 'magma') ||
-      needs.path_filter.outputs.files_changed == 'true' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      needs.bazel_diff.outputs.bazel_diff_ran == 'false' ||
+      (needs.bazel_diff.outputs.bazel_diff_ran == 'true' && needs.bazel_diff.outputs.all_unit_test_targets != '')
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +225,7 @@ jobs:
             bazel-target-rule: "cc_test"
           - bazel-config: "--config=production"
             bazel-target-rule: "cc_test"
-    name: Bazel Build & Test Job
+    name: Bazel Test Job
     runs-on: ubuntu-20.04
     steps:
       - name: Print variables
@@ -94,13 +234,12 @@ jobs:
           echo "github.repository_owner: ${{ github.repository_owner }}"
           echo "github.ref_name: ${{ github.ref_name }}"
           echo "inputs.publish_bazel_profile: ${{ inputs.publish_bazel_profile }}"
+          echo "needs.bazel_diff.outputs.bazel_diff_ran: ${{ needs.bazel_diff.outputs.bazel_diff_ran }}"
+          echo "needs.bazel_diff.outputs.all_unit_test_targets: ${{ needs.bazel_diff.outputs.all_unit_test_targets }}"
+          echo "needs.bazel_diff.outputs.cc_unit_test_targets: ${{ needs.bazel_diff.outputs.cc_unit_test_targets }}"
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        # The value of fetch-depth needs to exceed the maximum number of commits
-        # on all PRs. This is needed for bazel-diff to check out the merge-base.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-        with:
-          fetch-depth: 100
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Setup Bazel Base Image
@@ -122,9 +261,6 @@ jobs:
             cd /workspaces/magma
             set -euo pipefail
 
-            # Required for bazel-diff to perform git checkout.
-            git config --global --add safe.directory /workspaces/magma
-
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Configuring bazel remote cache.' 1>&2
             printf '\r%s\r\r' '###############################' 1>&2
@@ -133,19 +269,21 @@ jobs:
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Determining bazel test targets.' 1>&2
             printf '\r%s\r' '###############################' 1>&2
-            # Check that the workflow is run on a PR and that the .bazelrc and WORKSPACE files have not been affected.
-            if [[ ("${{ github.event_name }}" == "pull_request") && \
-                  ! $(git diff-tree --no-commit-id --name-only -r "${{ github.event.pull_request.base.sha }}" "${{ github.SHA }}" | \
-                    grep -E '(.bazelrc|WORKSPACE.bazel)') \
-                ]];
+            if [[ "${{ needs.bazel_diff.outputs.bazel_diff_ran }}" == 'true' ]];
             then
-              printf '\r%s\r' 'Determining targets via bazel-diff ...' 1>&2
-              IMPACTED_TARGETS_FILE="/tmp/impacted_targets.txt"
-              bazel/scripts/bazel_diff.sh "${{ github.event.pull_request.base.sha }}"  "${{ github.SHA }}" | tee "$IMPACTED_TARGETS_FILE"
-
-              printf '\r%s\r' 'Determining impacted test targets ...' 1>&2
-              # Choose all impacted test targets of type 'matrix.bazel-target-rule' that are not tagged as manual.
-              TEST_TARGETS=$(bazel/scripts/filter_test_targets.sh "${{ matrix.bazel-target-rule }}" < "$IMPACTED_TARGETS_FILE")
+              if [[ "${{ matrix.bazel-target-rule }}" == '.*_test' ]];
+              then
+                TEST_TARGETS="${{ needs.bazel_diff.outputs.all_unit_test_targets }}"
+              else
+                TEST_TARGETS="${{ needs.bazel_diff.outputs.cc_unit_test_targets }}"
+                if [[ -z "$TEST_TARGETS" ]];
+                then
+                  printf '\r%s\r' 'No test targets of type ${{ matrix.bazel-target-rule }} are impacted by the changes.' 1>&2
+                  printf '\r%s\r' 'No tests will be executed.' 1>&2
+                  exit 0
+                fi
+              fi
+              printf '\r%s\r' "The test targets of rule type ${{ matrix.bazel-target-rule }} to be executed are:" 1>&2
               printf '\r%s\r' "$TEST_TARGETS" 1>&2
             else
               printf '\r%s\r' 'Running all unit test targets of type ${{ matrix.bazel-target-rule }}.' 1>&2
@@ -166,8 +304,9 @@ jobs:
                 --test_output=errors \
                 --profile=Bazel_test_all_profile || TEST_FAILED="true"
             else
-              printf '\r%s\r' 'No test targets of type ${{ matrix.bazel-target-rule }} were impacted by the changes.' 1>&2
+              printf '\r%s\r' 'No test targets of type ${{ matrix.bazel-target-rule }} are impacted by the changes.' 1>&2
               printf '\r%s\r' 'No tests will be executed.' 1>&2
+              exit 0
             fi
 
             # Create Bazel unit-test results
@@ -220,7 +359,7 @@ jobs:
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Bazel Build & Test Job `bazel test //...` ${{ matrix.bazel-config }}"
+          SLACK_TITLE: "Bazel Test Job `bazel test //...` ${{ matrix.bazel-config }}"
           SLACK_USERNAME: ${{ github.workflow }}
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
@@ -247,11 +386,13 @@ jobs:
     if: always()
     # This job always needs to run. It will be green if the bazel_build_and_test
     # job was successful in all matrix jobs or if the job was skipped.
-    needs: [path_filter, bazel_build_and_test, if_bazel_build_and_test_success]
+    needs: [path_filter, bazel_build_and_test, if_bazel_build_and_test_success, bazel_diff]
     steps:
       - run: |
           bazel_build_and_test_success="${{ needs.if_bazel_build_and_test_success.outputs.success }}"
           files_changed="${{ needs.path_filter.outputs.files_changed }}"
+          bazel_diff_ran="${{ needs.bazel_diff.outputs.bazel_diff_ran }}"
+          all_unit_test_targets="${{ needs.bazel_diff.outputs.all_unit_test_targets }}"
 
           echo "The status of this job is determined by the statuses of the previous jobs in this workflow."
           echo "For more details on this matrix workflow please look at the following wiki page or the PR #13562:"
@@ -260,8 +401,14 @@ jobs:
 
           echo "bazel_build_and_test_success: $bazel_build_and_test_success"
           echo "files_changed: $files_changed"
+          echo "bazel_diff_ran: $bazel_diff_ran"
+          echo "all_unit_test_targets: $all_unit_test_targets"
 
-          if [[ $bazel_build_and_test_success == "true" || $files_changed != "true" ]];
+          if [[ \
+              "$bazel_build_and_test_success" == "true" || \
+              "$files_changed" != "true" || \
+              ("$bazel_diff_ran" == "true" && -z "$all_unit_test_targets") \
+              ]];
           then
             echo "Bazel build and test job passed or was skipped"
             exit 0
@@ -315,23 +462,18 @@ jobs:
           MSG_MINIMAL: actions url,commit
 
   python_import_check:
-    needs: path_filter
-    # Only run workflow if this is a push to the magma repository,
-    # if the workflow has been triggered manually or if it is a pull_request.
+    needs: [path_filter, bazel_diff]
     if: |
       (github.event_name == 'push' && github.repository_owner == 'magma') ||
-      needs.path_filter.outputs.files_changed == 'true' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      needs.bazel_diff.outputs.bazel_diff_ran == 'false' ||
+      (needs.bazel_diff.outputs.bazel_diff_ran == 'true' && needs.bazel_diff.outputs.py_service_targets != '')
     name: Bazel Python Import Check
     runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        # The value of fetch-depth needs to exceed the maximum number of commits
-        # on all PRs. This is needed for bazel-diff to check out the merge-base.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-        with:
-          fetch-depth: 100
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Setup Bazel Base Image
@@ -353,34 +495,23 @@ jobs:
             cd /workspaces/magma
             set -euo pipefail
 
-            # Required for bazel-diff to perform git checkout.
-            git config --global --add safe.directory /workspaces/magma
+            printf '\r%s\r' '###############################' 1>&2
+            printf '\r%s\r' 'Configuring bazel remote cache.' 1>&2
+            printf '\r%s\r\r' '###############################' 1>&2
+            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
 
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Determining bazel test targets.' 1>&2
             printf '\r%s\r' '###############################' 1>&2
-            # Check that the workflow is run on a PR and that the .bazelrc and WORKSPACE files have not been affected.
-            if [[ ("${{ github.event_name }}" == "pull_request") && \
-                  ! $(git diff-tree --no-commit-id --name-only -r "${{ github.event.pull_request.base.sha }}" "${{ github.SHA }}" | \
-                    grep -E '(.bazelrc|WORKSPACE.bazel)') \
-                ]];
+            if [[ "${{ needs.bazel_diff.outputs.bazel_diff_ran }}" == 'true' ]];
             then
-              printf '\r%s\r' 'Determining targets via bazel-diff ...' 1>&2
-              IMPACTED_TARGETS_FILE="/tmp/impacted_targets.txt"
-              bazel/scripts/bazel_diff.sh "${{ github.event.pull_request.base.sha }}"  "${{ github.SHA }}" | tee "$IMPACTED_TARGETS_FILE"
-              printf '\r%s\r' 'Determining impacted targets ...' 1>&2
-              # Choose all impacted targets of type 'py_binary' that are tagged as service.
-              TEST_TARGETS=$(bazel/scripts/filter_test_targets.sh "py_binary" "service" < "$IMPACTED_TARGETS_FILE")
+              TEST_TARGETS="${{ needs.bazel_diff.outputs.py_service_targets }}"
+              printf '\r%s\r' 'The service test targets of type py_binary are:' 1>&2
               printf '\r%s\r' "$TEST_TARGETS" 1>&2
             else
               printf '\r%s\r' 'Checking all service targets of type "py_binary" for ModuleNotFoundError.' 1>&2
               TEST_TARGETS="ALL_PYTHON_SERVICE_TARGETS"
             fi
-
-            printf '\r%s\r' '###############################' 1>&2
-            printf '\r%s\r' 'Configuring bazel remote cache.' 1>&2
-            printf '\r%s\r\r' '###############################' 1>&2
-            bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
 
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Executing python import bazelification check.' 1>&2
@@ -389,13 +520,13 @@ jobs:
             then
               if [[ "${TEST_TARGETS}" == "ALL_PYTHON_SERVICE_TARGETS" ]];
               then
-                bazel/scripts/test_python_service_imports.sh;
+                bazel/scripts/test_python_service_imports.sh 1>&2;
               else
                 # Converting string of whitespace separated targets into an array
                 TEST_TARGETS=( $TEST_TARGETS )
                 for target in "${TEST_TARGETS[@]}"
                 do
-                  bazel/scripts/test_python_service_imports.sh $target;
+                  bazel/scripts/test_python_service_imports.sh "$target" 1>&2;
                 done
               fi
             else
@@ -420,23 +551,18 @@ jobs:
           MSG_MINIMAL: actions url,commit
 
   bazel_package:
-    needs: path_filter
-    # Only run workflow if this is a push to the magma repository,
-    # if the workflow has been triggered manually or if it is a pull_request.
+    needs: [path_filter, bazel_diff]
     if: |
       (github.event_name == 'push' && github.repository_owner == 'magma') ||
-      needs.path_filter.outputs.files_changed == 'true' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      needs.bazel_diff.outputs.bazel_diff_ran == 'false' ||
+      (needs.bazel_diff.outputs.bazel_diff_ran == 'true' && needs.bazel_diff.outputs.run_package_job == 'true')
     name: Bazel Package Job
     runs-on: ubuntu-20.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        # The value of fetch-depth needs to exceed the maximum number of commits
-        # on all PRs. This is needed for bazel-diff to check out the merge-base.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-        with:
-          fetch-depth: 100
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Setup Bazel Base Image
@@ -458,56 +584,23 @@ jobs:
             cd /workspaces/magma
             set -euo pipefail
 
-            # Required for bazel-diff to perform git checkout.
-            git config --global --add safe.directory /workspaces/magma
-
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Configuring bazel remote cache.' 1>&2
             printf '\r%s\r\r' '###############################' 1>&2
             bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}"
 
             printf '\r%s\r' '###############################' 1>&2
-            printf '\r%s\r' 'Determining if release has to be build.' 1>&2
+            printf '\r%s\r' 'Building the release package.' 1>&2
             printf '\r%s\r' '###############################' 1>&2
-            # Check if the workflow is run on a PR and whether the .bazelrc and WORKSPACE files have been affected.
-            if [[ ("${{ github.event_name }}" == "pull_request") && \
-                  ! $(git diff-tree --no-commit-id --name-only -r "${{ github.event.pull_request.base.sha }}" "${{ github.SHA }}" | \
-                    grep -E '(.bazelrc|WORKSPACE.bazel)') \
-                ]];
-            then
-              printf '\r%s\r' 'Determining whether the release target (//lte/gateway/release:release_build) was affected ...' 1>&2
-              IMPACTED_TARGETS_FILE="/tmp/impacted_targets.txt"
-              bazel/scripts/bazel_diff.sh "${{ github.event.pull_request.base.sha }}"  "${{ github.SHA }}" | tee "$IMPACTED_TARGETS_FILE"
-              if [[ -z "$(grep '//lte/gateway/release:release_build' "$IMPACTED_TARGETS_FILE")" ]];
-              then
-                printf '\r%s\r' 'Skipping release build, the packages are not affected by the changes.' 1>&2
-                echo "package_was_built=false" > /workspaces/magma/build_status.txt
-                exit 0
-              else
-                printf '\r%s\r' 'The packages are affected by the changes, building the release ...' 1>&2
-              fi
-            fi
 
             bazel run //lte/gateway/release:release_build \
               --config=production \
               --profile=Bazel_build_package_profile
-            echo "package_was_built=true" > /workspaces/magma/build_status.txt
 
             mkdir packages
             mv /tmp/packages/*.deb packages
 
-      - name: Output value of 'package_was_built'
-        shell: bash
-        id: package_build_status
-        # This is necessary because the addnab/docker-run-action
-        # does not allow setting outputs from inside the container.
-        run: |
-          PACKAGE_BUILD_STATUS="$(cat build_status.txt)"
-          echo "$PACKAGE_BUILD_STATUS"
-          echo "$PACKAGE_BUILD_STATUS" >> $GITHUB_OUTPUT
-
       - name: Get magma version
-        if: ${{ steps.package_build_status.outputs.package_was_built == 'true' }}
         run: |
           version_pattern="magma_([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-[a-z0-9]+)_amd64.deb"
           for i in packages/*.deb; do
@@ -525,7 +618,6 @@ jobs:
           fi
 
       - name: Setup JFROG CLI
-        if: ${{ steps.package_build_status.outputs.package_was_built == 'true' }}
         uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
 
       - name: Set dry run environment variable
@@ -534,7 +626,6 @@ jobs:
           echo "IS_DRY=--dry-run" >> $GITHUB_ENV
 
       - name: Publish debian packages
-        if: ${{ steps.package_build_status.outputs.package_was_built == 'true' }}
         env:
           DEBIAN_META_INFO: deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64
         run: |
@@ -553,8 +644,7 @@ jobs:
         if: |
           github.event_name == 'push' &&
           github.repository_owner == 'magma' &&
-          github.ref_name == 'master' &&
-          steps.package_build_status.outputs.package_was_built == 'true'
+          github.ref_name == 'master'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: magma/magma
@@ -565,14 +655,12 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: |
           always() &&
-          github.event.inputs.publish_bazel_profile == 'true' &&
-          steps.package_build_status.outputs.package_was_built == 'true'
+          github.event.inputs.publish_bazel_profile == 'true'
         with:
           name: Bazel build package profile
           path: Bazel_build_package_profile
 
       - name: Build space left after run
-        if: ${{ steps.package_build_status.outputs.package_was_built == 'true' }}
         shell: bash
         run: |
           echo "Available storage:"


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #14553 
- Bazel-diff is executed at most once and the result controls the jobs that depend on it.
- Bazel-diff is only used on PRs.
- Job flow diagram:
![Screenshot from 2022-12-06 16-42-47](https://user-images.githubusercontent.com/34488763/205957281-14775591-1489-44ae-bcbd-3c57353c31d2.png)
- Job schematic:
![Screenshot from 2022-12-05 13-53-39](https://user-images.githubusercontent.com/34488763/205921635-cde1b007-3efb-4d9a-a1ca-6e1f6fb9dc60.png)
 

## Test Plan

- No changes: https://github.com/magma/magma/actions/runs/3628624756
- Changes to release, several python services, cc_test, go_test, py_test: https://github.com/magma/magma/actions/runs/3628677922
- Changes to release, python tests and one python service: https://github.com/magma/magma/actions/runs/3628329614/jobs/6119219562
- Changes to cc_test only (some jobs cancelled at the end due to push on the branch): https://github.com/magma/magma/actions/runs/3628767447
- Changes to python services (only main.py): https://github.com/magma/magma/actions/runs/3628876258
- Manual run on fork, no changes: https://github.com/LKreutzer/magma/actions/runs/3629554306


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
