### PR TITLE
chore(agw): Clean up integrated buildifier setup and update docs

### DIFF
--- a/.devcontainer/bazel-base/README.md
+++ b/.devcontainer/bazel-base/README.md
@@ -43,8 +43,8 @@ bazel test ...
 
 ## Format bazel files
 
-To format all bazel related files, exec into a bazel container and run the following
+To format all bazel related files run the following
 
 ```bash
-bazel run //:buildifier
+$MAGMA_ROOT/bazel/scripts/run_buildifier.sh format
 ```

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -436,8 +436,7 @@ jobs:
         run: |
           echo "To run this check locally use: ./bazel/scripts/run_buildifier.sh check"
           echo "To fix any errors locally use: ./bazel/scripts/run_buildifier.sh format"
-          echo "Depending on the environment this may require using 'sudo'."
-          sudo ./bazel/scripts/run_buildifier.sh check
+          ./bazel/scripts/run_buildifier.sh check
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push' && github.repository_owner == 'magma'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,56 +10,7 @@
 # limitations under the License.
 
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier", "buildifier_test")
 load("@rules_java//java:defs.bzl", "java_binary")
-
-buildifier(
-    name = "buildifier",
-    lint_mode = "fix",
-    lint_warnings = ["all"],
-    mode = "fix",
-)
-
-buildifier_test(
-    name = "check_starlark_format",
-    size = "small",
-    timeout = "short",
-    srcs = ["//:starlark_files"],
-    lint_mode = "warn",
-    lint_warnings = ["-unused-variable"],
-    verbose = True,
-)
-
-filegroup(
-    name = "starlark_files",
-    srcs = glob(
-        include = [
-            "**/*.BUILD",
-            "**/*.bzl",
-            "**/*.sky",
-            "**/BUILD",
-            "**/BUILD.*.bazel",
-            "**/BUILD.*.oss",
-            "**/BUILD.bazel",
-            "**/WORKSPACE",
-            "**/WORKSPACE.*.bazel",
-            "**/WORKSPACE.*.oss",
-            "**/WORKSPACE.bazel",
-            "*.BUILD",
-            "*.bzl",
-            "*.sky",
-            "BUILD.*.bazel",
-            "BUILD.*.oss",
-            "WORKSPACE.*.bazel",
-            "WORKSPACE.*.oss",
-        ],
-        exclude = [
-            "bazel-*/**",
-            ".git/**",
-            "go_repositories.bzl",  # generated file
-        ],
-    ),
-)
 
 # gazelle:prefix github.com/magma/magma
 # gazelle:exclude .cache/

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -25,10 +25,6 @@ http_archive(
     url = "https://github.com/cedarai/rules_pyvenv/archive/refs/tags/1.0.tar.gz",
 )
 
-### BUILDIFIER DEPENDENCIES
-# See https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md
-# buildifier is written in Go and hence needs rules_go to be built.
-# See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb",
@@ -63,16 +59,6 @@ gazelle_dependencies()
 # If you use WORKSPACE.bazel, use the following line instead of the bare gazelle_dependencies():
 # gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
 gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
-
-# protobuf dependency covered below
-
-http_archive(
-    name = "com_github_bazelbuild_buildtools",
-    sha256 = "7f43df3cca7bb4ea443b4159edd7a204c8d771890a69a50a190dc9543760ca21",
-    strip_prefix = "buildtools-5.0.1",
-    url = "https://github.com/bazelbuild/buildtools/archive/refs/tags/5.0.1.tar.gz",
-)
-### BUILDIFIER DEPENDENCIES
 
 http_archive(
     name = "bazel_skylib",

--- a/bazel/scripts/run_buildifier.sh
+++ b/bazel/scripts/run_buildifier.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 # found at https://github.com/bazelbuild/buildtools/tree/master/buildifier#readme
 
 BUILDIFIER_URL="https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64"
-BUILDIFIER_PATH="/usr/bin"
+BUILDIFIER_PATH="/tmp"
 BUILDIFIER_EXECUTABLE="$BUILDIFIER_PATH/buildifier-linux-amd64"
 
 # Command line argument, can be either 'check' or 'format'.

--- a/docs/readmes/lte/dev_unit_testing.md
+++ b/docs/readmes/lte/dev_unit_testing.md
@@ -140,6 +140,5 @@ To use the script, run
 To format all Bazel related files, run
 
 ```bash
-cd magma # or any subdirectory inside magma
-bazel run //:buildifier
+$MAGMA_ROOT/bazel/scripts/run_buildifier.sh format
 ```

--- a/orc8r/tools/ansible/roles/golang/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/golang/tasks/main.yml
@@ -72,13 +72,3 @@
     PATH: "{{ ansible_env.PATH }}:{{ go_bin_path }}"
   command: go install gotest.tools/gotestsum@v1.8.0
   when: full_provision
-
-- name: Install buildifier
-  become: yes
-  become_user: '{{ user }}'
-  environment:
-    GOPATH: "{{ gopath }}"
-    GOBIN: "{{ gobin }}"
-    PATH: "{{ ansible_env.PATH }}:{{ go_bin_path }}"
-  command: go install github.com/bazelbuild/buildtools/buildifier@c802c3b06ba6
-  when: full_provision


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Clean up integrated buildifier
- Change executable location to `/tmp` to avoid need for `sudo`
- Resolves https://github.com/magma/magma/issues/14551
- Follow up to https://github.com/magma/magma/pull/14639


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
