### PR TITLE
fix(agw): Migrated imei_htbl in mme_app to protobuf map

### DIFF
--- a/lte/gateway/c/core/oai/include/mme_config.hpp
+++ b/lte/gateway/c/core/oai/include/mme_config.hpp
@@ -55,6 +55,7 @@ extern "C" {
 }
 #endif
 
+#include "lte/gateway/c/core/oai/include/proto_map.hpp"
 #include "lte/gateway/c/core/oai/include/service303.hpp"
 #include "orc8r/gateway/c/common/sentry/SentryWrapper.hpp"
 
@@ -364,7 +365,7 @@ typedef struct restricted_plmn_s {
 typedef struct blocked_imei_list_s {
   int num;
   // data is NULL
-  hash_table_uint64_ts_t* imei_htbl;
+  magma::proto_map_uint64_uint32_t imei_map;
 } blocked_imei_list_t;
 
 typedef struct fed_mode_map_s {

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.cpp
@@ -418,6 +418,7 @@ int validate_imei(imeisv_t* imeisv) {
    * the hashlist
    */
   imei64_t tac64 = 0;
+  imei32_t temp_data = 0;
   if (!mme_config.blocked_imei.num) {
     OAILOG_DEBUG(LOG_NAS_EMM, "No Blocked IMEI exists, returning success!");
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, EMM_CAUSE_SUCCESS);
@@ -426,21 +427,19 @@ int validate_imei(imeisv_t* imeisv) {
                  "Blocked IMEI exists, proceed with validation...");
   }
   IMEI_MOBID_TO_IMEI_TAC64(imeisv, &tac64);
-  hashtable_rc_t h_rc = hashtable_uint64_ts_is_key_exists(
-      mme_config.blocked_imei.imei_htbl, (const hash_key_t)tac64);
-
-  if (HASH_TABLE_OK == h_rc) {
+  if (mme_config.blocked_imei.imei_map.get(tac64, &temp_data) == magma
+      : PROTO_MAP_OK) {
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, EMM_CAUSE_IMEI_NOT_ACCEPTED);
   } else {
     // Convert imei to uint64_t
     imei64_t imei64 = 0;
     IMEI_MOBID_TO_IMEI64(imeisv, &imei64);
-    hashtable_rc_t h_rc = hashtable_uint64_ts_is_key_exists(
-        mme_config.blocked_imei.imei_htbl, (const hash_key_t)imei64);
-    if (HASH_TABLE_OK == h_rc) {
+    if (mme_config.blocked_imei.imei_map.get(imei64, &temp_data) == magma
+        : PROTO_MAP_OK) {
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, EMM_CAUSE_IMEI_NOT_ACCEPTED);
     }
   }
+
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, EMM_CAUSE_SUCCESS);
 }
 


### PR DESCRIPTION
Migrated imei_htbl in mme_app to protobuf map

## Summary
Migrated imei_htbl in mme_app to protobuf map

pb.go file generated using command: `./build.py -g` in the path `magma/orc8r/cloud/docker` in magma-dev vm


## Test Plan

Verified compilation with following:
- make clean; make build_oai;
- make clean; bazel build //lte/gateway/c/core:agw_of
~make clean; bazel build --config=production //lte/gateway/c/core:agw_of~
- make clean; bazel test //lte/gateway/c/core/...
~make clean; bazel test //lte/gateway/c/core/oai/test/amf:amf_stateless_test~
- make clean; make FEATURES=mme_oai build_oai
~make clean; export FEATURES=mme_oai; make build_oai~

These compilations are no more valid on latest master after removal of target test_oai from Make file:
```
make clean; make test_oai;
make clean; make test_oai BUILD_TYPE=Debug OAI_TESTS=test_amf_app
```

Verified with sanity and in CI

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>

