### PR TITLE
fix(ci): Fix FeG radius redis tests

### DIFF
--- a/feg/radius/src/session/storage.common_test.go
+++ b/feg/radius/src/session/storage.common_test.go
@@ -16,7 +16,6 @@ package session
 import (
 	"fmt"
 	"math/rand"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,10 +55,8 @@ func loopReadWriteDelete(
 	storage GlobalStorage,
 	sessionID string,
 	count int,
-	onComplete *sync.WaitGroup,
 ) {
 	for i := 1; i < count; i++ {
 		performSignleReadWriteDeleteReadTest(t, storage, fmt.Sprintf("%s_%d", sessionID, i))
 	}
-	onComplete.Done()
 }

--- a/feg/radius/src/session/storage.memory_test.go
+++ b/feg/radius/src/session/storage.memory_test.go
@@ -36,9 +36,11 @@ func TestMultipleConcurrentInsertDeleteGet(t *testing.T) {
 
 	// Act
 	for i := 0; i < degOfParallelism; i++ {
+		onComplete.Add(1)
 		go func(called string, calling string) {
+			defer onComplete.Done()
 			sessionID := fmt.Sprintf("session_%s_%s", calling, called)
-			loopReadWriteDelete(t, storage, sessionID, reqPerConcurrentContext, &onComplete)
+			loopReadWriteDelete(t, storage, sessionID, reqPerConcurrentContext)
 		}(fmt.Sprintf("called%d", i), fmt.Sprintf("calling%d", i))
 	}
 	onComplete.Wait()

--- a/feg/radius/src/session/storage.redis_test.go
+++ b/feg/radius/src/session/storage.redis_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestBasicInsertGetRedis(t *testing.T) {
-	t.Skip("Skipping due to flakiness") // TODO GH14659
-
 	// Arrange
 	sessionID := "test"
 
@@ -37,8 +35,6 @@ func TestBasicInsertGetRedis(t *testing.T) {
 }
 
 func TestMultipleConcurrentInsertDeleteGetRedis(t *testing.T) {
-	t.Skip("Skipping due to flakiness") // TODO GH14659
-
 	// Arrange
 	degOfParallelism := 100
 	reqPerConcurrentContext := 100
@@ -51,9 +47,11 @@ func TestMultipleConcurrentInsertDeleteGetRedis(t *testing.T) {
 
 	// Act
 	for i := 0; i < degOfParallelism; i++ {
+		onComplete.Add(1)
 		go func(called string, calling string) {
+			defer onComplete.Done()
 			sessionID := fmt.Sprintf("session_%s_%s", calling, called)
-			loopReadWriteDelete(t, storage, sessionID, reqPerConcurrentContext, &onComplete)
+			loopReadWriteDelete(t, storage, sessionID, reqPerConcurrentContext)
 		}(fmt.Sprintf("called%d", i), fmt.Sprintf("calling%d", i))
 	}
 	onComplete.Wait()


### PR DESCRIPTION
## Summary

Works towards closing https://github.com/magma/magma/issues/14659.

This fixes the flakiness of `TestMultipleConcurrentInsertDeleteGetRedis` by fixing the handling of the wait group in the aforementioned test as well as in `TestMultipleConcurrentInsertDeleteGet`. In particular, it is necessary to call the `Add` method on the wait group in both tests to prevent `panic: sync: negative WaitGroup counter` errors.

This also moves the calling of the `Done` method from `loopReadWriteDelete` into the test functions themselves. This isn't strictly necessary to get the tests green, but I find it more intuitive to handle everything to do with the wait group in the test functions and not elsewhere. Additionally, I add the `defer` keyword, which prevents potential hanging goroutines by ensuring that `Done` is called even if the logic in the goroutine fails.

Finally, it removes the skipping of `TestBasicInsertGetRedis` which I didn't see failing when repeatedly running these tests.

## Test Plan

- [x] Green locally
- [x] Green in the CI
