### PR TITLE
chore: python code is checked by pylint

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -28,7 +28,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
+  BAZEL_CACHE_PLAIN_IMAGE: "ghcr.io/magma/magma/bazel-cache-plain:latest"
 
 jobs:
   path_filter:
@@ -94,21 +94,21 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
-      - name: Setup Bazel Base Image
+      - name: Setup Bazel Cache Image
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
+          image: ${{ env.BAZEL_CACHE_PLAIN_IMAGE }}
           options: --pull always
           # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
           run: |
-            echo "Pulled the bazel base image!"
+            echo "Pulled the bazel cache image!"
       - name: Run pylint
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
         env:
           PYTHONPATH: /workspaces/magma/lte/gateway/python:/workspaces/magma/orc8r/gateway/python
           PY_ENV_PATH: /tmp/pylintenv
         with:
-          image: ${{ env.BAZEL_BASE_IMAGE }}
+          image: ${{ env.BAZEL_CACHE_PLAIN_IMAGE }}
           shell: bash
           options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
           run: |

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -12,6 +12,7 @@
 name: AGW Lint
 
 on:
+  workflow_dispatch: null
   push:
     branches:
       - master
@@ -25,6 +26,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
+
+env:
+  BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
 
 jobs:
   path_filter:
@@ -78,3 +82,40 @@ jobs:
           fetch-depth: 0
       - name: jsonlint-mconfig
         run: find . -name gateway.mconfig -print0 | xargs --max-args=1 --null --replace='%' sh -c ">/dev/null jq . % || { echo % is not a valid json file; exit 1; } "
+
+  pylint:
+    name: pylint
+    runs-on: ubuntu-20.04
+    needs: path_filter
+    if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+      - name: Setup Bazel Base Image
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          options: --pull always
+          # Run a simple echo command to pull down the image. This makes it a bit more clear how much time is spent on building Magma and not pulling down the image.
+          run: |
+            echo "Pulled the bazel base image!"
+      - name: Run pylint
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3
+        env:
+          PYTHONPATH: /workspaces/magma/lte/gateway/python:/workspaces/magma/orc8r/gateway/python
+          PY_ENV_PATH: /tmp/pylintenv
+        with:
+          image: ${{ env.BAZEL_BASE_IMAGE }}
+          shell: bash
+          options: -v ${{ github.workspace }}:/workspaces/magma/ -v ${{ github.workspace }}/lte/gateway/configs:/etc/magma
+          run: |
+            set -euo pipefail
+            apt install -y python3.8-venv
+            cd /workspaces/magma
+            bazel run //dev_tools:python_env ${{ env.PY_ENV_PATH }}
+            ${{ env.PY_ENV_PATH }}/bin/pip3 install pylint==2.14.0
+            PYTHONPATH=${{ env.PYTHONPATH }} ${{ env.PY_ENV_PATH }}/bin/python3 -m pytest -s lte/gateway/python/magma/tests/pylint_tests.py
+            PYTHONPATH=${{ env.PYTHONPATH }} ${{ env.PY_ENV_PATH }}/bin/python3 -m pytest -s orc8r/gateway/python/magma/tests/pylint_tests.py

--- a/dev_tools/BUILD.bazel
+++ b/dev_tools/BUILD.bazel
@@ -97,6 +97,11 @@ dp_protos = [
     "//dp/protos:cbsd_python_proto",
 ]
 
+swagger_models = [
+    # List generated with bazel query 'kind(py_swagger, //...:*)' | sed 's/.*/    "&",/'
+    "//orc8r/swagger:magmad_events_v1",
+]
+
 all_protos = lte_protos + lte_oai_protos + orc8r_protos + feg_protos + dp_protos
 
 external_python_libs = [
@@ -136,5 +141,5 @@ py_venv(
     # We still also depend directly on the respective py_librarys in order to ensure that
     # they are built and present at the expected locations.
     name = "python_env",
-    deps = all_requirements + all_protos + external_python_libs + [":external_deps_wrapper"],
+    deps = all_requirements + all_protos + swagger_models + external_python_libs + [":external_deps_wrapper"],
 )

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -103,7 +103,7 @@ class IPAllocatorDHCP(IPAllocator):
         while True:
             wait_time = self._lease_renew_wait_min
             with self.dhcp_wait:
-                for dhcp_key, dhcp_desc in self._store.dhcp_store.items():
+                for _, dhcp_desc in self._store.dhcp_store.items():
                     logging.debug("monitor: %s", dhcp_desc)
                     # Only process active records.
                     if dhcp_desc.state not in DHCP_ACTIVE_STATES:
@@ -292,13 +292,13 @@ class IPAllocatorDHCP(IPAllocator):
         LOG.debug("lookup error for %s", str(key))
         return None
 
-    def alloc_ip_address(self, sid: str, vlan: int) -> IPDesc:
+    def alloc_ip_address(self, sid: str, vlan_id: int) -> IPDesc:
         """
         Assumption: one-to-one mappings between SID and IP.
 
         Args:
             sid (string): universal subscriber id
-            vlan: vlan of the APN
+            vlan_id: vlan of the APN
 
         Returns:
             ipaddress.ip_address: IP address allocated
@@ -307,7 +307,8 @@ class IPAllocatorDHCP(IPAllocator):
             NoAvailableIPError: if run out of available IP addresses
         """
         mac = create_mac_from_sid(sid)
-        dhcp_desc = self.get_dhcp_desc_from_store(mac, vlan)
+
+        dhcp_desc = self.get_dhcp_desc_from_store(mac, vlan_id)
         LOG.debug(
             "allocate IP for %s mac %s dhcp_desc %s", sid, mac,
             dhcp_desc,
@@ -318,7 +319,7 @@ class IPAllocatorDHCP(IPAllocator):
                 call_args = [
                     DHCP_HELPER_CLI,
                     "--mac", str(mac),
-                    "--vlan", str(vlan),
+                    "--vlan", str(vlan_id),
                     "--interface", self._iface,
                     "--save-file", tmpfile.name,
                     "--json",
@@ -328,7 +329,7 @@ class IPAllocatorDHCP(IPAllocator):
             with self.dhcp_wait:
                 dhcp_desc = self._parse_dhcp_helper_cli_response_to_store(
                     dhcp_desc=dhcp_desc, dhcp_response=dhcp_response,
-                    mac=mac, vlan=vlan,
+                    mac=mac, vlan=vlan_id,
                 )
 
         if dhcp_desc and dhcp_desc.ip and dhcp_desc.subnet:
@@ -339,7 +340,7 @@ class IPAllocatorDHCP(IPAllocator):
                 sid=sid,
                 ip_block=ip_block,
                 ip_type=IPType.DHCP,
-                vlan_id=vlan,
+                vlan_id=vlan_id,
             )
             self._store.assigned_ip_blocks.add(ip_block)
             self._store.ip_state_map.add_ip_to_state(
@@ -378,16 +379,17 @@ class IPAllocatorDHCP(IPAllocator):
         ret = subprocess.run(
             call_args,
             capture_output=True,
+            check=False,
         )
         if ret.returncode != 0:
             call_str = " ".join(call_args)
             logging.error(
-                f"CLI call '{call_str}' failed with return code "
-                f"{ret.returncode} and error {ret.stderr}",
+                "CLI call '%s' failed with return code %s and error %s",
+                call_str, ret.returncode, ret.stderr,
             )
-            raise NoAvailableIPError(f'Failed to call dhcp_helper_cli.')
+            raise NoAvailableIPError('Failed to call dhcp_helper_cli.')
 
-        with open(save_file, 'r') as f:
+        with open(save_file, 'r', encoding="utf-8") as f:
             dhcp_response = json.load(f)
         return dhcp_response
 
@@ -427,11 +429,11 @@ class IPAllocatorDHCP(IPAllocator):
         )
 
     def _release_dhcp_ip(self, ip_desc: IPDesc) -> None:
-        logging.info(f"Releasing: {ip_desc}")
+        logging.info("Releasing: %s", ip_desc)
         mac = create_mac_from_sid(ip_desc.sid)
         vlan = ip_desc.vlan_id
         dhcp_desc = self.get_dhcp_desc_from_store(mac, vlan)
-        logging.info(f"Releasing dhcp desc: {dhcp_desc}")
+        logging.info("Releasing dhcp desc: %s", dhcp_desc)
         if dhcp_desc:
             call_args = [
                 DHCP_HELPER_CLI,
@@ -446,15 +448,16 @@ class IPAllocatorDHCP(IPAllocator):
             ret = subprocess.run(
                 call_args,
                 capture_output=True,
+                check=False,
             )
 
             if ret.returncode != 0:
                 call_str = " ".join(call_args)
                 logging.error(
-                    f"CLI call '{call_str}' failed with return code "
-                    f"{ret.returncode} and error {ret.stderr}",
+                    "CLI call '%s' failed with return code %s and error %s",
+                    call_str, ret.returncode, ret.stderr,
                 )
-                raise NoAvailableIPError(f'Failed to call dhcp_helper_cli.')
+                raise NoAvailableIPError('Failed to call dhcp_helper_cli.')
 
             key = mac.as_redis_key(vlan)
             with self.dhcp_wait:

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -133,7 +133,7 @@ def test_allocate_ip_address(
             reference_time = datetime.now()
             actual_ip_desc = ip_allocator_fixture.alloc_ip_address(
                 sid=SID,
-                vlan=int(VLAN),
+                vlan_id=int(VLAN),
             )
             _assert_calls_and_deadlines(
                 advance_time=0,
@@ -248,6 +248,7 @@ def _assert_calls_and_deadlines(
     subprocess_mock.assert_called_with(
         call_args,
         capture_output=True,
+        check=False,
     )
     dhcp_desc = list(ip_allocator._store.dhcp_store.values())[0]
     expected_lease_expiration_time = reference_time + timedelta(seconds=advance_time + LEASE_EXPIRATION_TIME)
@@ -335,7 +336,7 @@ def create_subprocess_mock_dhcp_return() -> MagicMock:
     return m
 
 
-def create_subprocess_mock_json_file(call_args: List[str], capture_output=True) -> MagicMock:
+def create_subprocess_mock_json_file(call_args: List[str], capture_output=True, check=False) -> MagicMock:
     with open(call_args[8], "w") as f:
         f.write(
             """{"ip": "%s","subnet": "%s","server_ip": "%s", "router_ip": "%s","lease_expiration_time": %s}"""

--- a/lte/gateway/python/magma/pipelined/gw_mac_address.py
+++ b/lte/gateway/python/magma/pipelined/gw_mac_address.py
@@ -67,13 +67,14 @@ def get_iface_by_ip4(target_ip4: str) -> Optional[str]:
 
 
 def get_mac_by_ip6(gw_ip: str) -> str:
-    for iface, ip6 in get_ifaces_by_ip6(gw_ip):
+    for iface, _ in get_ifaces_by_ip6(gw_ip):
         # Refresh the ip neighbor table
-        if subprocess.run(["ping", "-c", "1", gw_ip]).returncode != 0:
+        if subprocess.run(["ping", "-c", "1", gw_ip], check=False).returncode != 0:
             continue
         res = subprocess.run(
             ["ip", "neigh", "get", gw_ip, "dev", iface],
             capture_output=True,
+            check=False,
         ).stdout.decode("utf-8")
         if "lladdr" in res:
             res = res.split("lladdr ")[1].split(" ")[0]
@@ -118,7 +119,8 @@ def _get_gw_mac_address_v4(gw_ip: str, vlan: str, non_nat_arp_egress_port: str) 
         logging.debug("ARP Res pkt %s", str(parsed))
         if str(parsed.arp.psrc) != gw_ip:
             logging.warning(
-                f"Unexpected IP in ARP response. expected: {gw_ip} pkt: {str(parsed)}",
+                "Unexpected IP in ARP response. expected: %s pkt: {str(parsed)}",
+                gw_ip,
             )
             return ""
         if vlan.isdigit():

--- a/lte/gateway/python/magma/tests/pylint_tests.py
+++ b/lte/gateway/python/magma/tests/pylint_tests.py
@@ -44,10 +44,13 @@ class MagmaPyLintTest(unittest.TestCase):
         )
         excluded_directories = []
         parent_path = os.path.dirname(os.path.dirname(__file__))
+        print("Starting pylint ...")
+        print(f"Checking all sub-directories of {parent_path}")
         directories = [
             d.name for d in os.scandir(parent_path)
             if d.is_dir() and d.name not in excluded_directories
         ]
         for directory in directories:
+            print(f"  Checking {directory}")
             path = os.path.join(parent_path, directory)
             py_wrap.assertNoLintErrors(path)

--- a/orc8r/gateway/python/magma/tests/pylint_tests.py
+++ b/orc8r/gateway/python/magma/tests/pylint_tests.py
@@ -42,14 +42,15 @@ class MagmaPyLintTest(unittest.TestCase):
             ],
             show_categories=["warning", "error", "fatal"],
         )
-
         excluded_directories = []
-
         parent_path = os.path.dirname(os.path.dirname(__file__))
+        print("Starting pylint ...")
+        print(f"Checking all sub-directories of {parent_path}")
         directories = [
             d.name for d in os.scandir(parent_path)
             if d.is_dir() and d.name not in excluded_directories
         ]
         for directory in directories:
+            print(f"  Checking {directory}")
             path = os.path.join(parent_path, directory)
             py_wrap.assertNoLintErrors(path)


### PR DESCRIPTION
## Summary

During changing test execution in ci from make to bazel, the pylint checks got lost. These can not easily be modeled with bazel because all python code would need to be a dependency of these tests. There was already regression happening ...

Here:
* execute pylint checks in workflow for agw linting
* use bazel py_venv for having access to external dependencies, generated proto code and generated swagger models (added here) - this is needed for pylint import checks
* fix pylint regression

Closes #14741.

## Test Plan

CI: https://github.com/magma/magma/actions/runs/3760656285/jobs/6391612810

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
