### PR TITLE
fix(feg): fix error messages in go http endpoints in feg

### DIFF
--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
@@ -127,7 +127,7 @@ func getGateway(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load federation gateway: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to load federation gateway: %v", err))
 	}
 
 	ret := &fegModels.FederationGateway{
@@ -217,14 +217,14 @@ func getClusterStatusHandler(c echo.Context) error {
 		return c.NoContent(http.StatusNotFound)
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	if network.Type != feg.FederationNetworkType {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("network %s is not a <%s> network", nid, feg.FederationNetworkType))
 	}
 	activeGw, err := health.GetActiveGateway(reqCtx, nid)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	ret := &fegModels.FederationNetworkClusterStatus{
 		ActiveGateway: activeGw,
@@ -244,11 +244,11 @@ func getHealthStatusHandler(c echo.Context) error {
 		return c.NoContent(http.StatusNotFound)
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	res, err := health.GetHealth(reqCtx, nid, gid)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, fegModels.ToFederationGatewayHealthStatusModel(res))
 }
@@ -257,5 +257,5 @@ func makeErr(err error) *echo.HTTPError {
 	if err == merrors.ErrNotFound {
 		return echo.ErrNotFound
 	}
-	return echo.NewHTTPError(http.StatusInternalServerError, err)
+	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 }

--- a/feg/gateway/services/n7_n40_proxy/n7/notifier_handler.go
+++ b/feg/gateway/services/n7_n40_proxy/n7/notifier_handler.go
@@ -82,12 +82,12 @@ func (c *N7Client) postSmPolicyUpdateNotification(ctx echo.Context) error {
 	if err != nil {
 		err = fmt.Errorf("invalid SmPolicyNotification received: %s", err)
 		glog.Errorf("postSmPolicyUpdateNotification: %s", err)
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	sessionId, imsi, err := getSessionIdAndIMSI(ctx.Param(EncodedSessionId))
 	if err != nil {
 		glog.Errorf("postSmPolicyUpdateNotification unable to fetch session-id for UpdateNotify - %s", err)
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	policyReauthProto := GetPolicyReauthRequestProto(sessionId, imsi, smUpdateNotify.SmPolicyDecision)
@@ -119,13 +119,13 @@ func (c *N7Client) postSmPolicyTerminateNotification(ctx echo.Context) error {
 	if err != nil {
 		err = fmt.Errorf("invalid TerminateNotification received: %s", err)
 		glog.Errorf("postSmPolicyTerminateNotification: %s", err)
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	sessionId, imsi, err := getSessionIdAndIMSI(ctx.Param(EncodedSessionId))
 	if err != nil {
 		glog.Errorf("postSmPolicyTerminateNotification unable to fetch session-id for TerminateNotify - %s", err)
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	ans, err := client.AbortSession(context.Background(), &protos.AbortSessionRequest{


### PR DESCRIPTION
Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>
Part of #14707.

## Summary

The method `echo.NewHTTPError` takes the error as a string. Currently, however, it is passed as an error object. This PR fixes this in the feg codebase. The following changes are made:

* `err` --> `err.Error()`
* `fmt.Errorf("text: %w", err)` --> `fmtSprintf("text: %v", err)`
* `fmt.Errorf(...)` --> `fmt.Sprintf(...)`


## Additional Information

- [ ] This change is backwards-breaking

