### PR TITLE
docs(agw): Remove make command from containerized AGW documentation

### DIFF
--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -38,7 +38,9 @@ The magma VM defined in [../Vagrantfile](../Vagrantfile) can be used to run the
 containerized AGW by running the following steps inside the VM:
 
 ```
-cd $MAGMA_ROOT/lte/gateway && make build  # You can skip this if you have built the AGW with make before
+sudo rm -rf /etc/snowflake && sudo touch /etc/snowflake
+cd $MAGMA_ROOT && bazel/scripts/link_scripts_for_bazel_integ_tests.sh
+bazel build `bazel query "attr(tags, util_script, kind(.*_binary, //orc8r/... union //lte/... union //feg/... except //lte/gateway/c/core:mme_oai))"`
 for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done
 sed -i 's/init_system: systemd/init_system: docker/' "${MAGMA_ROOT}"/lte/gateway/configs/magmad.yml
 sudo systemctl start magma_dp@envoy


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

As part of the Bazel switchover we are getting rid of make related commands and documentation. This PR replaces the `make` command in the conrainerized AGW documentation with new ones.
This PR closes #14391.

## Test Plan

1. Follow the documentation steps to set up containerized AGW in the gateway VM
2. Run the s1ap tests on the test VM with make or with bazel

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
