### PR TITLE
fix: clone repo from new location without redirection

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -130,7 +130,7 @@ RUN apt-get install -y --no-install-recommends \
 
 ##### libgtpnl
 # review https://github.com/OPENAIRINTERFACE/openair-cn/blob/master/build/tools/build_helper.gtpnl
-RUN git clone https://git.osmocom.org/libgtpnl && \
+RUN git clone https://gitea.osmocom.org/cellular-infrastructure/libgtpnl && \
     cd libgtpnl && \
     git reset --hard 345d687 && \
     autoreconf -fi && \


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The github repo was moved to a new location. Cloning it locally results in 
```
~ git clone https://git.osmocom.org/libgtpnl
Cloning into 'libgtpnl'...
warning: redirecting to https://gitea.osmocom.org/cellular-infrastructure/libgtpnl/
remote: Enumerating objects: 441, done.
remote: Counting objects: 100% (441/441), done.
remote: Compressing objects: 100% (184/184), done.
remote: Total 441 (delta 257), reused 411 (delta 242), pack-reused 0
Receiving objects: 100% (441/441), 101.92 KiB | 5.10 MiB/s, done.
Resolving deltas: 100% (257/257), done.
```

This PR resolves this issue. 

## Test Plan

- Cloned the repos locally from both locations.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
