### PR TITLE
refactor(agw): Improve `make check` command

### DIFF
--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -63,26 +63,20 @@ endif
 $(BIN)/pytest: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) pytest==7.1.2
 
-$(BIN)/pytest-cov: install_virtualenv
-	$(VIRT_ENV_PIP_INSTALL) pytest-cov==3.0.0
-
 $(BIN)/pylint: install_virtualenv
 	$(VIRT_ENV_PIP_INSTALL) pylint==2.14.0
-
-$(BIN)/pycodestyle: install_virtualenv
-	# pylint doesn't cover all the pep8 style guidelines. Specifically,
-	# E203, E301, E303, W203, W291, W292
-	$(VIRT_ENV_PIP_INSTALL) pycodestyle==2.8.0
 
 # Disable W0511: todo warnings
 # Disable R0903: Too few public methods
 CHECK_CMD_PYLINT := -find . -name '*.py' -exec $(BIN)/pylint --disable=R0903,W0511 {} +;
-CHECK_CMD_PYCODESTYLE := -find . -name '*.py' -exec $(BIN)/pycodestyle {} +;
 # ’-’ ignores the exit 1 and the script is not terminated by a linter error,
 # see https://www.gnu.org/software/make/manual/make.html#Errors
-check: buildenv $(BIN)/pylint $(BIN)/pycodestyle
-	$(CHECK_CMD_PYCODESTYLE)
+
+pylint: buildenv $(BIN)/pylint
 	$(CHECK_CMD_PYLINT)
+
+check:
+	./precommit.py --format --diff
 
 clean: $(CLEAN_LIST)
 	sudo rm -rf $(PYTHON_BUILD)/

--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -68,12 +68,6 @@ $(BIN)/pylint: install_virtualenv
 
 # Disable W0511: todo warnings
 # Disable R0903: Too few public methods
-CHECK_CMD_PYLINT := -find . -name '*.py' -exec $(BIN)/pylint --disable=R0903,W0511 {} +;
-# ’-’ ignores the exit 1 and the script is not terminated by a linter error,
-# see https://www.gnu.org/software/make/manual/make.html#Errors
-
-pylint: buildenv $(BIN)/pylint
-	$(CHECK_CMD_PYLINT)
 
 check:
 	./precommit.py --format --diff


### PR DESCRIPTION
Closes #14087 

With Sebastian Wolf <sebastian.wolf@tngtech.com>
Signed-off-by: Moritz Huebner <moritz.huebner@tngtech.com>

The `make integtests` command in the linked issue should actually be `make check`.

We analyzed the current `make check` behavior and found the following:
- The `pycodestyle` within `make check` command does effectively about as much as the `precommit.py` script.
- `precommit.py` is usually executed with the `--diff`flag, which means the formatting checks are only applied on the files that are different from master.
- `make check` applies the pycodestyle formatting check on all files which is much slower.
- `make check` runs pylint on all python files as well, which produces thousands of lines of suggested changes which take a long time to produce and currently crashes before pylint finishes.
- Overall we found that `make check` is not very useful in its current form

This PR makes `make check` just execute `./precommit.py --format --diff` ~~and moves the pylint part into a new `make pylint` command~~ see below.

To do after merging:
- [ ] Update https://github.com/magma/magma/wiki/Bazel-vs.-Make-commands-dictionary

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Use `precommit.py` script in `make check`.
- Remove pylint  from `make check`.
- ~~Extract pylint into new `make pylint` command.~~ After discussing offline, this was found to be unnecessary.
- Remove pycodestyle behavior from `make check` (behavior is contained within `precommit.py`)
<!-- Enumerate changes you made and why you made them -->

## Test Plan

Execute `make check` on a local branch and check that it applies the `precommit.py` formatting changes automatically as expected.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
