### PR TITLE
ci: promote debian packages to magma-packages-prod

### DIFF
--- a/.github/workflows/debian-packages-promote.yml
+++ b/.github/workflows/debian-packages-promote.yml
@@ -60,12 +60,6 @@ jobs:
           JF_USER: ${{ secrets.LF_JFROG_USERNAME }}
           JF_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
 
-      - name: Publish debian packages
-        if: steps.jfrog-setup.conclusion == 'success' && github.event_name == 'workflow_dispatch'
-        env:
-          source-directory: ${{ env.source-repository }}/${{ env.distribution }}
-          target-directory: ${{ env.target-repository }}/${{ env.distribution }}
-        run: |
-          for file in ./*.deb; do
-              file=${file:2}
-          done
+      - name: Move all debian packages to prod
+        if: steps.jfrog-setup.conclusion == 'success'
+        run: jf rt cp "${{ env.source-repository }}/pool/${{ env.distribution }}/(*.deb)" ${{ env.target-repository }}/pool/${{ env.distribution }}/{1}

--- a/.github/workflows/debian-packages-promote.yml
+++ b/.github/workflows/debian-packages-promote.yml
@@ -1,0 +1,71 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Magma Promote Debian Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      distribution:
+        description: Distribution to set?
+        type: string
+        default: 'focal-ci'
+        required: true
+
+jobs:
+  debian-packages-promote:
+    runs-on: ubuntu-20.04
+    env:
+      distribution: ${{ inputs.distribution }}
+      source-repository: magma-packages-test
+      target-repository: magma-packages-prod
+    steps:
+      - uses: tspascoal/get-user-teams-membership@39b5264024b7c3bd7480de2f2c8d3076eed49ec5 # pin@v1.0.4
+        name: Check if user has rights to promote
+        id: checkUserMember
+        with:
+          username: ${{ github.actor }}
+          team: 'approvers-ci'
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+
+      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        run: |
+          echo "User is not a member of the approvers-ci group."
+          exit 1
+
+      - name: Verify distribution
+        run: |
+          if [ ${{ env.distribution }} != 'focal-ci' ] && [[ ! ${{ env.distribution }} =~ ^focal-1\.[0-9]+\.[0-9]+$ ]]
+          then
+              echo "You have chosen 'distribution' ${{ env.distribution }} as input."
+              echo "ERROR: Distribution name format check fails. Only focal-1.x.y is allowed. Abort!"
+              exit 1
+          fi
+
+      - name: Setup JFrog CLI
+        id: jfrog-setup
+        # Workaround because secrets are available in `env` but not in `if`
+        if: ${{ env.JF_USER != '' && env.JF_PASSWORD != '' }}
+        uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
+        env:
+          JF_URL: https://linuxfoundation.jfrog.io/
+          JF_USER: ${{ secrets.LF_JFROG_USERNAME }}
+          JF_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
+
+      - name: Publish debian packages
+        if: steps.jfrog-setup.conclusion == 'success' && github.event_name == 'workflow_dispatch'
+        env:
+          source-directory: ${{ env.source-repository }}/${{ env.distribution }}
+          target-directory: ${{ env.target-repository }}/${{ env.distribution }}
+        run: |
+          for file in ./*.deb; do
+              file=${file:2}
+          done


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary

This PR uses a github workflow to promote all debian artifacts in `magma-packages-test` to `magma-packages-prod`.
The workflow can only be triggered manually by selected GH users (`approvers-ci`).

Closes [#14696](https://github.com/magma/magma/issues/14696)

## Test Plan
- [x] Manual test in CI   ([Workflow run](https://github.com/magma/magma/actions/runs/3809126108/jobs/6480258247), [Artifactory](https://linuxfoundation.jfrog.io/ui/native/magma-packages-tmp/))

