### PR TITLE
chore(agw): Extract new DHCP tool into a new package

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -107,7 +107,6 @@ setup(
         'ryu>=4.34',
         'spyne>=2.13,<2.14',
         'dpkt==1.9.8',
-        'scapy==2.4.5',
         'flask==1.1.4',
         'sentry_sdk>=1.5.0,<1.9',
         'aiodns>=3.0.0',
@@ -145,6 +144,7 @@ setup(
             'parameterized==0.8.1',
             'pytest==7.1.2',
             'pytest-cov==3.0.0',
+            'scapy==2.4.5',
         ],
     },
 )

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -107,6 +107,7 @@ ARCH=amd64
 PKGFMT=deb
 PKGNAME=magma
 SCTPD_PKGNAME=magma-sctpd
+DHCP_CLI_PKGNAME=magma-dhcp-cli
 
 # Magma system dependencies: anything that we depend on at the top level, add
 # here.
@@ -132,7 +133,6 @@ MAGMA_DEPS=(
     "libdouble-conversion-dev" # required for folly
     "libboost-chrono-dev" # required for folly
     "ntpdate" # required for eventd time synchronization
-    "python3-scapy >= 2.4.3-4"
     "tshark" # required for call tracing
     "libtins-dev" # required for Connection tracker
     "libmnl-dev" # required for Connection tracker
@@ -146,6 +146,7 @@ MAGMA_DEPS=(
     # Ubuntu bcc lib (bpfcc-tools) is pretty old, use magma repo package
     "bcc-tools"
     "wireguard"
+    "${DHCP_CLI_PKGNAME}"
     )
 
 # OAI runtime dependencies
@@ -428,5 +429,29 @@ $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/${PKGNAME}*" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/*.egg-info" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/usr/bin/*" /usr/local/bin/) \
 " # Leave this quote on a new line to mark end of BUILDCMD
+
+eval "$BUILDCMD"
+
+DESCRIPTION_DHCP="Magma DHCP helper CLI"
+LICENSE_DHCP="GPLv2"
+SCAPY_PACKAGE="python3-scapy"
+SCAPY_VERSION="2.4.5"
+
+BUILDCMD="fpm \
+-s dir \
+-t ${PKGFMT} \
+-a ${ARCH} \
+-n ${DHCP_CLI_PKGNAME} \
+-v ${FULL_VERSION} \
+--provides ${DHCP_CLI_PKGNAME} \
+--replaces ${DHCP_CLI_PKGNAME} \
+--package ${OUTPUT_DIR}/${DHCP_CLI_PKGNAME}_${FULL_VERSION}_${ARCH}.${PKGFMT} \
+--description '${DESCRIPTION_DHCP}' \
+--url '${URL}' \
+--vendor '${VENDOR}' \
+--license '${LICENSE_DHCP}' \
+--maintainer '${MAINTAINER}' \
+--depends '${SCAPY_PACKAGE} >= ${SCAPY_VERSION}' \
+${MAGMA_ROOT}/lte/gateway/python/scripts/dhcp_helper_cli.py=/usr/local/bin/"
 
 eval "$BUILDCMD"

--- a/lte/gateway/release/magma.lockfile.ubuntu
+++ b/lte/gateway/release/magma.lockfile.ubuntu
@@ -420,12 +420,6 @@
       "sysdep": "python3-ryu",
       "version": "4.30"
     },
-    "scapy": {
-      "root": true,
-      "source": "pypi",
-      "sysdep": "python3-scapy",
-      "version": "2.4.4"
-    },
     "sentry-sdk": {
       "root": true,
       "source": "pypi",
@@ -1006,12 +1000,6 @@
           "sysdep": "python3-ryu",
           "version": "4.34"
         },
-        "scapy": {
-          "root": true,
-          "source": "pypi",
-          "sysdep": "python3-scapy",
-          "version": "2.4.5"
-        },
         "sdnotify": {
           "root": true,
           "source": "apt",
@@ -1257,9 +1245,6 @@
         "ryu": {
           "version": "4.34"
         },
-        "scapy": {
-          "version": "2.4.5"
-        },
         "sdnotify": {
           "version": "0.3.2"
         },
@@ -1431,9 +1416,6 @@
     },
     "ryu": {
       "version": "4.30"
-    },
-    "scapy": {
-      "version": "2.4.4"
     },
     "sentry-sdk": {
       "version": "1.0.0"


### PR DESCRIPTION
## Summary

* Add a new fpm step to build-magma to build a new package for the DHCP tool.
* Make the new tool a dependency of the magma package.

Merge after #14528 and other replacement tickets are merged.

Work in progress.

## Test Plan

I built magma using `fab release package` with the following result:
```
vagrant@magma-dev:~/magma-packages$ dpkg -I magma_1.8.0-1670594023-fe21e7b4_amd64.deb 
 new Debian package, version 2.0.
 size 111505644 bytes: control archive=20484 bytes.
    2032 bytes,    64 lines      conffiles            
    4185 bytes,    14 lines      control              
   64439 bytes,   655 lines      md5sums              
    2111 bytes,    57 lines   *  postinst             #!/bin/bash
 Package: magma
 Version: 1.8.0-1670594023-fe21e7b4
 License: BSD-3-Clause
 Vendor: magma
 Architecture: amd64
 Maintainer: The Magma Authors <main@lists.magmacore.org>
 Installed-Size: 375147
 Depends: python3-aiodns (>= 3.0.0), python3-aioeventlet (>= 0.5.1), python3-aioh2 (>= 0.2.3), python3-aiohttp (>= 3.8.1), python3-bravado-core (>= 5.17.0), python3-chardet (>= 3.0.4), python3-cryptography (>= 2.8), python3-cython (>= 0.29.32), python3-docker (>= 4.1.0), python3-envoy (>= 0.0.3), python3-eventlet (>= 0.30.2), python3-fire (>= 0.4.0), python3-flask (>= 1.1.4), python3-freezegun (>= 1.2.1), python3-glob2 (>= 0.7), python3-grpcio (>= 1.46.3), python3-h2 (>= 3.2.0), python3-hpack (>= 3.0.0), python3-itsdangerous (>= 1.1.0), python3-jsonpickle (>= 2.2.0), python3-jsonschema (>= 3.2.0), python3-lxml (>= 4.9.1), python3-markupsafe (>= 1.1.1), python3-netifaces (>= 0.11.0), python3-ovs (>= 2.13.3), python3-protobuf (>= 3.20.3), python3-psutil (>= 5.9.1), python3-pycryptodome (>= 3.15.0), python3-pylint (>= 2.6.0), python3-pymemoize (>= 1.0.2), python3-pyroute2 (>= 0.6.13), python3-pystemd (>= 0.8.0), python3-python-dateutil (>= 2.8.2), python3-python-redis-lock (>= 3.7.0), python3-yaml (>= 5.3.1), python3-redis-collections (>= 0.11.0), python3-rfc3987 (>= 1.3.8), python3-ryu (>= 4.34), python3-sentry-sdk (>= 1.5.4), python3-snowflake (>= 0.0.3), python3-spyne (>= 2.13.15), python3-strict-rfc3339 (>= 0.7), python3-webcolors (>= 1.12), python3-wsgiserver (>= 1.3), python3-json-pointer (>= 0.1.2), python3-json-pointer (>= 2.3), python3-prometheus-client (>= 0.3.1), python3-systemd (>= 234), python3-systemd-python (>= 234), python3-aiodns (>= 3.0.0), python3-aioeventlet (>= 0.5.1), python3-aioh2 (>= 0.2.3), python3-aiohttp (>= 3.8.1), python3-bravado-core (>= 5.17.0), python3-chardet (>= 3.0.4), python3-cryptography (>= 2.8), python3-cython (>= 0.29.32), python3-docker (>= 4.1.0), python3-envoy (>= 0.0.3), python3-eventlet (>= 0.30.2), python3-fire (>= 0.4.0), python3-flask (>= 1.1.4), python3-freezegun (>= 1.2.1), python3-glob2 (>= 0.7), python3-grpcio (>= 1.46.3), python3-h2 (>= 3.2.0), python3-hpack (>= 3.0.0), python3-itsdangerous (>= 1.1.0), python3-jsonpickle (>= 2.2.0), python3-jsonschema (>= 3.2.0), python3-lxml (>= 4.9.1), python3-markupsafe (>= 1.1.1), python3-netifaces (>= 0.11.0), python3-ovs (>= 2.13.3), python3-protobuf (>= 3.20.3), python3-psutil (>= 5.9.1), python3-pycryptodome (>= 3.15.0), python3-pylint (>= 2.6.0), python3-pymemoize (>= 1.0.2), python3-pyroute2 (>= 0.6.13), python3-pystemd (>= 0.8.0), python3-python-dateutil (>= 2.8.2), python3-python-redis-lock (>= 3.7.0), python3-yaml (>= 5.3.1), python3-redis-collections (>= 0.11.0), python3-rfc3987 (>= 1.3.8), python3-ryu (>= 4.34), python3-sentry-sdk (>= 1.5.4), python3-snowflake (>= 0.0.3), python3-spyne (>= 2.13.15), python3-strict-rfc3339 (>= 0.7), python3-webcolors (>= 1.12), python3-wsgiserver (>= 1.3), python3-json-pointer (>= 0.1.2), python3-json-pointer (>= 2.3), python3-prometheus-client (>= 0.3.1), python3-systemd (>= 234), python3-systemd-python (>= 234), grpc-dev (>= 1.15.0), lighttpd (>= 1.4.45), libxslt1.1, nghttp2-proxy (>= 1.18.1), python3-protobuf (>= 3.20.3), redis-server (>= 3.2.0), sudo, dnsmasq (>= 2.7), net-tools, python3-pip, python3-apt, python3-aioeventlet, libsystemd-dev, libyaml-cpp-dev, libgoogle-glog-dev, python-redis, magma-cpp-redis, libfolly-dev, libdouble-conversion-dev, libboost-chrono-dev, ntpdate, tshark, libtins-dev, libmnl-dev, getenvoy-envoy, uuid-dev, libprotobuf17 (>= 3.0.0), nlohmann-json3-dev, sentry-native, td-agent-bit (>= 1.7.8), bcc-tools, wireguard, magma-dhcp-cli, libconfig9, oai-asn1c, oai-gnutls (>= 3.1.23), oai-nettle (>= 1.0.1), prometheus-cpp-dev (>= 1.0.2), liblfds710, libsctp-dev, magma-sctpd (>= 1.8.0), libczmq-dev (>= 4.0.2-7), libasan5, oai-freediameter (>= 0.0.2), magma-libfluid (>= 0.1.0.7), libopenvswitch (>= 2.15.4-9-magma), openvswitch-switch (>= 2.15.4-9-magma), openvswitch-common (>= 2.15.4-9-magma), openvswitch-datapath-dkms (>= 2.15.4-9-magma)
 Provides: magma
 Replaces: magma
 Section: default
 Priority: extra
 Homepage: https://github.com/magma/magma/
 Description: Magma Access Gateway
```
```
vagrant@magma-dev:~/magma-packages$ dpkg -I magma-dhcp-cli_1.8.0-1670594023-fe21e7b4_amd64.deb 
 new Debian package, version 2.0.
 size 4534 bytes: control archive=522 bytes.
     378 bytes,    14 lines      control              
     143 bytes,     2 lines      md5sums              
 Package: magma-dhcp-cli
 Version: 1.8.0-1670594023-fe21e7b4
 License: GPLv2
 Vendor: magma
 Architecture: amd64
 Maintainer: The Magma Authors <main@lists.magmacore.org>
 Installed-Size: 10
 Depends: python3-scapy (>= 2.4.5)
 Provides: magma-dhcp-cli
 Replaces: magma-dhcp-cli
 Section: default
 Priority: extra
 Homepage: https://github.com/magma/magma/
 Description: Magma DHCP helper CLI
```

## Additional Information

- [ ] This change is backwards-breaking