### PR TITLE
fix: steps that need sudo are executed as sudo

### DIFF
--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -72,6 +72,7 @@
       Verify-Peer "false";
       Verify-Host "false";
       };
+  become: true
   tags:
     - agwc
     - base
@@ -82,6 +83,7 @@
     filename: magma
     state: present
     update_cache: true
+  become: true
   tags:
     - agwc
     - base


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

In #14601 some provisioning steps were introduced/changed with insufficient rights. This breaks the mgama_deb provisioning.

## Test Plan

vagrant up magma_deb

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
