### PR TITLE
chore(ci): Add release build and coverage to docker bazel cache

### DIFF
--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -30,6 +30,8 @@ inputs:
     required: true
   PUSH_TO_REGISTRY:
     required: true
+  REMOVE_DOCKERIGNORE_FILE:
+    default: false
   BUILD_ARG_1:
     default: ''
   BUILD_ARG_2:
@@ -40,6 +42,13 @@ runs:
   steps:
     - name: Check Out Repo
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+    - name: Remove .dockerignore (optional step)
+      # The .dockerignore file excludes testing and release code that is needed during
+      # bazel builds but not for production environments. This step should only be run
+      # when building docker images with bazel cache for CI use.
+      if: ${{ inputs.REMOVE_DOCKERIGNORE_FILE == 'true' }}
+      shell: bash
+      run: rm .dockerignore
     - name: Set up Docker meta
       id: meta
       uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # pin@v4.1.1

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -87,6 +87,9 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM_BAZEL_CACHE_ASAN }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE_BAZEL_CACHE }}
+          # The .dockerignore file excludes testing and release code that is needed during
+          # bazel builds but not for production environments.
+          REMOVE_DOCKERIGNORE_FILE: "true"
           BUILD_ARG_1: "BAZEL_TARGET_RULE=cc_test"
           BUILD_ARG_2: "BAZEL_CONFIG=--config=asan"
           PUSH_TO_REGISTRY: "true"
@@ -106,6 +109,9 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM_BAZEL_CACHE_PLAIN }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE_BAZEL_CACHE }}
+          # The .dockerignore file excludes testing and release code that is needed during
+          # bazel builds but not for production environments.
+          REMOVE_DOCKERIGNORE_FILE: "true"
           BUILD_ARG_1: "BAZEL_TARGET_RULE=.*_test"
           PUSH_TO_REGISTRY: "true"
 
@@ -124,6 +130,9 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM_BAZEL_CACHE_PROD }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE_BAZEL_CACHE }}
+          # The .dockerignore file excludes testing and release code that is needed during
+          # bazel builds but not for production environments.
+          REMOVE_DOCKERIGNORE_FILE: "true"
           BUILD_ARG_1: "BAZEL_TARGET_RULE=cc_test"
           BUILD_ARG_2: "BAZEL_CONFIG=--config=production"
           PUSH_TO_REGISTRY: "true"

--- a/bazel/docker/Dockerfile.bazel.cache
+++ b/bazel/docker/Dockerfile.bazel.cache
@@ -27,6 +27,10 @@ RUN rm /var/cache/bazel-cache && \
     mkdir -p /var/cache/bazel-cache && \
     mkdir -p /var/cache/bazel-cache-repo && \
     cd $MAGMA_ROOT && \
+    if [ -z "${BAZEL_CONFIG}" ]; then echo "Running Bazel coverage on all 'cc_test' targets ..."; fi && \
+    if [ -z "${BAZEL_CONFIG}" ]; then bazel coverage //orc8r/gateway/c/... //lte/gateway/c/... --flaky_test_attempts=5; fi && \
+    if [ "${BAZEL_CONFIG}" = "--config=production" ]; then echo "Running Bazel release build ..." ; fi && \
+    if [ "${BAZEL_CONFIG}" = "--config=production" ]; then bazel run //lte/gateway/release:release_build --config=production; fi && \
     echo "Running Bazel test on all '${BAZEL_TARGET_RULE}' targets with config '${BAZEL_CONFIG}' ..." && \
     bazel test ${BAZEL_CONFIG} --flaky_test_attempts=5 --test_tag_filters=-manual `bazel query "kind(${BAZEL_TARGET_RULE}, //...)"` && \
     echo "The size of the /var/cache/bazel-cache* folders is:" && \


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Fix `.dockerignore` hiding most folders in cache build. Otherwise this leads to a failure of the release build.
- Add coverage and the release build selectively to the bazel caches.
- Resolves #14679

## Test Plan

- [Run on fork](https://github.com/LKreutzer/magma/actions/runs/3683741395)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
