### PR TITLE
fix(ci): assign correct SHA to CI runs triggered by `repository_dispatch`

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -621,7 +621,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: magma/magma
           event-type: magma-debian-artifact
-          client-payload: '{ "magma_version": "${{ env.MAGMA_VERSION }}" }'
+          client-payload: '{ "magma_version": "${{ env.MAGMA_VERSION }}", "trigger_sha": "${{ github.sha }}" }'
 
       - name: Publish bazel profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -872,4 +872,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: magma/magma
           event-type: build-all-artifact
-          client-payload: '{ "artifact": "${{ needs.agw-build.outputs.magma_package }}" }'
+          client-payload: '{ "artifact": "${{ needs.agw-build.outputs.magma_package }}", "trigger_sha": "${{ github.sha }}" }'

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -112,13 +112,13 @@ jobs:
         if: always() && github.event_name == 'repository_dispatch'
         env:
           FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
-          REPORT_FILENAME: "lte_integ_test_magma_deb_${{ github.sha }}.html"
+          REPORT_FILENAME: "lte_integ_test_magma_deb_${{ github.event.client_payload.trigger_sha }}.html"
         run: |
           npm install -g xunit-viewer
           [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
           [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
           [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
-          python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} debian_lte_integ_test --url $URL
+          python ci-scripts/firebase_publish_report.py -id ${{ github.event.client_payload.trigger_sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} debian_lte_integ_test --url $URL
 
       - name: Notify failure to slack
         if: failure() && github.repository_owner == 'magma'

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        with:
+          ref: ${{ github.event.client_payload.trigger_sha || github.sha }}
 
       - name: Cache magma-deb-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -92,4 +92,4 @@ jobs:
           SLACK_USERNAME: ${{ github.workflow }}
           SLACK_AVATAR: ":boom:"
         with:
-          args: "LTE Debian integration test failed on [${{ github.sha }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ github.sha }}): ${{ github.event.head_commit.message || github.event.pull_request.title }}"
+          args: "LTE Debian integration test failed on [${{ github.event.client_payload.trigger_sha }}](${{github.event.repository.owner.html_url}}/magma/commit/${{ github.event.client_payload.trigger_sha }}): ${{ github.event.head_commit.message || github.event.pull_request.title }}"

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        with:
+          ref: ${{ github.event.client_payload.trigger_sha || github.sha }}
       - name: Cache magma-deb-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

CI jobs triggered by `repository_dispatch` events are not always tagged with the SHA of the push that effectively triggered the workflow, but always with the SHA of the latest commit on master. This may lead to a mix-up if pushes occur while the workflow was not yet triggered by the `repository_dispatch` event. This PR parses the SHA of the triggering commit via `client_payload` to tag these runs correctly. 
The checkout-GitHub action also gets this information. For manual execution, `github.sha` is kept as a default fallback, see [this manually started test run](https://github.com/mpfirrmann/magma/actions/runs/3788009169/jobs/6440355291)
Closes #14745.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
