### PR TITLE
feat(ci): enable publishing of containerized LTE integ test results

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -188,3 +188,70 @@ jobs:
       registry: ${{ needs.build-containers.outputs.registry }}
       test_targets: extended_tests
     secrets: inherit
+
+  publish-container-test-results:
+    runs-on: ubuntu-20.04
+    if: always() && github.event_name == 'push'
+    needs: [test-containers-precommit, test-containers-extended]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+      - name: Create test_results directory
+        run: mkdir -p lte/gateway/test-results
+
+      - name: Download results of precommit tests
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        with:
+          name: test-results-precommit
+          path: "${{ github.workspace }}/lte/gateway/test-results"
+
+      - name: Download results of extended tests
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        with:
+          name: test-results-extended_tests
+          path: "${{ github.workspace }}/lte/gateway/test-results"
+
+      - name: Determine end result for both tests
+        run: |
+          echo "${{ needs.test-containers-precommit.outputs.final_status }}" > test_status_precommit.txt
+          echo "${{ needs.test-containers-extended.outputs.final_status }}" > test_status_extended.txt
+          diff test_status_precommit.txt test_status_extended.txt > /dev/null
+          if [ $? -eq 0 ]
+          then
+            mv test_status_precommit.txt test_status.txt
+          else
+            echo fail > test_status.txt
+          fi
+          rm test_status_*.txt
+
+      - name: Setup python
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+        with:
+          python-version: '3.8.10'
+
+      - name: Install pre-requisites
+        run: |
+          pip3 install --upgrade pip
+          pip3 install firebase_admin
+
+      - name: Publish results to Firebase
+        env:
+          FIREBASE_SERVICE_CONFIG: "${{ secrets.FIREBASE_SERVICE_CONFIG }}"
+          REPORT_FILENAME: "lte_integ_test_containerized${{ github.sha }}.html"
+        run: |
+          npm install -g xunit-viewer
+          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
+          [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
+          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} containerized_lte --url $URL
+
+      - name: Notify failure to slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK: "${{ secrets.SLACK_WEBHOOK }}"
+          SLACK_USERNAME: "${{ github.workflow }}"
+          SLACK_AVATAR: ":boom:"
+        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
+        with:
+          args: "Containerized LTE integration test failed on [${{ github.sha }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ github.sha }}): ${{ steps.commit.outputs.title}}"

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -50,6 +50,8 @@ on:
 
 jobs:
   lte-integ-test-containerized:
+    outputs:
+      final_status: ${{ steps.get_final_status.outputs.final_status }}
     runs-on: macos-12
     steps:
       - name: Show inputs
@@ -117,6 +119,15 @@ jobs:
         working-directory: lte/gateway
         run: |
           fab get_test_summaries:dst_path="test-results",sudo_tests=False,dev_vm_name="magma_deb"
+      - name: Get final status
+        id: get_final_status
+        if: always()
+        run: |
+          if [ -f test_status.txt ]
+          then
+            echo "final_status=$(cat test_status.txt)" >> $GITHUB_OUTPUT
+          else
+            echo "final_status=fail" >> $GITHUB_OUTPUT
       - name: Upload test results
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()

--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -88,6 +88,11 @@ def sudo_python_tests(args):
     prepare_and_publish('sudo_python_tests', args)
 
 
+def containerized_lte_integ_test(args):
+    """Prepare and publish containerized LTE Integ Test report"""
+    prepare_and_publish('containerized_lte_integ_test', args, 'test_status.txt')
+
+
 def prepare_and_publish(test_type: str, args, path: Optional[str] = None):
     """Prepare and publish test report"""
     report = url_to_html_redirect(args.run_id, args.url)
@@ -133,6 +138,7 @@ tests = {
     'cwf': cwf_integ_test,
     'sudo_python_tests': sudo_python_tests,
     'debian_lte_integ_test': debian_lte_integ_test,
+    'containerized_lte': containerized_lte_integ_test,
 }
 
 for key, value in tests.items():


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This enables the publishing of the LTE integration test results based on a containerized AGW. In order to do this ...

1. ... the `lte-integ-test-containerized.yml` returns the final `test_status`.
2. ... the `agw-build-publish-container.yml` downloads all `xml` files in the `test-results` folder and compares the two individual `test_status`' to conclude a final verdict.
3. ... the containerized LTE integ test job is added to the `firebase_publish_report.py` script.

Part of #14162.

## Test Plan

- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
