### PR TITLE
chore: lockfile is updated by pydep

### DIFF
--- a/lte/gateway/release/magma.lockfile.ubuntu
+++ b/lte/gateway/release/magma.lockfile.ubuntu
@@ -634,6 +634,12 @@
           "sysdep": "python3-docker",
           "version": "4.1.0"
         },
+        "dpkt": {
+          "root": true,
+          "source": "apt",
+          "sysdep": "python3-dpkt",
+          "version": "1.9.8"
+        },
         "envoy": {
           "root": true,
           "source": "apt",
@@ -1006,6 +1012,12 @@
           "sysdep": "python3-scapy",
           "version": "2.4.5"
         },
+        "sdnotify": {
+          "root": true,
+          "source": "apt",
+          "sysdep": "python3-sdnotify",
+          "version": "0.3.2"
+        },
         "sentry-sdk": {
           "root": true,
           "source": "pypi",
@@ -1088,7 +1100,7 @@
           "root": false,
           "source": "apt",
           "sysdep": "python3-websocket-client",
-          "version": "1.3.3"
+          "version": "1.4.2"
         },
         "werkzeug": {
           "root": false,
@@ -1145,6 +1157,9 @@
         },
         "docker": {
           "version": "4.1.0"
+        },
+        "dpkt": {
+          "version": "1.9.8"
         },
         "eventlet": {
           "version": "0.30.2"
@@ -1244,6 +1259,9 @@
         },
         "scapy": {
           "version": "2.4.5"
+        },
+        "sdnotify": {
+          "version": "0.3.2"
         },
         "sentry-sdk": {
           "version": "1.5.4"


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

**Problem**:
* the magma debian on master is broken because `python3-sdnotify` is not listed as a debian dependency.
* see https://github.com/magma/magma/actions/workflows/lte-integ-test-magma-deb.yml
* error picture: each test fails with error that ovs (via pipelined) can not be queried
* reproducing this locally shows in magmad logging, that magmad is not starting with a module not found on sdnotify

**Analysis**:
* sdnotify was added as a python dependency
* the magma python3-foo dependencies (list of dependencies in debian artifact) are created from the lockfile `lte/gateway/release/magma.lockfile.ubuntu`
* when a new dependency is added and pydep (`lte/gateway/release/pydep`) is executed in CI, then ...
  * pydep realizes that the new package is not in the repo - so it is build (and later uploaded by CI)
  * the lockfile is updated by pydep (`lte/gateway/release/pydep`) - this is not upstreamed in CI
  * -> this is, the dependency is uploaded, but will never be added as a dependency to the magma debian artifact (maybe it is for the artifact that is created in this specific run)
* later executions of pydep will ignore the new dependency as it is already in the artifactory - and the lockfile will be updated anymore
* Assumption for workflow if a new dependency is added ...
  * add the dependency to `setup.py` (is actually only the lte `setup.py` considered?)
  * run `fab release package` locally
  * create PR with new dependency AND updated lockfile

**Here**:
* excluded sdnotify (and dpkt - was also missing) manually in pydep so that already uploaded artifacts are ignored
* run pydep and push modified lockfile

## Test Plan

* on master check that ...
  * build_all runs through
  * make debian integ test does not fail because no service is started

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
