### PR TITLE
chore: magma and sctpd have a license set in deb meta data

### DIFF
--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -50,6 +50,8 @@ URL = "https://github.com/magma/magma/"
 
 MAINTAINER = "The Magma Authors <main@lists.magmacore.org>"
 
+LICENSE_BSD_3_CLAUSE = "BSD-3-Clause"
+
 ### SCTPD BUILD
 
 genrule(
@@ -240,6 +242,8 @@ genrule(
             "sed -i 's/VERSION=REPLACE_ME/VERSION={ver}/' $@".format(ver = VERSION),
             "sed -i 's/MAGMA_INPUT_FILE_NAME=REPLACE_ME/MAGMA_INPUT_FILE_NAME={name}.deb/' $@".format(name = MAGMA_FILE_NAME),
             "sed -i 's/SCTPD_INPUT_FILE_NAME=REPLACE_ME/SCTPD_INPUT_FILE_NAME={name}.deb/' $@".format(name = SCTPD_FILE_NAME),
+            "sed -i 's/MAGMA_LICENSE=REPLACE_ME/MAGMA_LICENSE={license}/' $@".format(license = LICENSE_BSD_3_CLAUSE),
+            "sed -i 's/SCTPD_LICENSE=REPLACE_ME/SCTPD_LICENSE={license}/' $@".format(license = LICENSE_BSD_3_CLAUSE),
         ]) + select({
             ":is_production": " && sed -i 's/DEV_BUILD=true/DEV_BUILD=false/' $@",
             "//conditions:default": "",

--- a/lte/gateway/release/update_deb_meta_info.sh.template
+++ b/lte/gateway/release/update_deb_meta_info.sh.template
@@ -21,6 +21,7 @@ set -euo pipefail
 
 update_version() {
     local INPUT_FILE_NAME=$1
+    local LICENSE=$2
 
     WORK_FOLDER=$(mktemp -d)
     cd "${WORK_FOLDER}"
@@ -37,6 +38,9 @@ update_version() {
     if [ "${DEV_BUILD}" = true ] ; then
         sed -i "s/\(Description: .*$\)/\1 - dev build/" control
     fi
+
+    echo "  Updating license to \"${LICENSE}\""
+    echo "License: $LICENSE" >> control
 
     if [ -f postinst ]; then
         COMMIT_HASH_WITH_VERSION="magma@${VERSION}.${COMMIT_COUNT}-${HASH_SHORT}"
@@ -64,6 +68,8 @@ update_version() {
 VERSION=REPLACE_ME # set by genrule
 MAGMA_INPUT_FILE_NAME=REPLACE_ME # set by genrule
 SCTPD_INPUT_FILE_NAME=REPLACE_ME # set by genrule
+MAGMA_LICENSE=REPLACE_ME # set by genrule
+SCTPD_LICENSE=REPLACE_ME # set by genrule
 DEV_BUILD=true # can be overridden by genrule
 
 RESULT_FOLDER=/tmp/packages
@@ -79,5 +85,5 @@ HASH_SHORT=${HASH::8}
 TIMESTAMP=$(date +%s)
 VERSION_SUFFIX="${TIMESTAMP}-${HASH_SHORT}"
 
-update_version $MAGMA_INPUT_FILE_NAME
-update_version $SCTPD_INPUT_FILE_NAME
+update_version $MAGMA_INPUT_FILE_NAME $MAGMA_LICENSE
+update_version $SCTPD_INPUT_FILE_NAME $SCTPD_LICENSE


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Bazel rules_pkg/pkg_deb currently does not support a `license` attribute. Here: add the license attribute for now after the build.

In clarification if we can contribute upstream support for the attribute https://github.com/bazelbuild/rules_pkg/issues 650.

## Test Plan

```
$ bazel run //lte/gateway/release:release_build --config=production
$ dpkg -I /tmp/packages/magma_1.9.0-1671444723-75c0c19d_amd64.deb
...
 License: BSD-3-Clause
$ dpkg -I /tmp/packages/magma-sctpd_1.9.0-1671444723-75c0c19d_amd64.deb
...
 License: BSD-3-Clause
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
