### PR TITLE
fix(ci): include wget into Dockerfile

### DIFF
--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -188,6 +188,7 @@ RUN apt-get update && apt-get install -y \
   sudo \
   tshark \
   tzdata \
+  wget \
   && rm -rf /var/lib/apt/lists/*
 
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Follow up from #14601. While there is no `wget` call in the `gateway_c` build itself, it is apparently needed somewhere along the line for the containers to run during the LTE integration tests based on a containerized AGW.

## Test Plan

- Spin up the containers locally (the CI job only runs on master).

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
