### PR TITLE
fix(ci): set correct names to test result artifacts

### DIFF
--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -121,5 +121,5 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
-          name: test-results-${{ matrix.test_targets }}
+          name: test-results-${{ inputs.test_targets }}
           path: lte/gateway/test-results/**/*.xml


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The test result artifacts are not correctly labeled for the upload. This PR tags them with the correct variable. Looking into the logs of past runs (e.g. [here](https://github.com/magma/magma/actions/runs/3648022634/jobs/6161728305#step:2:13)), we see that `${{ inputs.test_targets }}` holds the correct information.
Part of https://github.com/magma/magma/issues/14162.

## Test Plan

- Watch the summary page of the CI job for the names of the uploaded artifacts.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
