### PR TITLE
fix: flaky and harmful ipv6 test is disabled for now

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -122,7 +122,6 @@ s1aptests/test_attach_detach_setsessionrules_tcp_data.py
 
 PRECOMMIT_TESTS_IPV6 = \
 s1aptests/test_enable_ipv6_iface.py \
-s1aptests/test_ipv6_non_nat_dp_ul_tcp.py \
 s1aptests/test_disable_ipv6_iface.py
 
 PRECOMMIT_TESTS_NOT_CONTAINER = \
@@ -283,6 +282,7 @@ s1aptests/test_restore_config_after_non_sanity.py
 #---------------
 
 # TODO: Flaky ipv6 tests which randomly fail with connection refused
+#s1aptests/test_ipv6_non_nat_dp_ul_tcp.py
 #s1aptests/test_ipv6_non_nat_dp_dl_tcp.py
 #s1aptests/test_ipv6_non_nat_dp_ul_udp.py
 #s1aptests/test_ipv6_non_nat_dp_dl_udp.py


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

`test_ipv6_non_nat_dp_ul_tcp.py` often fails with harmful implications for follow-up tests.
* The test fails often during the attach phase
  * expected `UE_ATTACH_ACCEPT_IND = 12`, actually `UE_ATTACH_REJECT_IND = 23`
  * this seems to be related to `sessiond[389046]: I1204 18:31:06.951510 389046 LocalSessionManagerHandler.cpp:253] Rejecting requests since PipelineD is still setting up`
  * It is still unclear (to me) why this happens for the ipv6 case
* Now, in the flaky re-runs we often see a `segmentation fault`
  * It is unclear where this is coming from (no indication found in logging). Assumption: the s1aptester fails
  * This causes the test to stop - without clean-up -> the test tear-down is not called
  * nat is not enabled again (in the tear-down function)
* A follow-up test runs now still with the disabled nat setup
  * this makes calls to pipelined run into a 6h timeout - this call is started in s1ap-utils as a static init call
    * imho a static init call to pipelined is not a good pattern
    * this is not trivial to refactor
* Overall conclusion: the test should be disabled for now and in follow-up PRs ...
  * the static init call to pipelined should be refactored
  * to be discussed: tests should start with enabled nat
  * the segmentation faults should be analyzed (is this caused by the s1aptester?)
  * -> will create follow-up issues if reviewers agree with disabeling the test for now

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
