### PR TITLE
ci: manual execution only for test lte integration with make  

### DIFF
--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -13,10 +13,6 @@ name: AGW Build & Test LTE Integration With Make Dev Build
 
 on:
   workflow_dispatch: null
-  push:
-    branches:
-      - master
-      - 'v1.*'
 
 jobs:
   lte-integ-test:
@@ -54,7 +50,7 @@ jobs:
       - name: Install pre requisites
         run: |
           pip3 install --upgrade pip
-          pip3 install ansible fabric3 jsonpickle requests PyYAML firebase_admin
+          pip3 install ansible fabric3 jsonpickle requests PyYAML
           vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
       - name: Open up network interfaces for VM
         run: |
@@ -98,23 +94,3 @@ jobs:
           check_name: LTE integration test results
           junit_files: lte/gateway/test-results/**/*.xml
           check_run_annotations: all tests
-      - name: Publish results to Firebase
-        if: always() && github.event_name == 'push'
-        env:
-          FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
-          REPORT_FILENAME: "lte_integ_test_${{ github.sha }}.html"
-        run: |
-          npm install -g xunit-viewer
-          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
-          [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
-          [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
-          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} lte --url $URL
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_AVATAR: ":boom:"
-        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
-        with:
-          args: "LTE integration test failed on [${{ github.sha }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ github.sha }}): ${{ github.event.head_commit.message || github.event.pull_request.title }}"


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

As part of the plan described in  #14178, the PR sets the `AGW Build & Test LTE Integration With Make Dev Build` workflow to manual execution only.

:warning: DO NOT MERGE BEFORE [CI Dashboard PR 22](https://github.com/magma/ci-dashboard/pull/22)  is published