### PR TITLE
fix(agw): build-magma.sh adds license for magma and dhcp package

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -435,7 +435,7 @@ ${PY_PROTOS}=${PY_DEST} \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/${MAGMA_PKGNAME}*" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/*.egg-info" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/usr/bin/*" /usr/local/bin/) \
-${MAGMA_ROOT}/LICENSE=/usr/share/doc/${PKGNAME}/ \
+${MAGMA_ROOT}/LICENSE=/usr/share/doc/${MAGMA_PKGNAME}/ \
 " # Leave this quote on a new line to mark end of BUILDCMD
 
 eval "$BUILDCMD"
@@ -460,6 +460,8 @@ BUILDCMD="fpm \
 --license '${LICENSE_DHCP}' \
 --maintainer '${MAINTAINER}' \
 --depends '${SCAPY_PACKAGE} >= ${SCAPY_VERSION}' \
-${MAGMA_ROOT}/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py=/usr/local/bin/"
+${MAGMA_ROOT}/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py=/usr/local/bin/ \
+${MAGMA_ROOT}/lte/gateway/python/dhcp_helper_cli/LICENSE=/usr/share/doc/${DHCP_CLI_PKGNAME}/ \
+"
 
 eval "$BUILDCMD"


### PR DESCRIPTION
## Summary

Follow-up to #14722 and #14635.

- The license file in the magma deb package seems to have been lost due to a merge conflict (renamed variable in a concurrent commit).
- Also adds a license file for the dhcp deb package.

## Test Plan

Execute fabric to build a release.
```
vagrant@magma-dev:~/magma-packages$ dpkg -c magma-dhcp-cli_1.8.0-1671711421-74e4a1b3_amd64.deb | grep magma-dhcp-cli/LICENSE
-rw-r--r-- 0/0           18092 2022-12-21 10:54 ./usr/share/doc/magma-dhcp-cli/LICENSE
vagrant@magma-dev:~/magma-packages$ dpkg -c magma_1.8.0-1671711421-74e4a1b3_amd64.deb | grep magma/LICENSE
-rw-r--r-- 0/0            1509 2021-12-13 08:12 ./usr/share/doc/magma/LICENSE

vagrant@magma-dev:~/magma-packages$ dpkg -c magma-sctpd_1.8.0-1671711421-74e4a1b3_amd64.deb | grep magma-sctpd/LICENSE
-rw-r--r-- 0/0            1509 2021-12-13 08:12 ./usr/share/doc/magma-sctpd/LICENSE
```

## Additional Information

- [ ] This change is backwards-breaking