### PR TITLE
chore: rules_pkg is upgraded to a proper release version

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -157,13 +157,12 @@ load("//bazel:python_repositories.bzl", "python_repositories")
 
 python_repositories()
 
-# TODO: GH13522 upgrade to >0.7.0 when landed - see issue
 http_archive(
     name = "rules_pkg",
-    sha256 = "bdac8d3d178467c89f246e1e894b59c26c784569e91798901fb81291de834708",
-    strip_prefix = "rules_pkg-7f7bcf9c93bed9ee693b5bfedde5d72f9a2d6ea4",
+    sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
     urls = [
-        "https://github.com/bazelbuild/rules_pkg/archive/7f7bcf9c93bed9ee693b5bfedde5d72f9a2d6ea4.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

rules_pkg was imported on a master commit that fixes a problem that a created debian package that has an entry with more than 100 characters (path+filename) cannot be installed. The respective fix is included in the 0.8.0 release.

## Test Plan

Create a dummy file that is added to sctpd with more than 100 characters.
```
genrule(
    name = "foo",
    outs = ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
    cmd = "echo \"foo\" > \"$@\"",
)

pkg_files(
    name = "bar",
    srcs = [":foo"],
    prefix = "/foo",
)

pkg_tar(
    name = "sctpd_content",
    srcs = [
        ":bar",
...
```
Build package:
```
bazel build //lte/gateway/release:sctpd_deb_pkg
```
Try to install this file using 0.7.0 (without the fix):
```
vagrant@magma-dev:~/magma$ sudo apt install ./magma-sctpd_1.9.0-VERSION-SUFFIX_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'magma-sctpd' instead of './magma-sctpd_1.9.0-VERSION-SUFFIX_amd64.deb'
The following NEW packages will be installed:
  magma-sctpd
...
Unpacking magma-sctpd (1.9.0-VERSION-SUFFIX) ...
dpkg: error processing archive /home/vagrant/magma/magma-sctpd_1.9.0-VERSION-SUFFIX_amd64.deb (--unpack):
 corrupted filesystem tarfile in package archive: unsupported PAX tar header type 'x'
Errors were encountered while processing:
 /home/vagrant/magma/magma-sctpd_1.9.0-VERSION-SUFFIX_amd64.deb
```
Do the same using 0.8.0 (with fix):
```
vagrant@magma-dev:~/magma$ sudo apt install ./magma-sctpd_1.9.0-VERSION-SUFFIX_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'magma-sctpd' instead of './magma-sctpd_1.9.0-VERSION-SUFFIX_amd64.deb'
The following NEW packages will be installed:
  magma-sctpd
...
Unpacking magma-sctpd (1.9.0-VERSION-SUFFIX) ...
Setting up magma-sctpd (1.9.0-VERSION-SUFFIX) ...
vagrant@magma-dev:~/magma$ echo $?
0
```

Other (unexpected!) issues might be discovered when the created packages are run in the integration tests (post master merge).

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
