### PR TITLE
chore: Enable remote cache compression for Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,10 @@ build:production --define=production=1
 # a target to the actions' execution requirements.
 # See https://github.com/bazelbuild/bazel/issues/8830 for details.
 common --experimental_allow_tags_propagation
+# experimental_remote_cache_compression enables compression and decompression
+# of cache blocks with zstd. This reduces the remote cache traffic, local cache
+# size is not affected.
+common --experimental_remote_cache_compression
 
 # C/C++ CONFIGS
 build --cxxopt=-std=c++14


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The flag `--experimental_remote_cache_compression` enables compression and decompression of cache blobs, therefore reducing the cache traffic. Local caches are not affected.
This closes #14557.

## Test Plan

I used [build-buddy](https://github.com/magma/magma/wiki/Bazel-cache-analysis) to measure cache usage. Here two values were provided, the full size and compressed size. It was not straightforward if the compressed size only refers to the stored value or if it is also downloaded in compressed form. I created a local experiment to analyze traffic between my computer and the website:

(Disclaimer: I'm not a network expert, there are probably easier/prettier ways to achieve the same result.)
1. Figuring out IP addresses
    a) start tcpdump `sudo tcpdump -i eth0`
    b) start any build `bazel build //...`
    c) stop tcpdump after the build had run for 20 seconds `Ctrl + C`
    d) there should be 2 IP addresses in the output communicating
2. Use them to filter results: `sudo tcpdump -i eth0 -nn src FIRST_IP_ADDRESS or SECOND_IP_ADDRESS > build_buddy.pcap`
3. Run the whole build while tcpdump is running
4. Get the traffic size in bytes: `cat build_buddy.pcap | grep length | sed 's/.*length//' | awk '{s+=$1} END {print s}'`

The result I got was 968754554 bytes which is around 969MB, which is a lot smaller than the usual 4GB. The build-buddy results confirm these numbers.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
