### PR TITLE
chore(ci): Switch-off the bazel remote cache for the python sudo tests

### DIFF
--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -17,10 +17,6 @@ on:
     branches:
       - master
 
-env:
-  CACHE_KEY: magma-dev-vm
-  REMOTE_DOWNLOAD_OPTIMIZATION: false
-
 jobs:
   sudo-python-tests:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
@@ -63,7 +59,6 @@ jobs:
       - name: Run the sudo python tests
         run: |
           cd lte/gateway
-          vagrant ssh -c 'cd ~/magma; bazel/scripts/remote_cache_bazelrc_setup.sh "${{ env.CACHE_KEY }}" "${{ env.REMOTE_DOWNLOAD_OPTIMIZATION }}" "${{ secrets.BAZEL_REMOTE_PASSWORD }}";' magma
           vagrant ssh -c 'cd ~/magma; bazel/scripts/run_sudo_tests.sh --retry-on-failure --retry-attempts 1;' magma
       - name: Get test results
         if: always()


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #14681
- Switch-off the bazel remote cache for the python sudo tests

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
