### PR TITLE
test(agw): Add scaling tests for dhcp mode

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -244,6 +244,8 @@ s1aptests/test_s1_handover_cancel.py \
 s1aptests/test_s1_handover_failure.py \
 s1aptests/test_s1_handover_timer_expiry.py \
 s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py \
+s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py \
+s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py \
 s1aptests/test_restore_config_after_non_sanity.py
 
 #---------------

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -178,6 +178,8 @@ s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_rar_tcp_he.py \
 s1aptests/test_attach_detach_with_he_policy.py \
 s1aptests/test_paging_after_mme_restart.py \
+s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py \
+s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py \
 s1aptests/test_restore_mme_config_after_sanity.py
 
 EXTENDED_TESTS_LONG = s1aptests/test_modify_mme_config_for_sanity.py \
@@ -244,8 +246,6 @@ s1aptests/test_s1_handover_cancel.py \
 s1aptests/test_s1_handover_failure.py \
 s1aptests/test_s1_handover_timer_expiry.py \
 s1aptests/test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py \
-s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py \
-s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py \
 s1aptests/test_restore_config_after_non_sanity.py
 
 #---------------

--- a/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
@@ -1190,6 +1190,15 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_attach_detach_with_non_nat_dhcp",
+    size = "large",
+    srcs = ["test_attach_detach_with_non_nat_dhcp.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_PRECOMMIT_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
     name = "test_modify_mme_config_for_sanity",
     size = "medium",
     srcs = ["test_modify_mme_config_for_sanity.py"],
@@ -2207,15 +2216,6 @@ pytest_test(
     name = "test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue",
     size = "large",
     srcs = ["test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py"],
-    imports = [LTE_ROOT],
-    tags = TAG_NON_SANITY_TEST,
-    deps = [":s1ap_wrapper"],
-)
-
-pytest_test(
-    name = "test_attach_detach_with_non_nat_dhcp",
-    size = "large",
-    srcs = ["test_attach_detach_with_non_nat_dhcp.py"],
     imports = [LTE_ROOT],
     tags = TAG_NON_SANITY_TEST,
     deps = [":s1ap_wrapper"],

--- a/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
@@ -2222,6 +2222,24 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_attach_detach_with_non_nat_dhcp_multi_ue",
+    size = "large",
+    srcs = ["test_attach_detach_with_non_nat_dhcp_multi_ue.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_non_nat_dhcp_multi_ue_looped",
+    size = "large",
+    srcs = ["test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
     name = "test_restore_config_after_non_sanity",
     size = "medium",
     srcs = ["test_restore_config_after_non_sanity.py"],

--- a/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
@@ -1676,6 +1676,24 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_attach_detach_with_non_nat_dhcp_multi_ue",
+    size = "large",
+    srcs = ["test_attach_detach_with_non_nat_dhcp_multi_ue.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_non_nat_dhcp_multi_ue_looped",
+    size = "large",
+    srcs = ["test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
     name = "test_restore_mme_config_after_sanity",
     size = "small",
     srcs = ["test_restore_mme_config_after_sanity.py"],
@@ -2218,24 +2236,6 @@ pytest_test(
     srcs = ["test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py"],
     imports = [LTE_ROOT],
     tags = TAG_NON_SANITY_TEST,
-    deps = [":s1ap_wrapper"],
-)
-
-pytest_test(
-    name = "test_attach_detach_with_non_nat_dhcp_multi_ue",
-    size = "large",
-    srcs = ["test_attach_detach_with_non_nat_dhcp_multi_ue.py"],
-    imports = [LTE_ROOT],
-    tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
-    deps = [":s1ap_wrapper"],
-)
-
-pytest_test(
-    name = "test_attach_detach_with_non_nat_dhcp_multi_ue_looped",
-    size = "large",
-    srcs = ["test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py"],
-    imports = [LTE_ROOT],
-    tags = TAG_NON_SANITY_TEST + TAG_TRAFFIC_SERVER_TEST,
     deps = [":s1ap_wrapper"],
 )
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp.py
@@ -24,7 +24,6 @@ class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
     def setUp(self):
         """Initialize before test case execution"""
         self.magma_utils = MagmadUtil(None)
-
         self.magma_utils.enable_dhcp_config()
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
         self.magma_utils.disable_nat()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
@@ -35,7 +35,7 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
 
     def test_attach_detach_with_non_nat_dhcp(self):
-        """ Basic attach/detach test with two UEs and DHCP"""
+        """ Basic attach/detach test with 32 UEs and DHCP"""
         num_ues = 32
         ue_ids = []
         detach_type = [

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
@@ -1,0 +1,87 @@
+"""
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import time
+import unittest
+
+import s1ap_types
+from integ_tests.s1aptests import s1ap_wrapper
+from s1ap_utils import MagmadUtil
+
+
+class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
+
+    def setUp(self):
+        """Initialize before test case execution"""
+        self.magma_utils = MagmadUtil(None)
+        self.magma_utils.enable_dhcp_config()
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+        self.magma_utils.disable_nat()
+
+    def tearDown(self):
+        """Cleanup after test case execution"""
+        self.magma_utils.disable_dhcp_config()
+        self.magma_utils.enable_nat()
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_detach_with_non_nat_dhcp(self):
+        """ Basic attach/detach test with two UEs and DHCP"""
+        num_ues = 32
+        ue_ids = []
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
+        self._s1ap_wrapper.configUEDevice(num_ues)
+
+        for _ in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
+            # Now actually complete the attach
+            self._s1ap_wrapper._s1_util.attach(
+                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+            )
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+            ue_ids.append(req.ue_id)
+
+        for i, ue in enumerate(ue_ids):
+            # Now detach the UE
+            print("************************* Calling detach for UE id ", ue)
+            self._s1ap_wrapper.s1_util.detach(
+                ue,
+                detach_type[i % 2], True,
+            )
+
+        wait_interval = 5
+        max_iterations = 12
+        print(f"Waiting for a maximum of {max_iterations * wait_interval} seconds for IPs to be released")
+        for i in range(max_iterations):
+            keys, _, _, _ = self.magma_utils.get_redis_state()
+            if len(keys) == 0:
+                print(f"  All IPs released after {i * wait_interval} seconds")
+                break
+            print(f"  {len(keys)} IP(s) still in use after {i * wait_interval} seconds")
+            time.sleep(wait_interval)
+            if i == max_iterations - 1:
+                assert False, f"IPs not released after {max_iterations * wait_interval} seconds"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
@@ -63,7 +63,7 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
             # Now detach the UE
             print(
                 "************************* Running UE detach for UE id ",
-                req.ue_id
+                req.ue_id,
             )
             self._s1ap_wrapper.s1_util.detach(
                 req.ue_id, detach_type[i % 2], True,

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
@@ -1,0 +1,87 @@
+"""
+Copyright 2022 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import time
+import unittest
+
+import s1ap_types
+from integ_tests.s1aptests import s1ap_wrapper
+from s1ap_utils import MagmadUtil
+
+
+class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
+
+    def setUp(self):
+        """Initialize before test case execution"""
+        self.magma_utils = MagmadUtil(None)
+        self.magma_utils.enable_dhcp_config()
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+        self.magma_utils.disable_nat()
+
+    def tearDown(self):
+        """Cleanup after test case execution"""
+        self.magma_utils.disable_dhcp_config()
+        self.magma_utils.enable_nat()
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_detach_with_non_nat_dhcp(self):
+        # return
+        """ Basic attach/detach test with two UEs and DHCP"""
+        num_ues = 64
+        detach_type = [
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+        ]
+        self._s1ap_wrapper.configUEDevice(num_ues)
+
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            print(
+                "************************* Running End to End attach for ",
+                "UE id ", req.ue_id,
+            )
+            # Now actually complete the attach
+            self._s1ap_wrapper._s1_util.attach(
+                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+            )
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+            # Now detach the UE
+            print(
+                "************************* Running UE detach for UE id ",
+                req.ue_id
+            )
+            self._s1ap_wrapper.s1_util.detach(
+                req.ue_id, detach_type[i % 2], True,
+            )
+
+        wait_interval = 5
+        max_iterations = 12
+        print(f"Waiting for a maximum of {max_iterations * wait_interval} seconds for IPs to be released")
+        for i in range(max_iterations):
+            keys, _, _, _ = self.magma_utils.get_redis_state()
+            if len(keys) == 0:
+                print(f"  All IPs released after {i * wait_interval} seconds")
+                break
+            print(f"  {len(keys)} IP(s) still in use after {i * wait_interval} seconds")
+            time.sleep(wait_interval)
+            if i == max_iterations - 1:
+                assert False, f"IPs not released after {max_iterations * wait_interval} seconds"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
@@ -35,9 +35,8 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
 
     def test_attach_detach_with_non_nat_dhcp(self):
-        # return
-        """ Basic attach/detach test with two UEs and DHCP"""
-        num_ues = 64
+        """ looped attach/detach test with 32 UEs and DHCP"""
+        num_ues = 32
         detach_type = [
             s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -429,35 +429,23 @@ class IPAllocatorDHCP(IPAllocator):
         )
 
     def _release_dhcp_ip(self, ip_desc: IPDesc) -> None:
-        logging.info("Releasing: %s", ip_desc)
+        logging.info(f"Releasing: {ip_desc}")
         mac = create_mac_from_sid(ip_desc.sid)
         vlan = ip_desc.vlan_id
         dhcp_desc = self.get_dhcp_desc_from_store(mac, vlan)
-        logging.info("Releasing dhcp desc: %s", dhcp_desc)
+        logging.info(f"Releasing dhcp desc: {dhcp_desc}")
         if dhcp_desc:
-            call_args = [
-                DHCP_HELPER_CLI,
-                "--mac", str(mac),
-                "--vlan", str(vlan),
-                "--interface", self._iface,
-                "--json",
-                "release",
-                "--ip", str(ip_desc.ip),
-                "--server-ip", str(dhcp_desc.server_ip),
-            ]
-            ret = subprocess.run(
-                call_args,
-                capture_output=True,
-                check=False,
+            subprocess.Popen(
+                [
+                    DHCP_HELPER_CLI,
+                    "--mac", str(mac),
+                    "--vlan", str(vlan),
+                    "--interface", self._iface,
+                    "release",
+                    "--ip", str(ip_desc.ip),
+                    "--server-ip", str(dhcp_desc.server_ip),
+                ],
             )
-
-            if ret.returncode != 0:
-                call_str = " ".join(call_args)
-                logging.error(
-                    "CLI call '%s' failed with return code %s and error %s",
-                    call_str, ret.returncode, ret.stderr,
-                )
-                raise NoAvailableIPError('Failed to call dhcp_helper_cli.')
 
             key = mac.as_redis_key(vlan)
             with self.dhcp_wait:


### PR DESCRIPTION
With @MoritzThomasHuebner 

## Summary

This PR adds two scaling tests with repeated attach-detach loops for the non-nat mode with DHCP.
The locking in the release logic for this mode was changed, otherwise the database was locked for too long, so the release ran into a timeout.

## Test Plan

Check that the new s1ap integration tests are green. (might need re-provisioning of the dev VM, and needs the traffic server running with the udhcpd setup)
- [x] test_attach_detach_with_non_nat_dhcp_multi_ue.py
- [x] test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py

## Additional Information

- [ ] This change is backwards-breaking
