### PR TITLE
ci: switch to linux foundation artifactory in promotion workflows

### DIFF
--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       BRANCH_TAG: ${{ inputs.branch_tag }}
       RELEASE_TAG: ${{ inputs.release_tag }}
-      MAGMA_ARTIFACTORY: artifactory.magmacore.org
+      MAGMA_ARTIFACTORY: linuxfoundation.jfrog.io
     steps:
       - uses: tspascoal/get-user-teams-membership@39b5264024b7c3bd7480de2f2c8d3076eed49ec5 # pin@v1.0.4
         name: Check if user has rights to promote
@@ -44,8 +44,8 @@ jobs:
         name: Login to Artifactory
         with:
           registry: docker.${{ env.MAGMA_ARTIFACTORY }}
-          username: ${{ secrets.ARTIFACTORY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          username: ${{ secrets.LF_JFROG_USERNAME }}
+          password: ${{ secrets.LF_JFROG_PASSWORD }}
       - run: |
           wget https://github.com/magma/magma/raw/master/orc8r/tools/docker/promote.sh
           chmod 755 promote.sh

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       MAGMA_VERSION: ${{ inputs.magma_version }}
-      MAGMA_ARTIFACTORY: https://artifactory.magmacore.org:443/artifactory
-      HELM_CHART_MUSEUM_TOKEN: ${{ secrets.HELM_CHART_MUSEUM_TOKEN }}
-      HELM_CHART_MUSEUM_USERNAME: ${{ secrets.HELM_CHART_MUSEUM_USERNAME }}
+      MAGMA_ARTIFACTORY: https://linuxfoundation.jfrog.io/artifactory
+      HELM_CHART_MUSEUM_TOKEN: ${{ secrets.LF_JFROG_USERNAME }}
+      HELM_CHART_MUSEUM_USERNAME: ${{ secrets.LF_JFROG_PASSWORD }}
     steps:
       - uses: tspascoal/get-user-teams-membership@39b5264024b7c3bd7480de2f2c8d3076eed49ec5 # pin@v1.0.4
         name: Check if user has rights to promote

--- a/orc8r/tools/docker/promote.sh
+++ b/orc8r/tools/docker/promote.sh
@@ -29,7 +29,7 @@ declare -A repositories=(
   [orc8r]="controller magmalte nginx active-mode-controller configuration-controller radio-controller db-service"
   [feg]="gateway_go gateway_python"
   [agw]="agw_gateway_c agw_gateway_python ghz_gateway_c ghz_gateway_python agw_gateway_c_arm agw_gateway_python_arm"
-  [cwf]="cwag_go gateway_go gateway_pipelined gateway_python gateway_sessiond operator"
+  [cwag]="cwag_go gateway_go gateway_pipelined gateway_python gateway_sessiond operator"
 )
 
 # shellcheck disable=SC2068
@@ -37,26 +37,26 @@ for repo in ${!repositories[@]}; do
   for image in ${repositories[${repo}]}; do
 
     # Change docker URL to Artifactory
-    sed -i "s/docker/${repo}-prod/g" ~/.docker/config.json
+    sed -i "s/docker/magma-docker-${repo}-prod/g" ~/.docker/config.json
 
     # Pull docker image from test registry
-    docker pull "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${BRANCH_TAG}"
+    docker pull "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-test/${image}:${BRANCH_TAG}"
 
     # Tag docker image with new tag
-    docker tag "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${BRANCH_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${RELEASE_TAG}"
-    docker tag "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${BRANCH_TAG} ${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
+    docker tag "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-test/${image}:${BRANCH_TAG}" "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-prod/${image}:${RELEASE_TAG}"
+    docker tag "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-test/${image}:${BRANCH_TAG}" "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-prod/${image}:latest"
 
     # Push docker image to prod registry
-    docker push "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${RELEASE_TAG}"
-    docker push "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
+    docker push "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-prod/${image}:${RELEASE_TAG}"
+    docker push "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-prod/${image}:latest"
 
     # Remove uploaded image
-    docker rmi "${repo}-test.${MAGMA_ARTIFACTORY}/${image}:${BRANCH_TAG}"
-    docker rmi "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:${RELEASE_TAG}"
-    docker rmi "${repo}-prod.${MAGMA_ARTIFACTORY}/${image}:latest"
+    docker rmi "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-test/${image}:${BRANCH_TAG}"
+    docker rmi "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-prod/${image}:${RELEASE_TAG}"
+    docker rmi "${MAGMA_ARTIFACTORY}/magma-docker-${repo}-prod/${image}:latest"
 
     # Change docker URL back to docker
-    sed -i "s/${repo}-prod/docker/g" ~/.docker/config.json
-    echo "Promoted docker image artifact ${image} from ${repo}-test to ${repo}-prod registry successfully."
+    sed -i "s/magma-docker-${repo}-prod/docker/g" ~/.docker/config.json
+    echo "Promoted docker image artifact ${image} from magma-docker-${repo}-test to magma-docker-${repo}-prod registry successfully."
   done
 done


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

This PR replaces the Magma Core artifactory with the Linux Foundation artifactory in the promotion workflows for docker and helm charts. 

## Test Plan
- [x] Run promote script for Docker  ([workflow run in local fork](https://github.com/ajahl/magma/actions/runs/3695356457/jobs/6257628646))
- [x] Run promote script for Helm Charts ([workflow run in local fork](https://github.com/ajahl/magma/actions/runs/3695978446/jobs/6259058182))
- Manual in CI on master

## Additional Information

