### PR TITLE
fix(ci): Fix TestPostODS in FeG radius

### DIFF
--- a/feg/radius/lib/go/oc/exporters/ods_test.go
+++ b/feg/radius/lib/go/oc/exporters/ods_test.go
@@ -83,7 +83,6 @@ func (m *mockConfigProvider) setConfig(cfg Config) Config {
 }
 
 func TestPostODS(t *testing.T) {
-	t.Skip("Skipped because it fails consistently") // TODO GH14659
 
 	tests := []struct {
 		testName    string
@@ -100,7 +99,7 @@ func TestPostODS(t *testing.T) {
 			resp:        nil,
 		},
 		{
-			testName: "actuall_datapoints_should_pass",
+			testName: "actual_datapoints_should_pass",
 			metricsData: map[string]string{
 				"success": "1",
 				"failed":  "3",
@@ -133,6 +132,7 @@ func TestPostODS(t *testing.T) {
 			var odsCfg = Config{
 				Category: category,
 				Token:    token,
+				Prefix:   "dummy",
 				Entity:   entity,
 				GraphURL: u.String(),
 			}


### PR DESCRIPTION
## Summary

Works towards closing https://github.com/magma/magma/issues/14659.

Adds a `Prefix` field to the ODS config so that `entity` is constructed as expected in `PostToODS`. Without this, you get the following error:

```
Diff:
--- Expected
+++ Actual
@@ -1 +1 @@
-access_token=456|789&category_id=123&datapoints=[{"entity":"dummy.my_component","key":"failed","value":"3","tags":null},{"entity":"dummy.my_component","key":"success","value":"1","tags":null}]
+access_token=456|789&category_id=123&datapoints=[{"entity":".my_component","key":"failed","value":"3","tags":null},{"entity":".my_component","key":"success","value":"1","tags":null}]
```

This also fixes a typo in the test.

## Test Plan

- [x] Green locally
- [x] Green in the CI