### PR TITLE
refactor(agw): replace scapy in icmpv6.py

### DIFF
--- a/lte/gateway/python/scripts/BUILD.bazel
+++ b/lte/gateway/python/scripts/BUILD.bazel
@@ -275,7 +275,10 @@ py_binary(
     srcs = ["icmpv6.py"],
     legacy_create_init = False,
     tags = TAG_UTIL_SCRIPT,
-    deps = [requirement("scapy")],
+    deps = [
+        "//lte/gateway/python/magma/pipelined:ifaces",
+        requirement("dpkt"),
+    ],
 )
 
 py_binary(

--- a/lte/gateway/python/scripts/icmpv6.py
+++ b/lte/gateway/python/scripts/icmpv6.py
@@ -1,23 +1,47 @@
-""" Script to send icmpv6 data"""
+#!/usr/bin/env python3
+
+"""
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import binascii
+import socket
 import sys
 import time
 
-from scapy.all import Ether, ICMPv6EchoRequest, IPv6, sendp
+from dpkt import ethernet, icmp6, ip, ip6
+from magma.pipelined.ifaces import get_mac_address_from_iface
 
 dst = sys.argv[1]
 
 print("dst: %s" % dst)
 
+src_ip = socket.inet_pton(socket.AF_INET6, "2001::2")
+dst_ip = socket.inet_pton(socket.AF_INET6, dst)
+src_mac = get_mac_address_from_iface("eth0")
+src_mac_as_bytes = binascii.unhexlify(src_mac.replace(':', ''))
 
-eth = Ether()
+pkt = icmp6.ICMP6(type=icmp6.ICMP6_ECHO_REQUEST, data=icmp6.ICMP6.Echo())
+pkt = ip6.IP6(
+    src=src_ip, dst=dst_ip,
+    plen=8, nxt=ip.IP_PROTO_ICMP6,
+    hlim=64, data=bytes(pkt),
+)
+pkt = ethernet.Ethernet(
+    src=src_mac_as_bytes, dst=b'\xff' * 6,
+    type=ethernet.ETH_TYPE_IP6, data=bytes(pkt),
+)
 
-i = IPv6()
-i.dst = dst  # UE_IP
-i.src = "2001::2"
-
-q = ICMPv6EchoRequest()
-
-packet_icmp = eth / i / q
-for _ in range(1):
-    sendp(packet_icmp, iface="gtp_br0", count=1)
+with socket.socket(socket.AF_PACKET, socket.SOCK_RAW) as sock:
+    sock.bind(("gtp_br0", 0))
+    sock.send(bytes(pkt))
     time.sleep(0.5)


### PR DESCRIPTION
Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>

With @MoritzThomasHuebner 

## Summary

- Replaces scapy in the script `icmpv6.py` with `dpkt` and `socket`.
- Added a license header to the script.

## Test Plan

- [x] Run integration tests `test_ip{v6, v4v6}_paging_with_dedicated_bearer`, which use the script
- [x] Check manually that the packets are identical after our changes.

## Additional Information

- [ ] This change is backwards-breaking

