### PR TITLE
refactor(agw): replace scapy in packet_ryu_cli

### DIFF
--- a/lte/gateway/python/scripts/BUILD.bazel
+++ b/lte/gateway/python/scripts/BUILD.bazel
@@ -330,7 +330,7 @@ py_binary(
     tags = TAG_UTIL_SCRIPT,
     deps = [
         "//lte/gateway/python/integ_tests/s1aptests/ovs:rest_api",
-        requirement("scapy"),
+        requirement("dpkt"),
     ],
 )
 


### PR DESCRIPTION
Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>

With @MoritzThomasHuebner 

## Summary

Replace scapy with dkpt and socket in `packet_ryu_cli.py`
It's not really clear if this is used anywhere.

## Test Plan
- [x] Manually check that the created packets are identical
- [x] Run CI
## Additional Information

- [ ] This change is backwards-breaking
