### PR TITLE
chore(feg): Fix typos in FeG radius

### DIFF
--- a/feg/radius/lib/go/oc/exporters/ods_test.go
+++ b/feg/radius/lib/go/oc/exporters/ods_test.go
@@ -39,7 +39,7 @@ var (
 	entity   = "my_component"
 )
 
-// For testing purpose im omitting the time of the datapoint
+// For testing purpose omitting the time of the datapoint
 type DatapointTest struct {
 	Entity string   `json:"entity"`
 	Key    string   `json:"key"`
@@ -113,7 +113,7 @@ func TestPostODS(t *testing.T) {
 		},
 	}
 
-	// Iteratting over tests while mocking ODS graph endpoint each time.
+	// Iterating over tests while mocking ODS graph endpoint each time.
 	for _, test := range tests {
 		test := test
 		t.Run(test.testName, func(t *testing.T) {
@@ -293,7 +293,7 @@ func TestExportView(t *testing.T) {
 			output: map[string]string{"Latency.gauge": "103.000000"},
 		},
 	}
-	// Iteratting over tests while mocking ODS graph endpoint each time.
+	// Iterating over tests while mocking ODS graph endpoint each time.
 	for _, test := range tests {
 		test := test
 		t.Run(test.testName, func(t *testing.T) {

--- a/feg/radius/src/modules/eap/authstate/manager.memory_test.go
+++ b/feg/radius/src/modules/eap/authstate/manager.memory_test.go
@@ -37,10 +37,10 @@ func TestBasicInsertGet(t *testing.T) {
 	authReq := createRadiusPacket("called", "calling")
 
 	// Act and Assert
-	performSignleReadWriteDeleteReadTest(t, manager, authReq)
+	performSingleReadWriteDeleteReadTest(t, manager, authReq)
 }
 
-func performSignleReadWriteDeleteReadTest(t *testing.T, manager Manager, authReq radius.Packet) {
+func performSingleReadWriteDeleteReadTest(t *testing.T, manager Manager, authReq radius.Packet) {
 	// Arrange (randomize state)
 	correlationID := rand.Intn(9999999)
 	eapType := packet.EAPTypeAKA
@@ -90,7 +90,7 @@ func TestMultipleConcurrentInsertDeleteGet(t *testing.T) {
 			defer wg.Done()
 			authReq := createRadiusPacket(called, calling)
 			for i := 0; i < reqPerConcurrentContext; i++ {
-				performSignleReadWriteDeleteReadTest(t, manager, authReq)
+				performSingleReadWriteDeleteReadTest(t, manager, authReq)
 			}
 		}(fmt.Sprintf("called%d", i), fmt.Sprintf("calling%d", i))
 	}

--- a/feg/radius/src/session/storage.common_test.go
+++ b/feg/radius/src/session/storage.common_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func performSignleReadWriteDeleteReadTest(t *testing.T, storage GlobalStorage, sessionID string) {
+func performSingleReadWriteDeleteReadTest(t *testing.T, storage GlobalStorage, sessionID string) {
 	// Arrange
 	msisdn := fmt.Sprintf("+%d", rand.Intn(999999))
 
@@ -59,7 +59,7 @@ func loopReadWriteDelete(
 	onComplete *sync.WaitGroup,
 ) {
 	for i := 1; i < count; i++ {
-		performSignleReadWriteDeleteReadTest(t, storage, fmt.Sprintf("%s_%d", sessionID, i))
+		performSingleReadWriteDeleteReadTest(t, storage, fmt.Sprintf("%s_%d", sessionID, i))
 	}
 	onComplete.Done()
 }

--- a/feg/radius/src/session/storage.memory_test.go
+++ b/feg/radius/src/session/storage.memory_test.go
@@ -24,7 +24,7 @@ func TestBasicInsertGet(t *testing.T) {
 	storage := NewMultiSessionMemoryStorage()
 
 	// Act and Assert
-	performSignleReadWriteDeleteReadTest(t, storage, "test")
+	performSingleReadWriteDeleteReadTest(t, storage, "test")
 }
 
 func TestMultipleConcurrentInsertDeleteGet(t *testing.T) {

--- a/feg/radius/src/session/storage.redis_test.go
+++ b/feg/radius/src/session/storage.redis_test.go
@@ -33,7 +33,7 @@ func TestBasicInsertGetRedis(t *testing.T) {
 	storage := NewMultiSessionRedisStorage(mr.Addr(), "", 0)
 
 	// Act and Assert
-	performSignleReadWriteDeleteReadTest(t, storage, sessionID)
+	performSingleReadWriteDeleteReadTest(t, storage, sessionID)
 }
 
 func TestMultipleConcurrentInsertDeleteGetRedis(t *testing.T) {

--- a/feg/radius/src/session/storage_test.go
+++ b/feg/radius/src/session/storage_test.go
@@ -27,10 +27,10 @@ func TestBasicSessionStorageInsertGet(t *testing.T) {
 	storage := NewSessionStorage(NewMultiSessionMemoryStorage(), sessionID)
 
 	// Act and Assert
-	performSignleSessionStorageTest(t, storage, sessionID)
+	performSingleSessionStorageTest(t, storage, sessionID)
 }
 
-func performSignleSessionStorageTest(t *testing.T, storage Storage, sessionID string) {
+func performSingleSessionStorageTest(t *testing.T, storage Storage, sessionID string) {
 	// Arrange
 	msisdn := fmt.Sprintf("+%d", rand.Intn(999999))
 


### PR DESCRIPTION
## Summary

Clean-up of some typos in comments and function names I spotted while working on FeG radius.

## Test Plan

- [x] Affected tests are green locally
- [x] CI