### PR TITLE
fix: add correct repo version

### DIFF
--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -110,7 +110,7 @@ RUN git clone --depth 1 --branch v2021.02.15.00 https://github.com/facebook/foll
 # setup magma artifactories and install magma dependencies
 RUN wget -qO - https://linuxfoundation.jfrog.io/artifactory/api/security/keypair/magmaci/public | apt-key add - && \
     add-apt-repository 'deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main' && \
-    add-apt-repository 'deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.7.0 main' && \
+    add-apt-repository 'deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.8.0 main' && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bcc-tools \


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

PR adds the correct `focal-1.8.0` LF artifactory repository to the Dockerfile. This was overlooked in the 1.8 release.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
