### PR TITLE
fix(ci): Fix flakiness of radius tests with sleep

### DIFF
--- a/feg/radius/src/modules/coafixedip/coa_fixed_ip_test.go
+++ b/feg/radius/src/modules/coafixedip/coa_fixed_ip_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestCoaFixed(t *testing.T) {
-	t.Skip("Skipped due to flakiness") // TODO GH14659
-
 	// Arrange
 	secret := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
 	port := 4799

--- a/feg/radius/src/modules/coanas/coa_nas_test.go
+++ b/feg/radius/src/modules/coanas/coa_nas_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestCoaNas(t *testing.T) {
-	t.Skip("Skipped due to flakiness") // TODO GH14659
-
 	// Arrange
 	secret := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
 	port := 4799
@@ -73,8 +71,6 @@ func TestCoaNas(t *testing.T) {
 }
 
 func TestCoaNasNoResponse(t *testing.T) {
-	t.Skip("Skipped due to flakiness") // TODO GH14659
-
 	// Arrange
 	secret := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
 	addr := ":4799"
@@ -126,8 +122,6 @@ func TestCoaNasNoResponse(t *testing.T) {
 }
 
 func TestCoaNasFieldInvalid(t *testing.T) {
-	t.Skip("Skipped due to flakiness") // TODO GH14659
-
 	// Arrange
 	secret := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
 	port := 4799

--- a/feg/radius/src/modules/lbserve/lb_serve_test.go
+++ b/feg/radius/src/modules/lbserve/lb_serve_test.go
@@ -90,8 +90,6 @@ func TestLBServeFailsWithNoUpstreamHost(t *testing.T) {
 }
 
 func TestLBServeProxiesRequestToRadiusAndReturnsResponse(t *testing.T) {
-	t.Skip("Skipped due to flakiness") // TODO GH14659
-
 	// Arrange
 	var sessionID = "sessionID"
 
@@ -157,8 +155,6 @@ func spawnRadiusServer() (server *radius.PacketServer, port int, err error) {
 }
 
 func TestLBServeFailsWithRadiusError(t *testing.T) {
-	t.Skip("Skipped due to flakiness") // TODO GH14659
-
 	// Arrange
 	var sessionID = "sessionID"
 

--- a/feg/radius/src/modules/module_test_utils.go
+++ b/feg/radius/src/modules/module_test_utils.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"layeh.com/radius"
 )
@@ -38,6 +39,7 @@ func WaitForRadiusServerToBeReady(secret []byte, addr string) (err error) {
 		if err == nil {
 			return nil
 		}
+		time.Sleep(5 * time.Millisecond)
 	}
 	return fmt.Errorf(
 		"radius server failed to be ready after %d retries: %v",


### PR DESCRIPTION
## Summary

Works towards closing https://github.com/magma/magma/issues/14659.

A selection of the FeG radius unit tests are flaky due to errors like:

```
=== FAIL: modules/coanas TestCoaNas (0.00s)
Starting server...     coa_nas_test.go:49: 
                Error Trace:    coa_nas_test.go:49
                Error:          Expected nil, but got: &errors.errorString{s:"radius server failed to be ready after 10 retries: read udp 127.0.0.1:55495->127.0.0.1:4799: read: connection refused"}
                Test:           TestCoaNas
```

This modifies the behaviour of the recently introduced function that waits for the server to be ready by introducing a short sleep between retries. It also removes the skipping of the affected tests so that they run in the CI.

## Test Plan

- [x] I ran all of the tests in `feg/radius/src` 50 times locally without encountering any failures
- [x] CI