### PR TITLE
fix(agw): Fix name of DHCP CLI helper in Bazel build

### DIFF
--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -265,8 +265,8 @@ pkg_deb(
     maintainer = MAINTAINER,
     package = "magma-dhcp-cli",
     package_file_name = "{fname}.deb".format(fname = DHCP_HELPER_CLI_FILE_NAME),
-    provides = ["dhcp_helper_cli"],
-    replaces = ["dhcp_helper_cli"],
+    provides = ["magma-dhcp-cli"],
+    replaces = ["magma-dhcp-cli"],
     version = VERSION_DEB,
 )
 

--- a/lte/gateway/release/deb_dependencies.bzl
+++ b/lte/gateway/release/deb_dependencies.bzl
@@ -45,7 +45,7 @@ MAGMA_DEPS = [
     "uuid-dev",  # for liagentd
     "libprotobuf17 (>= 3.0.0)",
     "nlohmann-json3-dev",
-    "dhcp_helper_cli (>= {min_version})".format(min_version = DHCP_HELPER_CLI_MIN_VERSION),
+    "magma-dhcp-cli (>= {min_version})".format(min_version = DHCP_HELPER_CLI_MIN_VERSION),
     "sentry-native",  # sessiond
     "td-agent-bit (>= 1.7.8)",
     # eBPF compile and load tools for kernsnoopd and AGW datapath


### PR DESCRIPTION
## Summary

The package name was changed to "magma-dhcp-cli" during the review of #14635 but the dependency of the magma package was not updated.

## Test Plan

Build magma and execute `dpkg -I`: Now the dependency is shown correctly as `magma-dhcp-cli (>= 1.9.0)`.
```
vagrant@magma-dev:/tmp/packages$ dpkg -I magma_1.9.0-1671629659-8294ac93_amd64.deb 
 new Debian package, version 2.0.
 size 128710166 bytes: control archive=1749 bytes.
    1223 bytes,    12 lines      control              
    2111 bytes,    57 lines   *  postinst             #!/bin/bash
 Package: magma
 Version: 1.9.0-1671629659-8294ac93
 Section: contrib/devel
 Priority: optional
 Architecture: amd64
 Depends: grpc-dev (>= 1.15.0), lighttpd (>= 1.4.45), libxslt1.1, nghttp2-proxy (>= 1.18.1), redis-server (>= 3.2.0), sudo, dnsmasq (>= 2.7), net-tools, python3-pip, python3-apt, libsystemd-dev, libyaml-cpp-dev, libgoogle-glog-dev, python-redis, magma-cpp-redis, libfolly-dev, libdouble-conversion-dev, libboost-chrono-dev, ntpdate, tshark, libtins-dev, libmnl-dev, getenvoy-envoy, uuid-dev, libprotobuf17 (>= 3.0.0), nlohmann-json3-dev, magma-dhcp-cli (>= 1.9.0), sentry-native, td-agent-bit (>= 1.7.8), bcc-tools, wireguard, libconfig9, oai-asn1c, oai-gnutls (>= 3.1.23), oai-nettle (>= 1.0.1), prometheus-cpp-dev (>= 1.0.2), liblfds710, libsctp-dev, magma-sctpd (>= 1.9.0), libczmq-dev (>= 4.0.2-7), libasan5, oai-freediameter (>= 0.0.2), libsystemd-dev, magma-libfluid (>= 0.1.0.7), libopenvswitch (>= 2.15.4-8), openvswitch-switch (>= 2.15.4-8), openvswitch-common (>= 2.15.4-8), openvswitch-datapath-dkms (>= 2.15.4-8)
 Replaces: magma
 Provides: magma
 Maintainer: The Magma Authors <main@lists.magmacore.org>
 Description: Magma Access Gateway
 Homepage: https://github.com/magma/magma/
 License: BSD-3-Clause
```

## Additional Information

- [ ] This change is backwards-breaking