### PR TITLE
fix(ci): output test_status from containerized integ tests correctly

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -200,24 +200,33 @@ jobs:
       - name: Create test_results directory
         run: mkdir -p lte/gateway/test-results
 
-      - name: Download results of precommit tests
+      - name: Download test results of precommit tests
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
         with:
           name: test-results-precommit
           path: "${{ github.workspace }}/lte/gateway/test-results"
 
-      - name: Download results of extended tests
+      - name: Download final status of precommit tests
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        with:
+          name: test-status-precommit
+
+      - name: Download test results of extended tests
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
         with:
           name: test-results-extended_tests
           path: "${{ github.workspace }}/lte/gateway/test-results"
 
+      - name: Download final status of of extended tests
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        with:
+          name: test-status-extended_tests
+
       - name: Determine end result for both tests
         run: |
-          echo "${{ needs.test-containers-precommit.outputs.final_status }}" > test_status_precommit.txt
-          echo "${{ needs.test-containers-extended.outputs.final_status }}" > test_status_extended.txt
-          diff test_status_precommit.txt test_status_extended.txt > /dev/null
-          if [ $? -eq 0 ]
+          result_precommit=$(cat test_status_precommit.txt)
+          result_extended=$(cat test_status_extended_tests.txt)
+          if [ $result_precommit == $result_extended ]
           then
             mv test_status_precommit.txt test_status.txt
           else

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -50,8 +50,6 @@ on:
 
 jobs:
   lte-integ-test-containerized:
-    outputs:
-      final_status: ${{ steps.get_final_status.outputs.final_status }}
     runs-on: macos-12
     steps:
       - name: Show inputs
@@ -119,15 +117,14 @@ jobs:
         working-directory: lte/gateway
         run: |
           fab get_test_summaries:dst_path="test-results",sudo_tests=False,dev_vm_name="magma_deb"
-      - name: Get final status
-        id: get_final_status
+      - name: Adapt name of file containing final status
         if: always()
         run: |
           if [ -f test_status.txt ]
           then
-            echo "final_status=$(cat test_status.txt)" >> $GITHUB_OUTPUT
+            mv test_status.txt test_status_${{ inputs.test_targets }}.txt
           else
-            echo "final_status=fail" >> $GITHUB_OUTPUT
+            echo fail > test_status_${{ inputs.test_targets }}.txt
           fi
       - name: Upload test results
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
@@ -135,3 +132,9 @@ jobs:
         with:
           name: test-results-${{ inputs.test_targets }}
           path: lte/gateway/test-results/**/*.xml
+      - name: Upload final_status
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        if: always()
+        with:
+          name: test-status-${{ inputs.test_targets }}
+          path: test_status_${{ inputs.test_targets }}.txt


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Follow up of #14643. GitHub actions had some difficulties handling the `Exit 1` from the diff command and outputs across multiple jobs. The final status of the tests is now transferred via upload/download of the artifact and the results are combined via string comparison. This should lead to the CI dashboard correctly indicating the results of the LTE integ tests based on a containerized AGW.
Close #14162.

## Test Plan

- I mocked these workflows relatively crude to test the combining of the results on its own, see the few green runs [on my fork](https://github.com/mpfirrmann/magma/actions/workflows/agw-build-publish-container.yml).
- Look to the dashboard.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
