### PR TITLE
chore: Add helpful logging for executing the manual tests

### DIFF
--- a/bazel/python_utils/BUILD.bazel
+++ b/bazel/python_utils/BUILD.bazel
@@ -16,3 +16,12 @@ py_library(
     srcs = ["coverage_decorator.py"],
     visibility = ["//visibility:public"],
 )
+
+# 'conftest.py' is a configuration file for pytest, it is used to prevent
+# the execution of the Python sudo and LTE integration tests with the
+# 'bazel test' command.
+py_library(
+    name = "conftest",
+    srcs = ["conftest.py"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/python_utils/conftest.py
+++ b/bazel/python_utils/conftest.py
@@ -1,0 +1,35 @@
+# Copyright 2022 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+
+@pytest.hookimpl()
+def pytest_sessionstart(session):
+    if os.geteuid() != 0:
+        raise Exception(
+            "\n\n" + \
+            "################################################################################\n" * 3 + \
+            "To execute tests tagged as 'manual' you need to use the relevant shell script in\n" + \
+            "'$MAGMA_ROOT/bazel/scripts/'!\n" + \
+            "For Python sudo tests: '$MAGMA_ROOT/bazel/scripts/run_sudo_tests.sh'!\n" + \
+            "For LTE integration tests: '$MAGMA_ROOT/bazel/scripts/run_integ_tests.sh'!\n" + \
+            "The scripts can be used to execute individual tests. To have the full overview\n" + \
+            "of the available options add '--help' to them.\n" + \
+            "Note: You got this error, because the test is tagged as manual and the user id\n" + \
+            "is not zero, which indicates that you are not running the test as root.\n" + \
+            "Disclaimer: Do not execute bazel commands as root, because it can destroy your\n" + \
+            "local bazel setup, you have to use the above mentioned scripts." + \
+            "\n################################################################################" * 3 + \
+            "\n\n",
+        )

--- a/bazel/scripts/run_load_tests.sh
+++ b/bazel/scripts/run_load_tests.sh
@@ -19,6 +19,15 @@ set -euo pipefail
 # FUNCTION DECLARATIONS
 ###############################################################################
 
+help() {
+    echo "Run the AGW load tests with bazel."
+    echo "Usage:"
+    echo "   $(basename "$0") --help"
+    echo "      Display this help message."
+    echo "   $(basename "$0")" 
+    echo "      Executes all bazel tests that are tagged as load_test." 
+}
+
 build_load_tests() {
     echo "Building load tests..."
     bazel build //lte/gateway/python/load_tests:all
@@ -43,6 +52,12 @@ run_load_tests() {
 ###############################################################################
 # SCRIPT SECTION
 ###############################################################################
+
+if [[ "${1:-}" != "" ]];
+then
+    help
+    exit 0
+fi
 
 declare -a LOAD_TEST_LIST=("loadtest_mobilityd allocate" \
                            "loadtest_mobilityd release" \

--- a/bazel/test_constants.bzl
+++ b/bazel/test_constants.bzl
@@ -31,20 +31,28 @@ TAG_MANUAL = ["manual"]
 
 # Used for a "sudo test" that needs to be executed by a user with sudo
 # privileges. This is a restriction mainly known for some Python tests.
+# To run sudo tests execute: $MAGMA_ROOT/bazel/scripts/run_sudo_tests.sh
 # Note: for now a sudo test is also tagged as "manual".
 TAG_SUDO_TEST = ["sudo_test"] + TAG_MANUAL
 
 # Used for integration tests. These tests need to be executed manually
 # by a user with sudo privileges. These tags represent test categories,
 # which are used to determine the appropriate environment for them.
-TAG_PRECOMMIT_TEST = ["precommit_test"] + TAG_MANUAL
-TAG_EXTENDED_TEST = ["extended_test"] + TAG_MANUAL
-TAG_EXTENDED_TEST_SETUP = ["extended_setup"] + TAG_MANUAL
-TAG_EXTENDED_TEST_TEARDOWN = ["extended_teardown"] + TAG_MANUAL
-TAG_NON_SANITY_TEST = ["nonsanity_test"] + TAG_MANUAL
-TAG_NON_SANITY_TEST_SETUP = ["nonsanity_setup"] + TAG_MANUAL
-TAG_NON_SANITY_TEST_TEARDOWN = ["nonsanity_teardown"] + TAG_MANUAL
+# To run integration tests execute: $MAGMA_ROOT/bazel/scripts/run_integ_tests.sh
+TAG_INTEGRATION_TEST = ["integration_test"]
+TAG_PRECOMMIT_TEST = ["precommit_test"] + TAG_MANUAL + TAG_INTEGRATION_TEST
+TAG_EXTENDED_TEST = ["extended_test"] + TAG_MANUAL + TAG_INTEGRATION_TEST
+TAG_EXTENDED_TEST_SETUP = ["extended_setup"] + TAG_MANUAL + TAG_INTEGRATION_TEST
+TAG_EXTENDED_TEST_TEARDOWN = ["extended_teardown"] + TAG_MANUAL + TAG_INTEGRATION_TEST
+TAG_NON_SANITY_TEST = ["nonsanity_test"] + TAG_MANUAL + TAG_INTEGRATION_TEST
+TAG_NON_SANITY_TEST_SETUP = ["nonsanity_setup"] + TAG_MANUAL + TAG_INTEGRATION_TEST
+TAG_NON_SANITY_TEST_TEARDOWN = ["nonsanity_teardown"] + TAG_MANUAL + TAG_INTEGRATION_TEST
 TAG_TRAFFIC_SERVER_TEST = ["traffic_server_test"]
+
+# Used for load tests. These tests need to be executed by the
+# '$MAGMA_ROOT/bazel/scripts/run_load_tests.sh' script to preserve
+# the ordering of the test cases.
+TAG_LOAD_TEST = ["load_test"] + TAG_MANUAL
 
 # Tag for utility scripts that are used in the Magma VM.
 TAG_UTIL_SCRIPT = ["util_script"]

--- a/bazel/test_constants.bzl
+++ b/bazel/test_constants.bzl
@@ -38,7 +38,7 @@ TAG_SUDO_TEST = ["sudo_test"] + TAG_MANUAL
 # Used for integration tests. These tests need to be executed manually
 # by a user with sudo privileges. These tags represent test categories,
 # which are used to determine the appropriate environment for them.
-# To run integration tests execute: $MAGMA_ROOT/bazel/scripts/run_integ_tests.sh
+# To run the LTE integration tests execute: $MAGMA_ROOT/bazel/scripts/run_integ_tests.sh
 TAG_INTEGRATION_TEST = ["integration_test"]
 TAG_PRECOMMIT_TEST = ["precommit_test"] + TAG_MANUAL + TAG_INTEGRATION_TEST
 TAG_EXTENDED_TEST = ["extended_test"] + TAG_MANUAL + TAG_INTEGRATION_TEST

--- a/lte/gateway/python/load_tests/BUILD.bazel
+++ b/lte/gateway/python/load_tests/BUILD.bazel
@@ -11,6 +11,7 @@
 
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("//bazel:test_constants.bzl", "TAG_LOAD_TEST")
 
 MAGMA_ROOT = "../../../../"
 
@@ -32,6 +33,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_LOAD_TEST,
     deps = [
         ":common",
         "//orc8r/gateway/python/magma/common:service_registry",
@@ -48,6 +50,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_LOAD_TEST,
     deps = [
         ":common",
         "//lte/gateway/python/magma/subscriberdb:sid",
@@ -63,6 +66,7 @@ py_binary(
     srcs = ["loadtest_pipelined.py"],
     imports = [LTE_ROOT],
     legacy_create_init = False,
+    tags = TAG_LOAD_TEST,
     deps = [
         ":common",
         "//lte/gateway/python/magma/pipelined:policy_converters",
@@ -78,6 +82,7 @@ py_binary(
     srcs = ["loadtest_policydb.py"],
     imports = [LTE_ROOT],
     legacy_create_init = False,
+    tags = TAG_LOAD_TEST,
     deps = [
         ":common",
         "//lte/protos:policydb_python_proto",
@@ -90,6 +95,7 @@ py_binary(
     srcs = ["loadtest_sessiond.py"],
     imports = [LTE_ROOT],
     legacy_create_init = False,
+    tags = TAG_LOAD_TEST,
     deps = [
         ":common",
         "//lte/protos:session_manager_python_proto",
@@ -105,6 +111,7 @@ py_binary(
         ORC8R_ROOT,
     ],
     legacy_create_init = False,
+    tags = TAG_LOAD_TEST,
     deps = [
         ":common",
         "//lte/gateway/python/magma/subscriberdb:sid",


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Some tests (sudo-, integration-, loadtest) require root privileges and cannot be executed with `bazel test`.
Currently executing them with `bazel test` gives no indication that the tests were actually skipped.
This PR introduces a check for these tests, that will make them fail if they are not executed as sudo and give a helpful message about the scripts you should use to execute them.

:warning: Note: running `sudo bazel test` can break your local Bazel setup, do not try it! :x:

This closes #14651.

## Test Plan

Try:
`bazel test  --cache_test_results=no  //lte/gateway/python/magma/mobilityd/tests:test_ip_allocator_dhcp_e2e` (sudo)
`bazel test  --cache_test_results=no  //lte/gateway/python/magma/mobilityd/tests:test_multi_apn_ip_alloc` (not sudo)
`bazel test  --cache_test_results=no  //lte/gateway/python/magma/mobilityd/tests:test_ip_allocator_dhcp_e2e //lte/gateway/python/magma/mobilityd/tests:test_multi_apn_ip_alloc` (not sudo and sudo)
`bazel test  --cache_test_results=no  //lte/gateway/python/magma/mobilityd/tests/...` (sudo targets are ignored with wildcards)
`bazel/scripts/run_integ_tests.sh //lte/gateway/python/integ_tests/s1aptests:test_attach_detach` (integration tests)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
