### PR TITLE
chore: Add bazel AGW build alias

### DIFF
--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -100,4 +100,7 @@ RUN ldconfig -v
 RUN ln -s /workspaces/magma/.bazel-cache /var/cache/bazel-cache
 RUN ln -s /workspaces/magma/.bazel-cache-repo /var/cache/bazel-cache-repo
 
+# Convenience alias to build AGW services
+RUN echo 'alias magma-build-agw="bazel build //... --build_tag_filters=service,util_script,-mme_oai"' >> ~/.bashrc
+
 WORKDIR /workspaces/magma

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -27,3 +27,113 @@ java_binary(
     main_class = "com.bazel_diff.Main",
     runtime_deps = ["@bazel_diff//jar"],
 )
+
+alias(
+    name = "envoy_controller",
+    actual = "//feg/gateway/services/envoy_controller:envoy_controller",
+)
+
+alias(
+    name = "connectiond",
+    actual = "//lte/gateway/c/connection_tracker/src:connectiond",
+)
+
+alias(
+    name = "agw_of",
+    actual = "//lte/gateway/c/core:agw_of",
+)
+
+alias(
+    name = "mme_oai",
+    actual = "//lte/gateway/c/core:mme_oai",
+)
+
+alias(
+    name = "liagentd",
+    actual = "//lte/gateway/c/li_agent/src:liagentd",
+)
+
+alias(
+    name = "sctpd",
+    actual = "//lte/gateway/c/sctpd/src:sctpd",
+)
+
+alias(
+    name = "sessiond",
+    actual = "//lte/gateway/c/session_manager:sessiond",
+)
+
+alias(
+    name = "enodebd",
+    actual = "//lte/gateway/python/magma/enodebd:enodebd",
+)
+
+alias(
+    name = "health",
+    actual = "//lte/gateway/python/magma/health:health",
+)
+
+alias(
+    name = "kernsnoopd",
+    actual = "//lte/gateway/python/magma/kernsnoopd:kernsnoopd",
+)
+
+alias(
+    name = "mobilityd",
+    actual = "//lte/gateway/python/magma/mobilityd:mobilityd",
+)
+
+alias(
+    name = "monitord",
+    actual = "//lte/gateway/python/magma/monitord:monitord",
+)
+
+alias(
+    name = "pipelined",
+    actual = "//lte/gateway/python/magma/pipelined:pipelined",
+)
+
+alias(
+    name = "policydb",
+    actual = "//lte/gateway/python/magma/policydb:policydb",
+)
+
+alias(
+    name = "redirectd",
+    actual = "//lte/gateway/python/magma/redirectd:redirectd",
+)
+
+alias(
+    name = "smsd",
+    actual = "//lte/gateway/python/magma/smsd:smsd",
+)
+
+alias(
+    name = "subscriberdb",
+    actual = "//lte/gateway/python/magma/subscriberdb:subscriberdb",
+)
+
+alias(
+    name = "ctraced",
+    actual = "//orc8r/gateway/python/magma/ctraced:ctraced",
+)
+
+alias(
+    name = "directoryd",
+    actual = "//orc8r/gateway/python/magma/directoryd:directoryd",
+)
+
+alias(
+    name = "eventd",
+    actual = "//orc8r/gateway/python/magma/eventd:eventd",
+)
+
+alias(
+    name = "magmad",
+    actual = "//orc8r/gateway/python/magma/magmad:magmad",
+)
+
+alias(
+    name = "state",
+    actual = "//orc8r/gateway/python/magma/state:state",
+)

--- a/bazel/test_constants.bzl
+++ b/bazel/test_constants.bzl
@@ -51,3 +51,6 @@ TAG_UTIL_SCRIPT = ["util_script"]
 
 # Tag for Magma services.
 TAG_SERVICE = ["service"]
+
+# Tag to easily exclude OAI MME from builds
+TAG_MME_OAI = ["mme_oai"]

--- a/feg/gateway/services/envoy_controller/BUILD.bazel
+++ b/feg/gateway/services/envoy_controller/BUILD.bazel
@@ -31,5 +31,8 @@ go_binary(
     name = "envoy_controller",
     embed = [":envoy_controller_lib"],
     tags = TAG_SERVICE + ["no-cache"],
-    visibility = ["//lte/gateway/release:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/release:__pkg__",
+    ],
 )

--- a/lte/gateway/c/connection_tracker/src/BUILD.bazel
+++ b/lte/gateway/c/connection_tracker/src/BUILD.bazel
@@ -16,7 +16,10 @@ cc_binary(
     name = "connectiond",
     srcs = ["main.cpp"],
     tags = TAG_SERVICE + ["no-cache"],
-    visibility = ["//lte/gateway/release:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/release:__pkg__",
+    ],
     deps = [
         ":event_tracker",
         "//lte/protos:mconfigs_cpp_proto",

--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -11,7 +11,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:asn1c.bzl", "cc_asn1_library")
-load("//bazel:test_constants.bzl", "TAG_SERVICE")
+load("//bazel:test_constants.bzl", "TAG_MME_OAI", "TAG_SERVICE")
 
 package(default_visibility = ["//lte/gateway/c/core:__subpackages__"])
 
@@ -1176,6 +1176,7 @@ cc_library(
         "-DEMBEDDED_SGW=0",
         "-DS6A_OVER_GRPC=0",
     ],
+    tags = TAG_MME_OAI,
     deps = MME_DEPS,
 )
 
@@ -1185,7 +1186,10 @@ cc_binary(
     copts = ["-DEMBEDDED_SGW=1"],
     linkstatic = True,
     tags = TAG_SERVICE + ["no-cache"],
-    visibility = ["//lte/gateway/release:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/release:__pkg__",
+    ],
     deps = [":lib_agw_of"],
 )
 
@@ -1194,7 +1198,8 @@ cc_binary(
     srcs = ["oai/oai_mme/oai_mme.c"],
     copts = ["-DEMBEDDED_SGW=0"],
     linkstatic = True,
-    tags = TAG_SERVICE + ["no-cache"],
+    tags = TAG_SERVICE + TAG_MME_OAI + ["no-cache"],
+    visibility = ["//:__pkg__"],
     deps = [":lib_mme_oai"],
 )
 

--- a/lte/gateway/c/li_agent/src/BUILD.bazel
+++ b/lte/gateway/c/li_agent/src/BUILD.bazel
@@ -18,7 +18,10 @@ cc_binary(
     name = "liagentd",
     srcs = ["main.cpp"],
     tags = TAG_SERVICE + ["no-cache"],
-    visibility = ["//lte/gateway/release:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/release:__pkg__",
+    ],
     deps = [
         ":interface_monitor",
         "//orc8r/gateway/c/common/config:mconfig_loader",

--- a/lte/gateway/c/sctpd/src/BUILD.bazel
+++ b/lte/gateway/c/sctpd/src/BUILD.bazel
@@ -19,7 +19,10 @@ cc_binary(
     srcs = ["sctpd.cpp"],
     linkstatic = True,
     tags = TAG_SERVICE,
-    visibility = ["//lte/gateway/release:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/release:__pkg__",
+    ],
     deps = [
         ":config",
         ":sctpd_downlink_impl",

--- a/lte/gateway/c/session_manager/BUILD.bazel
+++ b/lte/gateway/c/session_manager/BUILD.bazel
@@ -429,7 +429,10 @@ cc_binary(
     #                 but where system libraries (excluding C/C++ runtime libraries) are linked dynamically
     linkstatic = True,
     tags = TAG_SERVICE + ["no-cache"],
-    visibility = ["//lte/gateway/release:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/release:__pkg__",
+    ],
     deps = [
         ":operational_states_handler",
         ":policy_loader",

--- a/lte/gateway/deploy/roles/bazel_aliases/tasks/main.yml
+++ b/lte/gateway/deploy/roles/bazel_aliases/tasks/main.yml
@@ -17,4 +17,4 @@
     line: "{{ item }}"
   with_items:
     # build all services and scripts needed to run the lte access gateway
-    - alias magma-build-agw='bazel build `bazel query "attr(tags, \"service|util_script\", kind(.*_binary, //orc8r/... union //lte/... union //feg/... except //lte/gateway/c/core:mme_oai))"`'
+    - alias magma-build-agw='bazel build //... --build_tag_filters=service,util_script,-mme_oai'

--- a/lte/gateway/python/magma/health/BUILD.bazel
+++ b/lte/gateway/python/magma/health/BUILD.bazel
@@ -31,7 +31,10 @@ py_binary(
     main = "main.py",
     python_version = "PY3",
     tags = TAG_SERVICE,
-    visibility = ["//lte/gateway/python:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/python:__pkg__",
+    ],
     deps = [
         ":health_lib",
         "//orc8r/gateway/python/magma/common:sentry",

--- a/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
+++ b/lte/gateway/python/magma/kernsnoopd/BUILD.bazel
@@ -31,7 +31,10 @@ py_binary(
     main = "main.py",
     python_version = "PY3",
     tags = TAG_SERVICE,
-    visibility = ["//lte/gateway/python:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/python:__pkg__",
+    ],
     deps = [
         ":kernsnoopd_lib",
         "//orc8r/gateway/python/magma/common:sentry",

--- a/lte/gateway/python/magma/mobilityd/BUILD.bazel
+++ b/lte/gateway/python/magma/mobilityd/BUILD.bazel
@@ -31,7 +31,10 @@ py_binary(
     main = "main.py",
     python_version = "PY3",
     tags = TAG_SERVICE,
-    visibility = ["//lte/gateway/python:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/python:__pkg__",
+    ],
     deps = [
         ":mobilityd_lib",
         "//lte/protos:mconfigs_python_proto",

--- a/lte/gateway/python/magma/monitord/BUILD.bazel
+++ b/lte/gateway/python/magma/monitord/BUILD.bazel
@@ -30,7 +30,10 @@ py_binary(
     legacy_create_init = False,
     main = "main.py",
     tags = TAG_SERVICE,
-    visibility = ["//lte/gateway/python:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/python:__pkg__",
+    ],
     deps = [
         ":monitord_lib",
         "//lte/protos:mconfigs_python_proto",

--- a/lte/gateway/python/magma/policydb/BUILD.bazel
+++ b/lte/gateway/python/magma/policydb/BUILD.bazel
@@ -30,7 +30,10 @@ py_binary(
     main = "main.py",
     python_version = "PY3",
     tags = TAG_SERVICE,
-    visibility = ["//lte/gateway/python:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/python:__pkg__",
+    ],
     deps = [
         ":policydb_lib",
         "//lte/gateway/python/magma/policydb/servicers:policy_servicer",

--- a/lte/gateway/python/magma/redirectd/BUILD.bazel
+++ b/lte/gateway/python/magma/redirectd/BUILD.bazel
@@ -31,7 +31,10 @@ py_binary(
     main = "main.py",
     python_version = "PY3",
     tags = TAG_SERVICE,
-    visibility = ["//lte/gateway/python:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/python:__pkg__",
+    ],
     deps = [
         ":redirect_server",
         "//lte/protos:mconfigs_python_proto",

--- a/lte/gateway/python/magma/smsd/BUILD.bazel
+++ b/lte/gateway/python/magma/smsd/BUILD.bazel
@@ -30,7 +30,10 @@ py_binary(
     main = "main.py",
     python_version = "PY3",
     tags = TAG_SERVICE,
-    visibility = ["//lte/gateway/python:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//lte/gateway/python:__pkg__",
+    ],
     deps = [
         ":smsd_lib",
         "//lte/protos:sms_orc8r_python_grpc",

--- a/orc8r/gateway/python/magma/eventd/BUILD.bazel
+++ b/orc8r/gateway/python/magma/eventd/BUILD.bazel
@@ -31,7 +31,10 @@ py_binary(
     main = "main.py",
     python_version = "PY3",
     tags = TAG_SERVICE,
-    visibility = ["//orc8r/gateway/python:__pkg__"],
+    visibility = [
+        "//:__pkg__",
+        "//orc8r/gateway/python:__pkg__",
+    ],
     deps = [
         ":eventd_lib",
         "//orc8r/gateway/python/magma/common:sentry",


### PR DESCRIPTION
Signed-off-by: Krisztián Varga <krisztian.varga@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR introduces new convenient aliases for building AGW.
This closes #14549.

## Test Plan

Build the bazel-base container -> try executing `magma-build-agw`
Build the devcontainer -> try executing `magma-build-agw`

Build the alias targets:
`for target in $(bazel query "attr(tags, service, //...)"); do bazel build "${target#*:}" || break; done;`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
