### PR TITLE
chore: traffic tests are waiting for started iperf instances

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -399,7 +399,6 @@ class TestWrapper(object):
         Raises:
             ValueError: If no valid IP is found
         """
-        time.sleep(1)
         # Configure downlink route in TRF server
         assert self._trf_util.update_dl_route(self.TEST_IP_BLOCK)
 
@@ -434,7 +433,6 @@ class TestWrapper(object):
         Raises:
             ValueError: If no valid IP is found
         """
-        time.sleep(1)
         ips = self._getAddresses(*ues)
         for ip, ue in zip(ips, ues):
             if not ip:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

For ul integration tests often the iperf instances are not reachable - this was already mitigated in https://github.com/magma/magma/pull/13277, but still occurs in CI. Often seen for `test_attach_ul_udp_data_with_mobilityd_restart` or `test_attach_ul_udp_data_with_mme_restart` with:
```
ERROR - unable to connect to server: Connection refused
Running iperf data failed with timeout
```
E.g., https://github.com/magma/magma/actions/runs/3648067067/jobs/6161049428 with `test_attach_ul_udp_data_with_mme_restart`.
From debugging this, it looks like, the test tries to transferes data before the iperf instances are actually running.
* The general waiting time is changed here to a wait for a barrier-point where all iperf instances are started.
* This is also guarded by a 10 second timeout.
* Note: this seems to be stable in various test runs - but it is still unclear to me why the previous approach had a similar effect. The general wait time was applied way before the iperf instances where started.

## Test Plan

Various runs on fork did not show the `Connection refused` behavior of the ul tests (other tests are still flaky). https://github.com/nstng/magma/actions/workflows/lte-integ-test-bazel-magma-deb.yml

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
