### PR TITLE
chore: magma deb artifacts package a license file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,8 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@rules_java//java:defs.bzl", "java_binary")
 
+exports_files(["LICENSE"])
+
 # gazelle:prefix github.com/magma/magma
 # gazelle:exclude .cache/
 # gazelle:exclude orc8r/

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -54,6 +54,12 @@ LICENSE_BSD_3_CLAUSE = "BSD-3-Clause"
 
 ### SCTPD BUILD
 
+pkg_files(
+    name = "sctpd_license",
+    srcs = ["//:LICENSE"],
+    prefix = "/usr/share/doc/{pkg_name}".format(pkg_name = SCTPD_PKGNAME),
+)
+
 genrule(
     name = "gen_sctpd_version",
     outs = ["version"],
@@ -78,6 +84,7 @@ pkg_tar(
     name = "sctpd_content",
     srcs = [
         ":sctpd_binary",
+        ":sctpd_license",
         ":sctpd_version",
         "//lte/gateway/deploy/roles/magma/files/systemd:sctpd_service_definition",
     ],
@@ -103,6 +110,12 @@ pkg_deb(
 )
 
 ### MAGMA BUILD
+
+pkg_files(
+    name = "magma_license",
+    srcs = ["//:LICENSE"],
+    prefix = "/usr/share/doc/{pkg_name}".format(pkg_name = MAGMA_PKGNAME),
+)
 
 pkg_filegroup(
     name = "magma_service_definitions",
@@ -193,6 +206,7 @@ pkg_tar(
         ":magma_configs",
         ":magma_ebpf",
         ":magma_go_binaries",
+        ":magma_license",
         ":magma_python_scripts",
         ":magma_python_services",
         ":magma_sctpd_min_version",

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -353,7 +353,8 @@ BUILDCMD="fpm \
 --exclude '*/.ignoreme' \
 ${SCTPD_BUILD}/sctpd=/usr/local/sbin/ \
 ${SCTPD_VERSION_FILE}=/usr/local/share/sctpd/version \
-$(glob_files "${SERVICE_DIR}/sctpd.service" /etc/systemd/system/sctpd.service)"
+$(glob_files "${SERVICE_DIR}/sctpd.service" /etc/systemd/system/sctpd.service) \
+${MAGMA_ROOT}/LICENSE=/usr/share/doc/${SCTPD_PKGNAME}/"
 
 eval "$BUILDCMD"
 
@@ -427,6 +428,7 @@ ${PY_PROTOS}=${PY_DEST} \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/${PKGNAME}*" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/*.egg-info" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/usr/bin/*" /usr/local/bin/) \
+${MAGMA_ROOT}/LICENSE=/usr/share/doc/${PKGNAME}/ \
 " # Leave this quote on a new line to mark end of BUILDCMD
 
 eval "$BUILDCMD"


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This change adds the magma LICENSE file to the make and bazel debian artifacts.

## Test Plan

```
#bazel
$ bazel run //lte/gateway/release:release_build --config=production
$ dpkg -c /tmp/packages/magma_1.9.0-1671466521-1bbee83a_amd64.deb | grep LICENSE
...
-rw-r--r-- 0/0            1509 2000-01-01 00:00 usr/share/doc/magma/LICENSE
$ dpkg -c /tmp/packages/magma-sctpd_1.9.0-1671466521-1bbee83a_amd64.deb | grep LICENSE
-rw-r--r-- 0/0            1509 2000-01-01 00:00 usr/share/doc/magma-sctpd/LICENSE

#make
$ ./lte/gateway/release/build-magma.sh #(remove costly build steps for a fast test)
$ dpkg -c magma-sctpd_1.8.0-1671470662-_amd64.deb | grep LICENSE
-rw-r--r-- 0/0            1509 2022-04-07 08:44 ./usr/share/doc/magma-sctpd/LICENSE
$ dpkg -c magma_1.8.0-1671470662-_amd64.deb | grep LICENSE
-rw-r--r-- 0/0            1509 2022-04-07 08:44 ./usr/share/doc/magma/LICENSE
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
