### PR TITLE
chore(agw): Fix deprecated attributes in bazel dependencies

### DIFF
--- a/bazel/asn1c.bzl
+++ b/bazel/asn1c.bzl
@@ -120,7 +120,7 @@ def _get_attrs():
         "_asn1c": attr.label(
             executable = True,
             default = Label("@system_libraries//:asn1c"),
-            cfg = "host",
+            cfg = "exec",
         ),
     }
 

--- a/bazel/python_swagger.bzl
+++ b/bazel/python_swagger.bzl
@@ -106,7 +106,7 @@ py_swagger = rule(
             providers = [java_common.JavaRuntimeInfo],
         ),
         "_swagger_cli": attr.label(
-            cfg = "host",
+            cfg = "exec",
             default = Label("@maven_swagger_codegen_cli//jar"),
             allow_single_file = True,
         ),


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Fix deprecated attributes in bazel dependencies
- See https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-cfg
- Preparation for https://github.com/magma/magma/issues/14551 as the new buildifier version will find this issue.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
