### PR TITLE
chore(ci): Switch-off bazel remote cache for codespaces

### DIFF
--- a/.devcontainer/post-create-commands.sh
+++ b/.devcontainer/post-create-commands.sh
@@ -5,17 +5,6 @@
 sudo ln -s "$1"/lte/gateway/configs /etc/magma
 echo "alias magtivate='source /home/vscode/build/python/bin/activate'" >> ~/.bashrc
 
-# Only pull in cache for devcontainer opened inside GitHub Codespaces.
-# Locally opened Devcontainer has access to persistent cache directory in .bazel-cache and .bazel-cache-repo.
-# This is a little hacky, but GITHUB_CODESPACE_TOKEN should only be defined for the Codespace case
-if [[ -z $GITHUB_CODESPACE_TOKEN ]]; then
-    echo "Assuming the devcontainer is opened locally, not using Bazel remote cache..."
-else
-    echo "Assuming the devcontainer is opened in GitHub Codespaces, using read-only Bazel remote cache..."
-    cache_key=bazel-base-image  #  the devcontainer is based on the bazel-base container
-    (cd "$1" && bazel/scripts/remote_cache_bazelrc_setup.sh $cache_key)
-fi
-
 echo "Generating compile_commands.json for C/C++ code navigation"
 "$1"/dev_tools/gen_compilation_database.py
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Switch-off bazel remote cache for codespaces
  - The cache-key is already out of date, so for users this should not make a difference.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
