### PR TITLE
fix(ci): upload correct GHz images

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -96,6 +96,7 @@ jobs:
           REGISTRY: ${{ env.registry }}
           FILE: lte/gateway/docker/services/c/Dockerfile
           TAGS: ${{ steps.set-agwc-tags.outputs.c_image_tags }}
+          TARGET: gateway_c
       - run: echo "C container image digest is ${{ steps.docker-builder-c.outputs.digest }}"
       - run: echo "docker-builder-c conclusion = ${{ steps.docker-builder-c.conclusion }}"
 
@@ -107,6 +108,7 @@ jobs:
           REGISTRY: ${{ env.registry }}
           FILE: lte/gateway/docker/services/python/Dockerfile
           TAGS: ${{ steps.set-agwc-tags.outputs.python_image_tags }}
+          TARGET: gateway_python
       - run: echo "Python container image digest is ${{ steps.docker-builder-python.outputs.digest }}"
       - run: echo "docker-builder-python conclusion = ${{ steps.docker-builder-python.conclusion }}"
 
@@ -118,6 +120,7 @@ jobs:
           REGISTRY: ${{ env.registry }}
           FILE: feg/gateway/docker/go/Dockerfile
           TAGS: ${{ steps.set-agwc-tags.outputs.go_image_tags }}
+          TARGET: gateway_go
       - run: echo "Go container image digest is ${{ steps.docker-builder-go.outputs.digest }}"
       - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
 
@@ -151,6 +154,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
           REGISTRY: ${{ env.registry }}
           TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_c:${{ steps.get-short-git-sha.outputs.sha }}
+          TARGET: agw_c_ghz
           CONTEXT: lte/gateway/docker/ghz
 
       - uses: ./.github/workflows/composite/docker-builder-agw
@@ -159,6 +163,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
           REGISTRY: ${{ env.registry }}
           TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_python:${{ steps.get-short-git-sha.outputs.sha }}
+          TARGET: agw_python_ghz
           CONTEXT: lte/gateway/docker/ghz
 
   test-containers-precommit:

--- a/.github/workflows/composite/docker-builder-agw/action.yml
+++ b/.github/workflows/composite/docker-builder-agw/action.yml
@@ -25,6 +25,10 @@ inputs:
   TAGS:
     description: Docker image stream tags
     required: true
+  TARGET:
+    description: Target stage in the Docker file
+    required: false
+    default: ""
   FILE:
     description: Docker file
     required: false
@@ -45,6 +49,7 @@ runs:
       run: |
         echo "Registry:   ${{ inputs.REGISTRY }}"
         echo "Tags:       ${{ inputs.TAGS }}"
+        echo "Target:     ${{ inputs.TARGET }}"
         echo "Dockerfile: ${{ inputs.FILE }}"
         echo "Context:    ${{ inputs.CONTEXT }}"
       shell: bash
@@ -70,6 +75,7 @@ runs:
         context: ${{ inputs.CONTEXT }}
         file: ${{ inputs.CONTEXT }}/${{ inputs.FILE }}
         tags: ${{ inputs.TAGS }}
+        target: ${{ inputs.TARGET }}
         push: ${{ steps.docker-login.conclusion == 'success' }}
 
     - run: echo "Image digest for \`${{ inputs.TAGS }}\` is \`${{ steps.build-docker.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR utilizes the `target` input to the `docker/build-push-action` to upload the correct GHz images as described in [the documentation](https://docs.docker.com/build/ci/github-actions/configure-builder/#isolated-buildersl).
Closes #14627. 

## Test Plan

- See the [adapted GitHub action](https://github.com/mpfirrmann/magma/actions/runs/3733814442) and compare the SHAs for the [c image](https://github.com/mpfirrmann/magma/actions/runs/3733814442/jobs/6335086590#step:6:357) and the [python image](https://github.com/mpfirrmann/magma/actions/runs/3733814442/jobs/6335086590#step:7:354) with the respective entries in the artifactory.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
