### PR TITLE
chore(ci): Use pre-built buildifier in CI

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -284,24 +284,13 @@ jobs:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - name: Setup Bazel Base Image
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
-        with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
-          options: --pull always
-          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
-          run: |
-            echo "Pulled the bazel base image!"
       - name: Run starlark format check
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
-        with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
-          shell: bash
-          # TODO: Remove work-around mount of Github workspace to /magma (https://github.com/addnab/docker-run-action/issues/11)
-          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
-          run: |
-            cd /workspaces/magma
-            bazel run //:check_starlark_format
+        shell: bash
+        run: |
+          echo "To run this check locally use: ./bazel/scripts/run_buildifier.sh check"
+          echo "To fix any errors locally use: ./bazel/scripts/run_buildifier.sh format"
+          echo "Depending on the environment this may require using 'sudo'."
+          sudo ./bazel/scripts/run_buildifier.sh check
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0

--- a/bazel/scripts/run_buildifier.sh
+++ b/bazel/scripts/run_buildifier.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -euo pipefail
+
+###############################################################################
+# SCRIPT SECTION
+###############################################################################
+
+# This is a wrapper script for the bazel buildifier. Further information can be
+# found at https://github.com/bazelbuild/buildtools/tree/master/buildifier#readme
+
+BUILDIFIER_URL="https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64"
+BUILDIFIER_PATH="/usr/bin"
+BUILDIFIER_EXECUTABLE="$BUILDIFIER_PATH/buildifier-linux-amd64"
+
+# Command line argument, can be either 'check' or 'format'.
+BUILDIFIER_MODE="${1:-}"
+
+case "$BUILDIFIER_MODE" in
+    "check")
+        BUILDIFIER_OPTIONS=("-mode=diff" "--lint=warn" "--warnings=-unused-variable" "-v=true")
+        ;;
+    "format")
+        BUILDIFIER_OPTIONS=("-mode=fix" "--lint=fix" "--warnings=all")
+        ;;
+    *)
+        echo "Invalid argument '$BUILDIFIER_MODE'."
+        echo "Valid arguments are 'check' or 'format'."
+        exit 1
+        ;;
+esac
+
+# Check if the Buildifier executable is already present on the system.
+if [[ -s "$BUILDIFIER_EXECUTABLE" ]];
+then
+    echo "Buildifier executable is already present, skipping download."
+else
+    echo "Downloading pre-built buildifier ..."
+    wget --quiet --directory-prefix "$BUILDIFIER_PATH" "$BUILDIFIER_URL"
+    chmod +x "$BUILDIFIER_EXECUTABLE"
+    echo "Download successful."
+fi
+
+if [[ -z "${MAGMA_ROOT:-}" ]];
+then
+  echo "Warning: 'MAGMA_ROOT' is not set, defaulting to current directory."
+  echo "This script should be run from the base of the magma repository."
+  WORKING_DIR="./"
+else
+  WORKING_DIR="$MAGMA_ROOT"
+fi
+
+echo "Running bazel buildifier with the following command:"
+set -x
+# The '-r' option is used to find starlark files recursively in the WORKING_DIR.
+"$BUILDIFIER_EXECUTABLE" "${BUILDIFIER_OPTIONS[@]}" -r "$WORKING_DIR"


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #14551
- Download pre-built buildifier from release and use in CI job.
- Upgrade to version `5.1.0`
- Requires https://github.com/magma/magma/pull/14642
- Clean up of the bazel integrated buildifier and all its depencies will be handled separately in a follow up.

## Test Plan

- Run the script with: 
  - `./bazel/scripts/run_buildifier.sh check`
  - `./bazel/scripts/run_buildifier.sh format`
- Run on PR with problems: https://github.com/magma/magma/actions/runs/3639385015/jobs/6142705045
- Run on PR without problems: https://github.com/magma/magma/actions/runs/3639867123/jobs/6143799854

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
