### PR TITLE
docs: Replace make run with bazel steps in the quick start guide

### DIFF
--- a/docs/readmes/basics/quick_start_guide.md
+++ b/docs/readmes/basics/quick_start_guide.md
@@ -75,8 +75,7 @@ We will kick off the initial build of the AGW from source here.
 
 ```bash
 HOST [magma/lte/gateway]$ vagrant ssh magma
-MAGMA-VM [/home/vagrant]$ cd magma/lte/gateway
-MAGMA-VM [/home/vagrant/magma/lte/gateway]$ make run
+MAGMA-VM [/home/vagrant]$ cd $MAGMA_ROOT && bazel/scripts/build_and_run_bazelified_agw.sh
 ```
 
 **Note**: If you encounter unexpected errors during this process, try running
@@ -85,8 +84,8 @@ information.
 
 This will take a while (we have a lot of CXX files to build). With 2 extensive
 build jobs running, now is a good time to grab a coffee or lunch. The first
-build ever from source will take a while, but afterwards, a persistent ccache
-and Docker's native layer caching will speed up subsequent builds
+build ever from source will take a while, but afterwards, a persistent Bazel
+cache and Docker's native layer caching will speed up subsequent builds
 significantly.
 
 You can monitor what happens in the other tab now:


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Replace `make run` by bazel instructions that were removed from unlinked doc in in [this PR](https://github.com/magma/magma/pull/14703/files#diff-7a99a0f1b62bd164bda426d3f37dee9c08accce69ec7328a61ffe1c899b15b70).

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
