### PR TITLE
fix(agw): fix arp traffic in pipelined

### DIFF
--- a/lte/gateway/deploy/roles/trfserver/files/udhcpd.conf
+++ b/lte/gateway/deploy/roles/trfserver/files/udhcpd.conf
@@ -15,7 +15,6 @@ end             192.168.128.254 #default: 192.168.0.254
 interface       eth2            #default: eth0
 opt     dns     192.168.10.2 192.168.10.10
 option  subnet  255.255.255.0
-opt     router  192.168.10.2
 opt     wins    192.168.10.10
 option  dns     129.219.13.81   # appended to above DNS servers for a total of 3
 option  domain  local

--- a/lte/gateway/python/magma/pipelined/gw_mac_address.py
+++ b/lte/gateway/python/magma/pipelined/gw_mac_address.py
@@ -121,6 +121,7 @@ def _get_gw_mac_address_v4(gw_ip: str, vlan: str, non_nat_arp_egress_port: str) 
                 f"Unexpected IP in ARP response. expected: {gw_ip} pkt: {str(parsed)}",
             )
             return ""
+
         if vlan.isdigit():
             if parsed.dot1q is not None and str(parsed.dot1q.vlan) == vlan:
                 mac = parsed.arp.hwsrc
@@ -178,12 +179,12 @@ def _send_packet_and_receive_response(pkt: dpkt.arp.ARP, vlan: str, non_nat_arp_
     buffsize = 2 ** 16
     sol_packet = 263
     packet_aux_data = 8
-    with socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(0x0003)) as s:
+    with socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(dpkt.ethernet.ETH_TYPE_ARP)) as s:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, buffsize)
         if vlan.isdigit():
             s.setsockopt(sol_packet, packet_aux_data, 1)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, 1)
-        s.bind((non_nat_arp_egress_port, 0x0003))
+        s.bind((non_nat_arp_egress_port, dpkt.ethernet.ETH_TYPE_ARP))
         s.send(bytes(pkt))
         if vlan.isdigit():
             res, aux, _, _ = s.recvmsg(0xffff, socket.CMSG_LEN(4096))


### PR DESCRIPTION
With @MoritzThomasHuebner .

## Summary

When running integration tests in non-nat mode, there are errors in pipelined with `Unexpected IP in ARP response`. 
* Some of these are IPv4 packets instead of ARP packets
* Some have an unexpected source IP address (the one specified as router IP in the `udhcpd.conf` on the traffic server)

The first issue is solved by setting the socket to only receive ARP packets.
The second issue is resolved by deleting the relevant line from the config file.

## Test Plan

Run non-nat integration tests and check the pipelined logs for errors.

## Additional Information

- [ ] This change is backwards-breaking

