### PR TITLE
chore(ci): bump `gabrielfalcao/pyenv-action`version to remove depreca…

### DIFF
--- a/.github/workflows/agw-docker-load-test.yml
+++ b/.github/workflows/agw-docker-load-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run apt
         run: sudo apt-get update && sudo apt -y upgrade
       - name: setup pyenv
-        uses: "gabrielfalcao/pyenv-action@5327db2939908b2ef8f62d284403d678c4b611d0" # pin@v8
+        uses: "gabrielfalcao/pyenv-action@c35d86605f074d0c7ce32e4aa79ef91645a57f14" # pin@v11
         with:
           default: 3.8.10
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0


### PR DESCRIPTION
…tions warning

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Summary
GitHub deprecated `save-state` and `save-output` workflow commands with its recent update to `@actions/core` package to v1.10.0. This PR bumps the version of the third party library `gabrielfalcao/pyenv-action` from v8 to the latest version v11 with adapted commands.
Closes #14471.

## Test Plan
- Full text search on repository for `gabrielfalcao/pyenv-action`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
