### PR TITLE
ci: remove lte dev integ test handling in publishing script

### DIFF
--- a/ci-scripts/firebase_publish_report.py
+++ b/ci-scripts/firebase_publish_report.py
@@ -63,11 +63,6 @@ def url_to_html_redirect(run_id: str, url: Optional[str]):
     )
 
 
-def lte_integ_test(args):
-    """Prepare and publish LTE Integ Test report"""
-    prepare_and_publish('lte_integ_test', args, 'test_status.txt')
-
-
 def debian_lte_integ_test(args):
     """Prepare and publish LTE Integ Test report"""
     prepare_and_publish('debian_lte_integ_test', args, 'test_status.txt')
@@ -133,7 +128,6 @@ parser.add_argument("--run_id", default="none", help="Github Actions Run ID")
 subparsers = parser.add_subparsers(title='subcommands', dest='cmd')
 
 tests = {
-    'lte': lte_integ_test,
     'feg': feg_integ_test,
     'cwf': cwf_integ_test,
     'sudo_python_tests': sudo_python_tests,


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

As part of #14178 and #14663, this PR removes publishing lte dev integ test results from the publishing script. 

:warning: DO NOT MERGE BEFORE [CI Dashboard PR 22](https://github.com/magma/ci-dashboard/pull/22) is published.
