### PR TITLE
chore(ci): Remove the bazel-diff build from the Bazel Docker cache

### DIFF
--- a/bazel/docker/Dockerfile.bazel.cache
+++ b/bazel/docker/Dockerfile.bazel.cache
@@ -29,8 +29,6 @@ RUN rm /var/cache/bazel-cache && \
     cd $MAGMA_ROOT && \
     echo "Running Bazel test on all '${BAZEL_TARGET_RULE}' targets with config '${BAZEL_CONFIG}' ..." && \
     bazel test ${BAZEL_CONFIG} --flaky_test_attempts=5 --test_tag_filters=-manual `bazel query "kind(${BAZEL_TARGET_RULE}, //...)"` && \
-    echo "Running Bazel build //:bazel-diff" && \
-    bazel build //:bazel-diff && \
     echo "The size of the /var/cache/bazel-cache* folders is:" && \
     du -sh /var/cache/bazel-cache*
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Since https://github.com/magma/magma/pull/14626 bazel-diff is only run once in a separate job, which runs in bazel-base and will continue to only use bazel-base. The addition of bazel-base to the cache build is thus unnecessary.
  - The containers will be used in https://github.com/magma/magma/pull/14571 
- Additionally there were runs in the past where this second build got stuck during the docker build for unknown reasons.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
