### PR TITLE
feat: switch emakeev/milenage to magma/milenage

### DIFF
--- a/feg/gateway/services/testcore/hss/servicers/ai.go
+++ b/feg/gateway/services/testcore/hss/servicers/ai.go
@@ -17,10 +17,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/emakeev/milenage"
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/magma/milenage"
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"

--- a/feg/gateway/services/testcore/hss/servicers/ai_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/ai_test.go
@@ -17,11 +17,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/emakeev/milenage"
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/fiorix/go-diameter/v4/diam/dict"
+	"github.com/magma/milenage"
 	"github.com/stretchr/testify/assert"
 
 	"magma/feg/cloud/go/protos"

--- a/feg/gateway/services/testcore/hss/servicers/auth.go
+++ b/feg/gateway/services/testcore/hss/servicers/auth.go
@@ -17,8 +17,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/emakeev/milenage"
 	"github.com/golang/glog"
+	"github.com/magma/milenage"
 
 	"magma/lte/cloud/go/protos"
 )

--- a/feg/gateway/services/testcore/hss/servicers/auth_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/auth_test.go
@@ -16,7 +16,7 @@ package servicers_test
 import (
 	"testing"
 
-	"github.com/emakeev/milenage"
+	"github.com/magma/milenage"
 	"github.com/stretchr/testify/assert"
 
 	"magma/feg/gateway/services/testcore/hss/servicers"

--- a/feg/gateway/services/testcore/hss/servicers/hss.go
+++ b/feg/gateway/services/testcore/hss/servicers/hss.go
@@ -18,12 +18,12 @@ import (
 	"log"
 	"time"
 
-	"github.com/emakeev/milenage"
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/fiorix/go-diameter/v4/diam/dict"
 	"github.com/fiorix/go-diameter/v4/diam/sm"
+	"github.com/magma/milenage"
 
 	"magma/feg/cloud/go/protos/mconfig"
 	"magma/feg/gateway/diameter"

--- a/feg/gateway/services/testcore/hss/servicers/ma.go
+++ b/feg/gateway/services/testcore/hss/servicers/ma.go
@@ -17,11 +17,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/emakeev/milenage"
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/golang/glog"
+	"github.com/magma/milenage"
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"


### PR DESCRIPTION
Switch emakeev/milenage to magma/milenage - which is 99% identical - because consolidation is good for security. See https://github.com/magma/security/issues/143.

I haven't removed emakeev/milenage from go.mod and go.sum. Yet. 

Signed-off-by: Lucas Gonze <lucas@gonze.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
