### PR TITLE
feat(agw): Use json file to communicate with the DHCP helper cli

### DIFF
--- a/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py
+++ b/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py
@@ -268,6 +268,12 @@ def print_info(info: Dict, print_json: bool) -> None:
         print(f"router_ip: {info['router_ip']}")
 
 
+def save_to_file(info: Dict, filename: str) -> None:
+    if filename:
+        with open(filename, "w") as f:
+            f.write(json.dumps(info))
+
+
 def allocate_arg_handler(opts: argparse.Namespace) -> None:
     mac = MacAddress(opts.mac)
     vlan = int(opts.vlan)
@@ -277,6 +283,7 @@ def allocate_arg_handler(opts: argparse.Namespace) -> None:
     cli.allocate()
 
     print_info(cli.get_info(), opts.json)
+    save_to_file(cli.get_info(), opts.save_file)
 
 
 def release_arg_handler(opts: argparse.Namespace) -> None:
@@ -290,6 +297,7 @@ def release_arg_handler(opts: argparse.Namespace) -> None:
     cli.release()
 
     print_info(cli.get_info(), opts.json)
+    save_to_file(cli.get_info(), opts.save_file)
 
 
 def renew_arg_handler(opts: argparse.Namespace) -> None:
@@ -303,6 +311,7 @@ def renew_arg_handler(opts: argparse.Namespace) -> None:
     cli.renew()
 
     print_info(cli.get_info(), opts.json)
+    save_to_file(cli.get_info(), opts.save_file)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -313,6 +322,7 @@ def create_parser() -> argparse.ArgumentParser:
 
     parser.add_argument('--mac', help='MAC address to allocate/release', required=True)
     parser.add_argument('--json', help='Print the allocation/release information in json format', default=False, action='store_true')
+    parser.add_argument('--save-file', help='Save to the specified file', default="")
     parser.add_argument('--vlan', help='Whether to use VLAN (0 means no VLAN)', default=0)
     parser.add_argument('--interface', help='The network interface to send the request to', default='eth0')
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -353,7 +353,7 @@ class IPAllocatorDHCP(IPAllocator):
             raise NoAvailableIPError(msg)
 
     def _parse_dhcp_helper_cli_response_to_store(
-            self, dhcp_desc: DHCPDescriptor, dhcp_response: subprocess.CompletedProcess,
+            self, dhcp_desc: DHCPDescriptor, dhcp_response: Dict[str, Any],
             mac: MacAddress, vlan: int,
     ) -> DHCPDescriptor:
         if dhcp_response:

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -22,13 +22,12 @@ from __future__ import (
 
 import json
 import logging
+import os
 import subprocess
 import threading
 from copy import deepcopy
 from datetime import datetime
 from ipaddress import IPv4Network, ip_address, ip_network
-from json import JSONDecodeError
-import os
 from threading import Condition
 from typing import Any, Dict, List, Optional
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -391,7 +391,7 @@ class IPAllocatorDHCP(IPAllocator):
 
         with open(save_file, 'r') as f:
             dhcp_response = json.load(f)
-        # os.remove(save_file)
+        os.remove(save_file)
         return dhcp_response
 
     def release_ip(self, ip_desc: IPDesc) -> None:

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -22,7 +22,6 @@ from __future__ import (
 
 import json
 import logging
-import os
 import subprocess
 import tempfile
 import threading

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -120,8 +120,8 @@ class IPAllocatorDHCP(IPAllocator):
                             "--mac", str(dhcp_desc.mac),
                             "--vlan", str(dhcp_desc.vlan),
                             "--interface", self._iface,
-                            "--json",
                             "--save-file", save_file,
+                            "--json",
                             "allocate",
                         ]]
                         dhcp_cli_response = self._get_dhcp_helper_cli_response(call_args, save_file)
@@ -137,8 +137,8 @@ class IPAllocatorDHCP(IPAllocator):
                             "--mac", str(dhcp_desc.mac),
                             "--vlan", str(dhcp_desc.vlan),
                             "--interface", self._iface,
-                            "--json",
                             "--save-file", save_file,
+                            "--json",
                             "renew",
                             "--ip", str(dhcp_desc.ip),
                             "--server-ip", str(dhcp_desc.server_ip),

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -109,15 +109,19 @@ def run_dhcp_allocator_thread(
 
 def test_allocate_ip_address(
     ip_allocator_fixture: IPAllocatorDHCP,
+    ip_allocator_dhcp_fixture: IPAllocatorDHCP,
     ip_desc_fixture: IPDesc,
     dhcp_desc_fixture: DHCPDescriptor,
 ) -> None:
     ip_allocator_fixture.start_monitor_thread()
+    dhcp_desc = list(ip_allocator_dhcp_fixture._store.dhcp_store.values())[0]
+    save_file = f"/tmp/dhcp_cli_{str(dhcp_desc.mac)}.json"
     call_args = [[
         DHCP_HELPER_CLI,
         "--mac", str(dhcp_desc_fixture.mac),
         "--vlan", str(dhcp_desc_fixture.vlan),
         "--interface", ip_allocator_fixture._iface,
+        "--save-file", save_file,
         "--json",
         "allocate",
     ]]
@@ -163,12 +167,14 @@ def test_renewal_of_ip(
     ip_allocator_dhcp_fixture: IPAllocatorDHCP,
 ) -> None:
     dhcp_desc = list(ip_allocator_dhcp_fixture._store.dhcp_store.values())[0]
+    save_file = f"/tmp/dhcp_cli_{str(dhcp_desc.mac)}.json"
     call_args = [[
         DHCP_HELPER_CLI,
         "--mac", str(dhcp_desc.mac),
         "--vlan", str(dhcp_desc.vlan),
         "--interface", ip_allocator_dhcp_fixture._iface,
         "--json",
+        "--save-file", save_file,
         "renew",
         "--ip", str(dhcp_desc.ip),
         "--server-ip", str(dhcp_desc.server_ip),
@@ -185,12 +191,14 @@ def test_allocate_ip_after_expiry(
     ip_allocator_dhcp_fixture: IPAllocatorDHCP,
 ) -> None:
     dhcp_desc = list(ip_allocator_dhcp_fixture._store.dhcp_store.values())[0]
+    save_file = f"/tmp/dhcp_cli_{str(dhcp_desc.mac)}.json"
     call_args = [[
         DHCP_HELPER_CLI,
         "--mac", str(dhcp_desc.mac),
         "--vlan", str(dhcp_desc.vlan),
         "--interface", ip_allocator_dhcp_fixture._iface,
         "--json",
+        "--save-file", save_file,
         "allocate",
     ]]
     _run_allocator_and_assert(

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -125,24 +125,24 @@ def test_allocate_ip_address(
         "allocate",
     ]]
 
-    with freezegun.freeze_time(FROZEN_TEST_TIME), \
-            patch(
-                "subprocess.run",
-                return_value=create_subprocess_mock_dhcp_return(),
-                side_effect=create_subprocess_mock_json_file,
-    ) as subprocess_mock:
-        reference_time = datetime.now()
-        actual_ip_desc = ip_allocator_fixture.alloc_ip_address(
-            sid=SID,
-            vlan=int(VLAN),
-        )
-        _assert_calls_and_deadlines(
-            advance_time=0,
-            call_args=call_args,
-            ip_allocator=ip_allocator_fixture,
-            reference_time=reference_time,
-            subprocess_mock=subprocess_mock,
-        )
+    with freezegun.freeze_time(FROZEN_TEST_TIME):
+        with patch(
+            "subprocess.run",
+            return_value=create_subprocess_mock_dhcp_return(),
+            side_effect=create_subprocess_mock_json_file,
+        ) as subprocess_mock:
+            reference_time = datetime.now()
+            actual_ip_desc = ip_allocator_fixture.alloc_ip_address(
+                sid=SID,
+                vlan=int(VLAN),
+            )
+            _assert_calls_and_deadlines(
+                advance_time=0,
+                call_args=call_args,
+                ip_allocator=ip_allocator_fixture,
+                reference_time=reference_time,
+                subprocess_mock=subprocess_mock,
+            )
 
     assert actual_ip_desc == ip_desc_fixture
 
@@ -212,7 +212,7 @@ def test_allocate_ip_after_expiry(
 
 
 def _run_allocator_and_assert(
-        advance_time: int, call_args: List[List[str]], ip_allocator_dhcp_fixture: IPAllocatorDHCP,
+        advance_time: int, call_args: List[str], ip_allocator_dhcp_fixture: IPAllocatorDHCP,
 ) -> None:
     with freezegun.freeze_time(FROZEN_TEST_TIME) as frozen_datetime, \
             patch(

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -223,10 +223,10 @@ def _run_allocator_and_assert(
 ) -> None:
     with freezegun.freeze_time(FROZEN_TEST_TIME) as frozen_datetime, \
             patch(
-                "subprocess.run",
-                return_value=create_subprocess_mock_dhcp_return(),
+                "subprocess.run", return_value=create_subprocess_mock_dhcp_return(),
                 side_effect=create_subprocess_mock_json_file,
-    ) as subprocess_mock:
+    ) as \
+            subprocess_mock:
         reference_time = datetime.now()
         run_dhcp_allocator_thread(
             frozen_datetime=frozen_datetime,

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -154,15 +154,14 @@ def test_allocate_ip_address(
 
 def test_no_renewal_of_ip(ip_allocator_dhcp_fixture: IPAllocatorDHCP) -> None:
     advance_time = 1
-    with freezegun.freeze_time(FROZEN_TEST_TIME) as frozen_datetime, \
-            patch("subprocess.run", return_value=create_subprocess_mock_dhcp_return()) as subprocess_mock:
-        run_dhcp_allocator_thread(
-            frozen_datetime=frozen_datetime,
-            ip_allocator_dhcp_fixture=ip_allocator_dhcp_fixture,
-            freeze_time=advance_time,
-        )
-
-        subprocess_mock.assert_not_called()
+    with freezegun.freeze_time(FROZEN_TEST_TIME) as frozen_datetime:
+        with patch("subprocess.run", return_value=create_subprocess_mock_dhcp_return()) as subprocess_mock:
+            run_dhcp_allocator_thread(
+                frozen_datetime=frozen_datetime,
+                ip_allocator_dhcp_fixture=ip_allocator_dhcp_fixture,
+                freeze_time=advance_time,
+            )
+            subprocess_mock.assert_not_called()
 
 
 @patch("tempfile.NamedTemporaryFile")

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -23,12 +23,7 @@ from magma.mobilityd.dhcp_desc import DHCPDescriptor, DHCPState
 from magma.mobilityd.ip_allocator_dhcp import DHCP_HELPER_CLI, IPAllocatorDHCP
 from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
 from magma.mobilityd.mac import MacAddress, sid_to_mac
-from magma.mobilityd.mobility_store import (
-    AssignedIpBlocksSet,
-    MobilityStore,
-    defaultdict_key,
-    ip_states,
-)
+from magma.mobilityd.mobility_store import MobilityStore
 
 SID = "IMSI123456789"
 MAC = MacAddress(sid_to_mac(SID).lower())

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -13,7 +13,7 @@ limitations under the License.
 import os
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address, IPv4Network
-from typing import Any, List
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import fakeredis
@@ -130,7 +130,7 @@ def test_allocate_ip_address(
                 "subprocess.run",
                 return_value=create_subprocess_mock_dhcp_return(),
                 side_effect=create_subprocess_mock_json_file,
-            ) as subprocess_mock:
+    ) as subprocess_mock:
         reference_time = datetime.now()
         actual_ip_desc = ip_allocator_fixture.alloc_ip_address(
             sid=SID,
@@ -219,7 +219,7 @@ def _run_allocator_and_assert(
                 "subprocess.run",
                 return_value=create_subprocess_mock_dhcp_return(),
                 side_effect=create_subprocess_mock_json_file,
-            ) as subprocess_mock:
+    ) as subprocess_mock:
         reference_time = datetime.now()
         run_dhcp_allocator_thread(
             frozen_datetime=frozen_datetime,

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -324,11 +324,16 @@ def test_force_remove_ip_block_with_allocated_ip(
 def create_subprocess_mock_dhcp_return() -> MagicMock:
     m = MagicMock()
     m.returncode = 0
-    m.stdout = """{"ip": "%s","subnet": "%s","server_ip": "%s", "router_ip": "%s","lease_expiration_time": %s}""" % (IP, IP_NETWORK, SERVER_IP, ROUTER_IP, LEASE_EXPIRATION_TIME)
+    m.stdout = """{"ip": "%s","subnet": "%s","server_ip": "%s", "router_ip": "%s","lease_expiration_time": %s}""" % (
+        IP, IP_NETWORK, SERVER_IP, ROUTER_IP, LEASE_EXPIRATION_TIME,
+    )
     return m
 
 
 def create_subprocess_mock_json_file(call_args, capture_output=True) -> MagicMock:
     with open(call_args[8], "w") as f:
-        f.write("""{"ip": "%s","subnet": "%s","server_ip": "%s", "router_ip": "%s","lease_expiration_time": %s}""" % (IP, IP_NETWORK, SERVER_IP, ROUTER_IP, LEASE_EXPIRATION_TIME))
+        f.write(
+            """{"ip": "%s","subnet": "%s","server_ip": "%s", "router_ip": "%s","lease_expiration_time": %s}"""
+            % (IP, IP_NETWORK, SERVER_IP, ROUTER_IP, LEASE_EXPIRATION_TIME),
+        )
     return create_subprocess_mock_dhcp_return()

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -220,25 +220,24 @@ def test_allocate_ip_after_expiry(
 def _run_allocator_and_assert(
         advance_time: int, call_args: List[str], ip_allocator_dhcp_fixture: IPAllocatorDHCP,
 ) -> None:
-    with freezegun.freeze_time(FROZEN_TEST_TIME) as frozen_datetime, \
-            patch(
+    with freezegun.freeze_time(FROZEN_TEST_TIME) as frozen_datetime:
+        with patch(
                 "subprocess.run", return_value=create_subprocess_mock_dhcp_return(),
                 side_effect=create_subprocess_mock_json_file,
-    ) as \
-            subprocess_mock:
-        reference_time = datetime.now()
-        run_dhcp_allocator_thread(
-            frozen_datetime=frozen_datetime,
-            ip_allocator_dhcp_fixture=ip_allocator_dhcp_fixture,
-            freeze_time=advance_time,
-        )
-        _assert_calls_and_deadlines(
-            advance_time=advance_time,
-            call_args=call_args,
-            ip_allocator=ip_allocator_dhcp_fixture,
-            reference_time=reference_time,
-            subprocess_mock=subprocess_mock,
-        )
+        ) as subprocess_mock:
+            reference_time = datetime.now()
+            run_dhcp_allocator_thread(
+                frozen_datetime=frozen_datetime,
+                ip_allocator_dhcp_fixture=ip_allocator_dhcp_fixture,
+                freeze_time=advance_time,
+            )
+            _assert_calls_and_deadlines(
+                advance_time=advance_time,
+                call_args=call_args,
+                ip_allocator=ip_allocator_dhcp_fixture,
+                reference_time=reference_time,
+                subprocess_mock=subprocess_mock,
+            )
 
 
 def _assert_calls_and_deadlines(

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -13,7 +13,7 @@ limitations under the License.
 import os
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address, IPv4Network
-from typing import Any
+from typing import Any, List
 from unittest.mock import MagicMock, patch
 
 import fakeredis

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -114,7 +114,7 @@ def test_allocate_ip_address(
     mock_tempfile.return_value.__enter__.return_value.name = TMP_FILE
     mock_tempfile.return_value.__exit__.side_effect = lambda *args: os.remove(TMP_FILE)
     ip_allocator_fixture.start_monitor_thread()
-    call_args = [[
+    call_args = [
         DHCP_HELPER_CLI,
         "--mac", str(dhcp_desc_fixture.mac),
         "--vlan", str(dhcp_desc_fixture.vlan),
@@ -122,7 +122,7 @@ def test_allocate_ip_address(
         "--save-file", TMP_FILE,
         "--json",
         "allocate",
-    ]]
+    ]
 
     with freezegun.freeze_time(FROZEN_TEST_TIME):
         with patch(
@@ -174,7 +174,7 @@ def test_renewal_of_ip(
     mock_tempfile.return_value.__exit__.side_effect = lambda *args: os.remove(TMP_FILE)
 
     dhcp_desc = list(ip_allocator_dhcp_fixture._store.dhcp_store.values())[0]
-    call_args = [[
+    call_args = [
         DHCP_HELPER_CLI,
         "--mac", str(dhcp_desc.mac),
         "--vlan", str(dhcp_desc.vlan),
@@ -184,7 +184,7 @@ def test_renewal_of_ip(
         "renew",
         "--ip", str(dhcp_desc.ip),
         "--server-ip", str(dhcp_desc.server_ip),
-    ]]
+    ]
 
     _run_allocator_and_assert(
         advance_time=3,
@@ -202,7 +202,7 @@ def test_allocate_ip_after_expiry(
     mock_tempfile.return_value.__exit__.side_effect = lambda *args: os.remove(TMP_FILE)
 
     dhcp_desc = list(ip_allocator_dhcp_fixture._store.dhcp_store.values())[0]
-    call_args = [[
+    call_args = [
         DHCP_HELPER_CLI,
         "--mac", str(dhcp_desc.mac),
         "--vlan", str(dhcp_desc.vlan),
@@ -210,7 +210,7 @@ def test_allocate_ip_after_expiry(
         "--save-file", TMP_FILE,
         "--json",
         "allocate",
-    ]]
+    ]
     _run_allocator_and_assert(
         advance_time=5,
         call_args=call_args,
@@ -243,12 +243,12 @@ def _run_allocator_and_assert(
 
 
 def _assert_calls_and_deadlines(
-        advance_time: int, call_args: List[List[str]], ip_allocator: IPAllocatorDHCP,
+        advance_time: int, call_args: List[str], ip_allocator: IPAllocatorDHCP,
         reference_time: datetime.date, subprocess_mock: MagicMock,
 ) -> None:
     subprocess_mock.assert_called_once()
     subprocess_mock.assert_called_with(
-        *call_args,
+        call_args,
         capture_output=True,
     )
     dhcp_desc = list(ip_allocator._store.dhcp_store.values())[0]
@@ -256,7 +256,7 @@ def _assert_calls_and_deadlines(
     expected_lease_renew_deadline = reference_time + timedelta(seconds=advance_time + LEASE_EXPIRATION_TIME / 2)
     assert dhcp_desc.lease_expiration_time == expected_lease_expiration_time
     assert dhcp_desc.lease_renew_deadline == expected_lease_renew_deadline
-    assert not os.path.exists(call_args[0][8])
+    assert not os.path.exists(call_args[8])
 
 
 @pytest.fixture
@@ -337,7 +337,7 @@ def create_subprocess_mock_dhcp_return() -> MagicMock:
     return m
 
 
-def create_subprocess_mock_json_file(call_args, capture_output=True) -> MagicMock:
+def create_subprocess_mock_json_file(call_args: List[str], capture_output=True) -> MagicMock:
     with open(call_args[8], "w") as f:
         f.write(
             """{"ip": "%s","subnet": "%s","server_ip": "%s", "router_ip": "%s","lease_expiration_time": %s}"""

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -89,7 +89,6 @@ setup(
         'scripts/dp_probe_cli.py',
         'scripts/user_trace_cli.py',
         'scripts/icmpv6.py',
-        'dhcp_helper_cli/dhcp_helper_cli.py',
         'load_tests/loadtest_sessiond.py',
         'load_tests/loadtest_pipelined.py',
         'load_tests/loadtest_mobilityd.py',

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -89,6 +89,7 @@ setup(
         'scripts/dp_probe_cli.py',
         'scripts/user_trace_cli.py',
         'scripts/icmpv6.py',
+        'dhcp_helper_cli/dhcp_helper_cli.py',
         'load_tests/loadtest_sessiond.py',
         'load_tests/loadtest_pipelined.py',
         'load_tests/loadtest_mobilityd.py',


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
Until now we have used the json formatted stdout from the CLI. This may cause issues in the future if, e.g. deprecation warnings appear in stdout. The current workaround is to just use the last line of stdout assuming that all possible warnings would appear above the line.

As an improvement, we add the option to save the desired output as a json file and use this option in mobilityd to communicate.

With @wolfseb 

## Summary

- Adds an option to save the output of the dhcp cli to a json file
- Use this new option to communicate between mobilityd and the cli
<!-- Enumerate changes you made and why you made them -->

## Test Plan

- [x] Run the mobilityd sudo tests
- [x] Run `test_attach_detach_with_non_nat_dhcp.py` integration test

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
