### PR TITLE
fix(orc8r): fix error messages in go http endpoints in orc8r

### DIFF
--- a/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/nprobe/obsidian/handlers/handlers.go
@@ -75,7 +75,7 @@ func listNetworkProbeTasks(c echo.Context) error {
 		return echo.ErrNotFound
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to load existing NetworkProbeTasks: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to load existing NetworkProbeTasks: %v", err))
 	}
 
 	ret := make(map[string]*models.NetworkProbeTask, len(ents))
@@ -95,10 +95,10 @@ func getCreateNetworkProbeTaskHandlerFunc(storage storage.NProbeStorage) echo.Ha
 
 		payload := &models.NetworkProbeTask{}
 		if err := c.Bind(payload); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, err)
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 		if err := payload.ValidateModel(reqCtx); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, err)
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
 		// generate random correlation ID if not provided
@@ -115,7 +115,7 @@ func getCreateNetworkProbeTaskHandlerFunc(storage storage.NProbeStorage) echo.Ha
 
 		taskID := string(payload.TaskID)
 		if err := storage.StoreNProbeData(networkID, taskID, data); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to store NetworkProbeData: %w", err))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to store NetworkProbeData: %v", err))
 		}
 
 		_, err := configurator.CreateEntity(
@@ -129,7 +129,7 @@ func getCreateNetworkProbeTaskHandlerFunc(storage storage.NProbeStorage) echo.Ha
 			serdes.Entity,
 		)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		return c.NoContent(http.StatusCreated)
 	}
@@ -154,7 +154,7 @@ func getNetworkProbeTask(c echo.Context) error {
 		return echo.ErrNotFound
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	ret := (&models.NetworkProbeTask{}).FromBackendModels(ent)
@@ -170,10 +170,10 @@ func updateNetworkProbeTask(c echo.Context) error {
 
 	payload := &models.NetworkProbeTask{}
 	if err := c.Bind(payload); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := payload.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	_, err := configurator.UpdateEntity(reqCtx, networkID, payload.ToEntityUpdateCriteria(), serdes.Entity)
@@ -195,7 +195,7 @@ func getDeleteNetworkProbeTaskHandlerFunc(storage storage.NProbeStorage) echo.Ha
 		_ = storage.DeleteNProbeData(networkID, taskID)
 		err := configurator.DeleteEntity(c.Request().Context(), networkID, lte.NetworkProbeTaskEntityType, taskID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		return c.NoContent(http.StatusNoContent)
 	}
@@ -214,7 +214,7 @@ func listNetworkProbeDestinations(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	ret := make(map[string]*models.NetworkProbeDestination, len(ents))
@@ -233,10 +233,10 @@ func createNetworkProbeDestination(c echo.Context) error {
 
 	payload := &models.NetworkProbeDestination{}
 	if err := c.Bind(payload); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := payload.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	_, err := configurator.CreateEntity(
@@ -250,7 +250,7 @@ func createNetworkProbeDestination(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -274,7 +274,7 @@ func getNetworkProbeDestination(c echo.Context) error {
 		return echo.ErrNotFound
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	ret := (&models.NetworkProbeDestination{}).FromBackendModels(ent)
@@ -290,10 +290,10 @@ func updateNetworkProbeDestination(c echo.Context) error {
 
 	payload := &models.NetworkProbeDestination{}
 	if err := c.Bind(payload); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := payload.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	_, err := configurator.UpdateEntity(reqCtx, networkID, payload.ToEntityUpdateCriteria(), serdes.Entity)
@@ -313,7 +313,7 @@ func deleteNetworkProbeDestination(c echo.Context) error {
 	networkID, destinationID := values[0], values[1]
 	err := configurator.DeleteEntity(c.Request().Context(), networkID, lte.NetworkProbeDestinationEntityType, destinationID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
@@ -55,7 +55,7 @@ func ListBaseNames(c echo.Context) error {
 			serdes.Entity,
 		)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 
 		ret := map[string]*models.BaseNameRecord{}
@@ -66,7 +66,7 @@ func ListBaseNames(c echo.Context) error {
 	} else {
 		names, err := configurator.ListEntityKeys(reqCtx, networkID, lte.BaseNameEntityType)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		sort.Strings(names)
 		return c.JSON(http.StatusOK, names)
@@ -80,7 +80,7 @@ func CreateBaseName(c echo.Context) error {
 	}
 	bnr := &models.BaseNameRecord{}
 	if err := c.Bind(bnr); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	bnrEnt := bnr.ToEntity()
 	reqCtx := c.Request().Context()
@@ -109,7 +109,7 @@ func CreateBaseName(c echo.Context) error {
 		}
 	}
 	if err := configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create base name: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to create base name: %v", err))
 	}
 
 	return c.JSON(http.StatusCreated, string(bnr.Name))
@@ -128,10 +128,10 @@ func GetBaseName(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusNotFound, err)
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.JSON(http.StatusOK, (&models.BaseNameRecord{}).FromEntity(ret))
@@ -146,7 +146,7 @@ func UpdateBaseName(c echo.Context) error {
 
 	bnr := &models.BaseNameRecord{}
 	if err := c.Bind(bnr); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if string(bnr.Name) != baseName {
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("base name in body does not match URL param"))
@@ -160,10 +160,10 @@ func UpdateBaseName(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to check if base name exists: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to check if base name exists: %v", err))
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	// Verify that associated subscribers and policies exist
@@ -199,7 +199,7 @@ func UpdateBaseName(c echo.Context) error {
 	}
 
 	if err = configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update base name: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to update base name: %v", err))
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -213,7 +213,7 @@ func DeleteBaseName(c echo.Context) error {
 
 	err := configurator.DeleteEntity(c.Request().Context(), networkID, lte.BaseNameEntityType, baseName)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -236,7 +236,7 @@ func ListRules(c echo.Context) error {
 			serdes.Entity,
 		)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 
 		ret := map[string]*models.PolicyRule{}
@@ -247,7 +247,7 @@ func ListRules(c echo.Context) error {
 	} else {
 		ruleIDs, err := configurator.ListEntityKeys(reqCtx, networkID, lte.PolicyRuleEntityType)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		sort.Strings(ruleIDs)
 		return c.JSON(http.StatusOK, ruleIDs)
@@ -263,10 +263,10 @@ func CreateRule(c echo.Context) error {
 
 	rule := &models.PolicyRule{}
 	if err := c.Bind(rule); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := rule.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	updateToNewIPModel(rule.FlowList)
@@ -297,7 +297,7 @@ func CreateRule(c echo.Context) error {
 	}
 
 	if err := configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to create policy: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to create policy: %v", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -318,7 +318,7 @@ func GetRule(c echo.Context) error {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
 	case err != nil:
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.JSON(http.StatusOK, (&models.PolicyRule{}).FromEntity(ent))
@@ -333,10 +333,10 @@ func UpdateRule(c echo.Context) error {
 
 	rule := &models.PolicyRule{}
 	if err := c.Bind(rule); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := rule.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if ruleID != string(*rule.ID) {
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("rule ID in body does not match URL param"))
@@ -352,7 +352,7 @@ func UpdateRule(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if policy exists: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to check if policy exists: %v", err))
 	}
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -399,7 +399,7 @@ func UpdateRule(c echo.Context) error {
 	}
 
 	if err = configurator.WriteEntities(reqCtx, networkID, writes, serdes.Entity); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update policy rule: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to update policy rule: %v", err))
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
@@ -45,7 +45,7 @@ func ListRatingGroups(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	groupsByID := map[models.RatingGroupID]*models.RatingGroup{}
@@ -65,15 +65,15 @@ func CreateRatingGroup(c echo.Context) error {
 
 	group := new(models.RatingGroup)
 	if err := c.Bind(group); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := group.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	_, err := configurator.CreateEntity(reqCtx, networkID, group.ToEntity(), serdes.Entity)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -94,7 +94,7 @@ func GetRatingGroup(c echo.Context) error {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
 	case err != nil:
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.JSON(http.StatusOK, (&models.RatingGroup{}).FromEntity(ent))
@@ -109,20 +109,20 @@ func UpdateRatingGroup(c echo.Context) error {
 
 	ratingGroup := new(models.MutableRatingGroup)
 	if err := c.Bind(ratingGroup); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := ratingGroup.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	groupID, err := swag.ConvertUint32(ratingGroupID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	// 404 if rating group doesn't exist
 	exists, err := configurator.DoesEntityExist(reqCtx, networkID, lte.RatingGroupEntityType, ratingGroupID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Failed to check if rating group exists: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to check if rating group exists: %v", err))
 	}
 	if !exists {
 		return echo.ErrNotFound
@@ -130,7 +130,7 @@ func UpdateRatingGroup(c echo.Context) error {
 
 	_, err = configurator.UpdateEntity(reqCtx, networkID, ratingGroup.ToEntityUpdateCriteria(groupID), serdes.Entity)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -143,7 +143,7 @@ func DeleteRatingGroup(c echo.Context) error {
 
 	err := configurator.DeleteEntity(c.Request().Context(), networkID, lte.RatingGroupEntityType, ratingGroupID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/lte/cloud/go/services/smsd/servicers/smsd_rest.go
+++ b/lte/cloud/go/services/smsd/servicers/smsd_rest.go
@@ -43,7 +43,7 @@ func (s *SMSDRestServicer) listMessages(c echo.Context) error {
 
 	messages, err := s.store.GetSMSs(networkID, nil, nil, false, nil, nil)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	out := make([]*models.SmsMessage, 0, len(messages))
@@ -61,7 +61,7 @@ func (s *SMSDRestServicer) getMessage(c echo.Context) error {
 
 	msgs, err := s.store.GetSMSs(networkID, []string{pk}, nil, false, nil, nil)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	if funk.IsEmpty(msgs) {
 		return echo.ErrNotFound
@@ -78,15 +78,15 @@ func (s *SMSDRestServicer) createMessage(c echo.Context) error {
 
 	payload := &models.MutableSmsMessage{}
 	if err := c.Bind(payload); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := payload.ValidateModel(context.Background()); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	pk, err := s.store.CreateSMS(networkID, payload.ToProto())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusCreated, pk)
 }
@@ -99,7 +99,7 @@ func (s *SMSDRestServicer) deleteMessage(c echo.Context) error {
 
 	err := s.store.DeleteSMSs(networkID, []string{pk})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -181,8 +181,8 @@ func getListSubscribersHandler(subscriberStorage subscriberstorage.SubscriberSto
 		if pageSizeParam := c.QueryParam(ParamPageSize); pageSizeParam != "" {
 			pageSize, err = strconv.ParseUint(pageSizeParam, 10, 32)
 			if err != nil {
-				err := fmt.Errorf("invalid page size parameter: %s", err)
-				return echo.NewHTTPError(http.StatusBadRequest, err)
+				err = fmt.Errorf("invalid page size parameter: %s", err)
+				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 			}
 		}
 		pageToken := c.QueryParam(ParamPageToken)
@@ -222,7 +222,7 @@ func getListSubscribersHandler(subscriberStorage subscriberstorage.SubscriberSto
 		// size will be returned.
 		subs, nextPageToken, err := loadSubscriberPage(reqCtx, networkID, uint32(pageSize), pageToken, subscriberStorage)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 
 		// get total number of subscribers
@@ -257,12 +257,12 @@ func createSubscribersHandler(c echo.Context) error {
 
 	payload := subscribermodels.MutableSubscribers{}
 	if err := c.Bind(&payload); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	reqCtx := c.Request().Context()
 	if err := payload.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if nerr := validateSubscriberProfiles(reqCtx, networkID, getSubProfiles(payload)...); nerr != nil {
 		return nerr
@@ -298,16 +298,16 @@ func updateSubscriberHandler(c echo.Context) error {
 
 	payload := &subscribermodels.MutableSubscriber{}
 	if err := c.Bind(payload); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	reqCtx := c.Request().Context()
 	if err := payload.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if string(payload.ID) != subscriberID {
 		err := fmt.Errorf("subscriber ID from parameters (%s) and payload (%s) must match", subscriberID, payload.ID)
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	if nerr := validateSubscriberProfiles(reqCtx, networkID, string(*payload.Lte.SubProfile)); nerr != nil {
@@ -332,7 +332,7 @@ func deleteSubscriberHandler(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -346,7 +346,7 @@ func getListSubscriberStateHandler(subscriberStorage subscriberstorage.Subscribe
 
 		statesBySID, err := loadAllStatesForIMSIs(c.Request().Context(), networkID, nil, subscriberStorage)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		modelsBySID := map[string]*subscribermodels.SubscriberState{}
 		for sid, states := range statesBySID {
@@ -398,15 +398,15 @@ func createMSISDNsHandler(c echo.Context) error {
 
 	payload := &subscribermodels.MsisdnAssignment{}
 	if err := c.Bind(payload); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := payload.ValidateModel(context.Background()); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	err := subscriberdb.SetIMSIForMSISDN(c.Request().Context(), networkID, string(payload.Msisdn), string(payload.ID))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.NoContent(http.StatusCreated)
@@ -432,7 +432,7 @@ func deleteMSISDNHandler(c echo.Context) error {
 
 	err := subscriberdb.DeleteMSISDN(c.Request().Context(), networkID, msisdn)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -446,12 +446,12 @@ func updateSubscriberProfile(c echo.Context) error {
 
 	var payload = new(subscribermodels.SubProfile)
 	if err := c.Bind(payload); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	reqCtx := c.Request().Context()
 	if err := payload.ValidateModel(reqCtx); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	currentCfg, err := configurator.LoadEntityConfig(reqCtx, networkID, lte.SubscriberEntityType, subscriberID, serdes.Entity)
@@ -472,7 +472,7 @@ func updateSubscriberProfile(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to update profile: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to update profile: %v", err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -494,7 +494,7 @@ func makeSubscriberStateHandler(desiredState string) echo.HandlerFunc {
 		newConfig.Lte.State = desiredState
 		err = configurator.CreateOrUpdateEntityConfig(reqCtx, networkID, lte.SubscriberEntityType, subscriberID, newConfig, serdes.Entity)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		return c.NoContent(http.StatusOK)
 	}
@@ -707,7 +707,7 @@ func createSubscribers(ctx context.Context, networkID string, subs ...*subscribe
 
 	if len(uniqueIDs) != len(ids) {
 		duplicates := funk.FilterString(ids, func(s string) bool { return uniqueIDs[s] > 1 })
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("found multiple subscriber models for IDs: %+v", duplicates))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("found multiple subscriber models for IDs: %+v", duplicates))
 	}
 
 	// TODO(hcgatewood) iterate over this to remove "too many placeholders" error
@@ -717,7 +717,7 @@ func createSubscribers(ctx context.Context, networkID string, subs ...*subscribe
 		return obsidian.MakeHTTPError(err, http.StatusInternalServerError)
 	}
 	if len(found) != 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("found %v existing subscribers which would have been overwritten: %+v", len(found), found.TKs()))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("found %v existing subscribers which would have been overwritten: %+v", len(found), found.TKs()))
 	}
 
 	_, err = configurator.CreateEntities(ctx, networkID, ents, serdes.Entity)
@@ -836,7 +836,7 @@ func deleteSubscriber(ctx context.Context, networkID, key string) error {
 
 	err = configurator.DeleteEntities(ctx, networkID, deletes)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return nil
@@ -950,5 +950,5 @@ func makeErr(err error) *echo.HTTPError {
 	if err == merrors.ErrNotFound {
 		return echo.ErrNotFound
 	}
-	return echo.NewHTTPError(http.StatusInternalServerError, err)
+	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 }

--- a/orc8r/cloud/go/services/certifier/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/certifier/obsidian/handlers/handlers.go
@@ -65,10 +65,10 @@ func listUsersHandler(c echo.Context) error {
 func createUserHandler(c echo.Context) error {
 	data := &models.User{}
 	if err := c.Bind(data); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := data.Validate(strfmt.Default); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	username := fmt.Sprintf("%v", *data.Username)
 	password := []byte(fmt.Sprintf("%v", *data.Password))
@@ -84,7 +84,7 @@ func getUserHandler(c echo.Context) error {
 	username := c.Param("username")
 	user, err := certifier.GetUser(c.Request().Context(), username)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, user)
 }
@@ -94,12 +94,12 @@ func updateUserHandler(c echo.Context) error {
 	var updatePassword string
 	err := json.NewDecoder(c.Request().Body).Decode(&updatePassword)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error decoding request body for updating user: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("error decoding request body for updating user: %v", err))
 	}
 	newUser := &protos.User{Username: username, Password: []byte(updatePassword)}
 	err = certifier.UpdateUser(c.Request().Context(), newUser)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return nil
 }
@@ -109,7 +109,7 @@ func deleteUserHandler(c echo.Context) error {
 	deleteUser := &protos.User{Username: username}
 	err := certifier.DeleteUser(c.Request().Context(), deleteUser)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error deleting user: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("error deleting user: %v", err))
 	}
 	return nil
 }
@@ -118,7 +118,7 @@ func getUserTokensHandler(c echo.Context) error {
 	username := c.Param("username")
 	res, err := certifier.ListUserTokens(c.Request().Context(), &protos.User{Username: username})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to list user tokens: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to list user tokens: %v", err))
 	}
 	return c.JSON(http.StatusOK, protos.PolicyListProtoToModel(res.PolicyLists))
 }
@@ -128,10 +128,10 @@ func addUserTokenHandler(c echo.Context) error {
 
 	policies := &models.Policies{}
 	if err := c.Bind(policies); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := policies.Validate(strfmt.Default); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	policiesProto, err := protos.PoliciesModelToProto(policies)
@@ -160,10 +160,10 @@ func deleteUserTokenHandler(c echo.Context) error {
 func loginHandler(c echo.Context) error {
 	data := &models.User{}
 	if err := c.Bind(data); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if err := data.Validate(strfmt.Default); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	username := fmt.Sprintf("%v", *data.Username)
 	password := []byte(fmt.Sprintf("%v", *data.Password))

--- a/orc8r/cloud/go/services/eventd/log/handlers/log_handlers.go
+++ b/orc8r/cloud/go/services/eventd/log/handlers/log_handlers.go
@@ -63,7 +63,7 @@ func countLogs(c echo.Context, client *elastic.Client) error {
 
 	params, err := getCountParameters(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	query := secureElasticQuery(networkID, params)
 	result, err := client.Count().
@@ -71,7 +71,7 @@ func countLogs(c echo.Context, client *elastic.Client) error {
 		Query(query).
 		Do(c.Request().Context())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -104,7 +104,7 @@ func queryLogs(c echo.Context, client *elastic.Client) error {
 
 	params, err := getQueryParameters(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	query := secureElasticQuery(networkID, params)
 
@@ -116,10 +116,10 @@ func queryLogs(c echo.Context, client *elastic.Client) error {
 		Query(query).
 		Do(c.Request().Context())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	if result.Error != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("Elastic Error Type: %s, Reason: %s", result.Error.Type, result.Error.Reason))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Elastic Error Type: %s, Reason: %s", result.Error.Type, result.Error.Reason))
 	}
 	return c.JSON(http.StatusOK, result.Hits.Hits)
 }

--- a/orc8r/cloud/go/services/eventd/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/eventd/obsidian/handlers/handlers.go
@@ -88,7 +88,7 @@ func setInitErrorHandlers(err error) []obsidian.Handler {
 
 func getInitErrorHandler(err error) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("initialization Error: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("initialization Error: %v", err))
 	}
 }
 
@@ -119,13 +119,13 @@ func GetEventCountHandler(client *elastic.Client) func(c echo.Context) error {
 func EventsHandler(c echo.Context, client *elastic.Client) error {
 	queryParams, err := getQueryParameters(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	results, err := eventdC.GetEvents(c.Request().Context(), queryParams, client)
 	if err != nil {
 		glog.Error(err)
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, results)
 }
@@ -137,13 +137,13 @@ func EventsHandler(c echo.Context, client *elastic.Client) error {
 func MultiStreamEventsHandler(c echo.Context, client *elastic.Client) error {
 	params, err := getMultiStreamQueryParameters(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	results, err := eventdC.GetMultiStreamEvents(c.Request().Context(), params, client)
 	if err != nil {
 		glog.Error(err)
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, results)
 }
@@ -152,13 +152,13 @@ func MultiStreamEventsHandler(c echo.Context, client *elastic.Client) error {
 func EventCountHandler(c echo.Context, client *elastic.Client) error {
 	params, err := getMultiStreamQueryParameters(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	result, err := eventdC.GetEventCount(c.Request().Context(), params, client)
 	if err != nil {
 		glog.Error(err)
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -184,7 +184,7 @@ func getQueryParameters(c echo.Context) (eventdC.EventQueryParams, error) {
 
 // StreamNameHTTPErr indicates that stream_name is missing
 func StreamNameHTTPErr() *echo.HTTPError {
-	return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("Missing stream name"))
+	return echo.NewHTTPError(http.StatusBadRequest, "Missing stream name")
 }
 
 func getMultiStreamQueryParameters(c echo.Context) (eventdC.MultiStreamEventQueryParams, error) {

--- a/orc8r/cloud/go/services/metricsd/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/metricsd/obsidian/handlers/handlers.go
@@ -116,7 +116,7 @@ func GetObsidianHandlers(configMap *config.Map) []obsidian.Handler {
 
 func getInitErrorHandler(err error) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("initialization Error: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("initialization Error: %v", err))
 	}
 }
 
@@ -129,7 +129,7 @@ func pushHandler(c echo.Context) error {
 	var pushedMetrics []*protos.PushedMetric
 	err := json.NewDecoder(c.Request().Body).Decode(&pushedMetrics)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	metrics := &protos.PushedMetricsContainer{
@@ -138,7 +138,7 @@ func pushHandler(c echo.Context) error {
 	}
 	err = metricsd.PushMetrics(c.Request().Context(), metrics)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusOK)
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
@@ -127,22 +127,22 @@ func GetViewFiringAlertHandler(alertmanagerURL string, client HttpClient) func(c
 func configurePrometheusAlert(networkID, url string, c echo.Context, client HttpClient) error {
 	rule, err := buildRuleFromContext(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("misconfigured rule: %v", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("misconfigured rule: %v", err))
 	}
 
 	err = alert.SecureRule(true, metrics.NetworkLabelName, networkID, &rule)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	errs := rule.Validate()
 	if len(errs) != 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("invalid rule: %v\n", errs))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid rule: %v", errs))
 	}
 
 	sendErr := sendConfig(rule, url, http.MethodPost, client)
 	if sendErr != nil {
-		return echo.NewHTTPError(sendErr.Code, sendErr)
+		return echo.NewHTTPError(sendErr.Code, fmt.Sprintf("%s", sendErr.Message))
 	}
 	return c.JSON(http.StatusCreated, rule.Alert)
 }
@@ -150,23 +150,23 @@ func configurePrometheusAlert(networkID, url string, c echo.Context, client Http
 func sendConfig(payload interface{}, url string, method string, client HttpClient) *echo.HTTPError {
 	requestBody, err := json.Marshal(payload)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(requestBody))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("create http request: %w", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("create http request: %v", err))
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("make %s request: %w", method, err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("make %s request: %v", method, err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		var body echo.HTTPError
 		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return echo.NewHTTPError(resp.StatusCode, fmt.Errorf("error writing config: %v", body.Message))
+		return echo.NewHTTPError(resp.StatusCode, fmt.Sprintf("error writing config: %v", body.Message))
 	}
 	return nil
 }
@@ -186,13 +186,13 @@ func retrieveAlertRule(c echo.Context, url string, client HttpClient) error {
 	if resp.StatusCode != http.StatusOK {
 		var body echo.HTTPError
 		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return echo.NewHTTPError(resp.StatusCode, fmt.Errorf("error reading rules: %v", body.Message))
+		return echo.NewHTTPError(resp.StatusCode, fmt.Sprintf("error reading rules: %v", body.Message))
 	}
 
 	var rules []alert.RuleJSONWrapper
 	err = json.NewDecoder(resp.Body).Decode(&rules)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error decoding server response: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("error decoding server response: %v", err))
 	}
 	return c.JSON(http.StatusOK, rules)
 }
@@ -200,13 +200,13 @@ func retrieveAlertRule(c echo.Context, url string, client HttpClient) error {
 func deleteAlertRule(c echo.Context, url string, client HttpClient) error {
 	alertName := c.QueryParam(AlertNameQueryParam)
 	if alertName == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("alert name not provided"))
+		return echo.NewHTTPError(http.StatusBadRequest, "alert name not provided")
 	}
 	url += fmt.Sprintf("/%s", neturl.PathEscape(alertName))
 
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("could not form request: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("could not form request: %v", err))
 	}
 
 	resp, err := client.Do(req)
@@ -218,7 +218,7 @@ func deleteAlertRule(c echo.Context, url string, client HttpClient) error {
 	if resp.StatusCode != http.StatusOK {
 		var body echo.HTTPError
 		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return echo.NewHTTPError(resp.StatusCode, fmt.Errorf("error deleting rule: %v", body.Message))
+		return echo.NewHTTPError(resp.StatusCode, fmt.Sprintf("error deleting rule: %v", body.Message))
 	}
 	return c.JSON(http.StatusOK, nil)
 }
@@ -226,17 +226,17 @@ func deleteAlertRule(c echo.Context, url string, client HttpClient) error {
 func updateAlertRule(c echo.Context, url string, client HttpClient) error {
 	rule, err := buildRuleFromContext(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("misconfigured rule: %v", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("misconfigured rule: %v", err))
 	}
 	alertName := c.Param(AlertNamePathParam)
 	if alertName == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("alert name not provided"))
+		return echo.NewHTTPError(http.StatusBadRequest, "alert name not provided")
 	}
 	url += fmt.Sprintf("/%s", neturl.PathEscape(alertName))
 
 	sendErr := sendConfig(rule, url, http.MethodPut, client)
 	if sendErr != nil {
-		return echo.NewHTTPError(sendErr.Code, sendErr)
+		return echo.NewHTTPError(sendErr.Code, fmt.Sprintf("%s", sendErr.Message))
 	}
 	return c.JSON(http.StatusOK, nil)
 }
@@ -244,7 +244,7 @@ func updateAlertRule(c echo.Context, url string, client HttpClient) error {
 func bulkUpdateAlerts(c echo.Context, url string, client HttpClient) error {
 	rules, err := buildRuleListFromContext(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("error parsing rule payload: %v", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error parsing rule payload: %v", err))
 	}
 
 	resp, err := sendBulkConfig(rules, url, client)
@@ -257,27 +257,27 @@ func bulkUpdateAlerts(c echo.Context, url string, client HttpClient) error {
 func sendBulkConfig(payload interface{}, url string, client HttpClient) (string, error) {
 	requestBody, err := json.Marshal(payload)
 	if err != nil {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, err)
+		return "", echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(requestBody))
 	if err != nil {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("create http request: %w", err))
+		return "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("create http request: %v", err))
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("make PUT request: %w", err))
+		return "", echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("make PUT request: %v", err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		var body echo.HTTPError
 		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return "", echo.NewHTTPError(resp.StatusCode, fmt.Errorf("error writing config: %v", body.Message))
+		return "", echo.NewHTTPError(resp.StatusCode, fmt.Sprintf("error writing config: %v", body.Message))
 	}
 	contents, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", echo.NewHTTPError(http.StatusInternalServerError, err)
+		return "", echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return string(contents), nil
 }
@@ -290,14 +290,14 @@ func viewFiringAlerts(networkID, getAlertsURL string, c echo.Context, client Htt
 	if resp.StatusCode/100 != 2 {
 		var body echo.HTTPError
 		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return echo.NewHTTPError(resp.StatusCode, fmt.Errorf("alertmanager error: %v", body.Message))
+		return echo.NewHTTPError(resp.StatusCode, fmt.Sprintf("alertmanager error: %v", body.Message))
 	}
 	defer resp.Body.Close()
 
 	var alerts []models.GettableAlert
 	err = json.NewDecoder(resp.Body).Decode(&alerts)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error decoding alertmanager response: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("error decoding alertmanager response: %v", err))
 	}
 	networkAlerts := getAlertsForNetwork(networkID, alerts)
 	return c.JSON(http.StatusOK, networkAlerts)

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
@@ -142,7 +142,7 @@ func configurePrometheusAlert(networkID, url string, c echo.Context, client Http
 
 	sendErr := sendConfig(rule, url, http.MethodPost, client)
 	if sendErr != nil {
-		return echo.NewHTTPError(sendErr.Code, fmt.Sprintf("%s", sendErr.Message))
+		return sendErr
 	}
 	return c.JSON(http.StatusCreated, rule.Alert)
 }
@@ -236,7 +236,7 @@ func updateAlertRule(c echo.Context, url string, client HttpClient) error {
 
 	sendErr := sendConfig(rule, url, http.MethodPut, client)
 	if sendErr != nil {
-		return echo.NewHTTPError(sendErr.Code, fmt.Sprintf("%s", sendErr.Message))
+		return sendErr
 	}
 	return c.JSON(http.StatusOK, nil)
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler_test.go
@@ -70,12 +70,12 @@ func TestGetConfigurePrometheusAlertHandler(t *testing.T) {
 		{
 			Name:          "invalid rule",
 			Payload:       badLabelsRule,
-			ExpectedError: "code=400, message=invalid rule: [invalid label name: !labelName]\n",
+			ExpectedError: "code=400, message=invalid rule: [invalid label name: !labelName]",
 		},
 		{
 			Name:                 "server error",
 			ClientExpectedReturn: []interface{}{empty500Response, nil},
-			ExpectedError:        "code=500, message=code=500, message=error writing config: <nil>",
+			ExpectedError:        "code=500, message=error writing config: <nil>",
 		},
 		{
 			Name:          "bad payload",
@@ -205,7 +205,7 @@ func TestGetUpdateAlertRuleHandler(t *testing.T) {
 		{
 			Name:                 "server non-200 response",
 			ClientExpectedReturn: []interface{}{empty500Response, nil},
-			ExpectedError:        "code=500, message=code=500, message=error writing config: <nil>",
+			ExpectedError:        "code=500, message=error writing config: <nil>",
 		},
 		{
 			Name:          "bad payload",

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers.go
@@ -90,7 +90,7 @@ func configureAlertReceiver(c echo.Context, url string, client HttpClient) error
 
 	sendErr := sendConfig(receiver, url, http.MethodPost, client)
 	if sendErr != nil {
-		return echo.NewHTTPError(sendErr.Code, fmt.Sprintf("%s", sendErr.Message))
+		return sendErr
 	}
 	return c.NoContent(http.StatusOK)
 }
@@ -131,7 +131,7 @@ func updateAlertReceiver(c echo.Context, url string, client HttpClient) error {
 
 	sendErr := sendConfig(receiver, url, http.MethodPut, client)
 	if sendErr != nil {
-		return echo.NewHTTPError(sendErr.Code, fmt.Sprintf("%s", sendErr.Message))
+		return sendErr
 	}
 	return c.NoContent(http.StatusOK)
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers.go
@@ -85,12 +85,12 @@ func getHandlerWithRouteFunc(configManagerURL string, handlerImplFunc func(echo.
 func configureAlertReceiver(c echo.Context, url string, client HttpClient) error {
 	receiver, err := buildReceiverFromContext(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	sendErr := sendConfig(receiver, url, http.MethodPost, client)
 	if sendErr != nil {
-		return echo.NewHTTPError(sendErr.Code, fmt.Errorf("%s", sendErr.Message))
+		return echo.NewHTTPError(sendErr.Code, fmt.Sprintf("%s", sendErr.Message))
 	}
 	return c.NoContent(http.StatusOK)
 }
@@ -105,7 +105,7 @@ func retrieveAlertReceivers(c echo.Context, url string, client HttpClient) error
 	if resp.StatusCode != http.StatusOK {
 		var body echo.HTTPError
 		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return echo.NewHTTPError(resp.StatusCode, fmt.Errorf("error reading receivers: %v", body.Message))
+		return echo.NewHTTPError(resp.StatusCode, fmt.Sprintf("error reading receivers: %v", body.Message))
 	}
 	var recs []config.Receiver
 	err = json.NewDecoder(resp.Body).Decode(&recs)
@@ -118,20 +118,20 @@ func retrieveAlertReceivers(c echo.Context, url string, client HttpClient) error
 func updateAlertReceiver(c echo.Context, url string, client HttpClient) error {
 	receiver, err := buildReceiverFromContext(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	receiverName := c.Param(ReceiverNamePathParam)
 	if receiverName == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("receiver name not provided"))
+		return echo.NewHTTPError(http.StatusBadRequest, "receiver name not provided")
 	}
 	if receiverName != receiver.Name {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("new receiver configuration must have same name"))
+		return echo.NewHTTPError(http.StatusBadRequest, "new receiver configuration must have same name")
 	}
 	url += fmt.Sprintf("/%s", neturl.PathEscape(receiverName))
 
 	sendErr := sendConfig(receiver, url, http.MethodPut, client)
 	if sendErr != nil {
-		return echo.NewHTTPError(sendErr.Code, sendErr)
+		return echo.NewHTTPError(sendErr.Code, fmt.Sprintf("%s", sendErr.Message))
 	}
 	return c.NoContent(http.StatusOK)
 }
@@ -139,23 +139,23 @@ func updateAlertReceiver(c echo.Context, url string, client HttpClient) error {
 func deleteAlertReceiver(c echo.Context, url string, client HttpClient) error {
 	receiverName := c.QueryParam(ReceiverNameQueryParam)
 	if receiverName == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("receiver name not provided"))
+		return echo.NewHTTPError(http.StatusBadRequest, "receiver name not provided")
 	}
 	url += fmt.Sprintf("/%s", neturl.PathEscape(receiverName))
 
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	if resp.StatusCode != http.StatusOK {
 		var body echo.HTTPError
 		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return echo.NewHTTPError(resp.StatusCode, fmt.Errorf("error deleting receiver: %v", body.Message))
+		return echo.NewHTTPError(resp.StatusCode, fmt.Sprintf("error deleting receiver: %v", body.Message))
 	}
 	return c.NoContent(http.StatusOK)
 }
@@ -170,12 +170,12 @@ func retrieveAlertRoute(c echo.Context, url string, client HttpClient) error {
 	if resp.StatusCode != http.StatusOK {
 		var body echo.HTTPError
 		_ = json.NewDecoder(resp.Body).Decode(&body)
-		return echo.NewHTTPError(resp.StatusCode, fmt.Errorf("error reading alerting route: %v", body.Message))
+		return echo.NewHTTPError(resp.StatusCode, fmt.Sprintf("error reading alerting route: %v", body.Message))
 	}
 	var route config.Route
 	err = json.NewDecoder(resp.Body).Decode(&route)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error decoding server response %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("error decoding server response %v", err))
 	}
 	return c.JSON(http.StatusOK, route)
 }
@@ -183,12 +183,12 @@ func retrieveAlertRoute(c echo.Context, url string, client HttpClient) error {
 func updateAlertRoute(c echo.Context, url string, client HttpClient) error {
 	route, err := buildRouteFromContext(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("invalid route specification: %v", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid route specification: %v", err))
 	}
 
 	sendErr := sendConfig(route, url, http.MethodPost, client)
 	if sendErr != nil {
-		return echo.NewHTTPError(sendErr.Code, fmt.Errorf("error updating alert route: %v", sendErr.Message))
+		return echo.NewHTTPError(sendErr.Code, fmt.Sprintf("error updating alert route: %v", sendErr.Message))
 	}
 	return c.NoContent(http.StatusOK)
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers_test.go
@@ -227,7 +227,7 @@ func TestGetUpdateAlertReceiverHandler(t *testing.T) {
 		{
 			Name:                 "server error",
 			ClientExpectedReturn: []interface{}{empty500Response, nil},
-			ExpectedError:        "code=500, message=code=500, message=error writing config: <nil>",
+			ExpectedError:        "code=500, message=error writing config: <nil>",
 		},
 	}
 	for i := range tests {

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
@@ -90,7 +90,7 @@ func GetPrometheusTargetsMetadata(api PrometheusAPI) func(c echo.Context) error 
 			c.QueryParam(utils.ParamLimit),
 		)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		return c.JSON(http.StatusOK, res)
 	}
@@ -104,7 +104,7 @@ func GetPrometheusQueryHandler(api PrometheusAPI) func(c echo.Context) error {
 		}
 		restrictedQuery, err := preparePrometheusQuery(c, networkQueryRestrictorProvider(nID))
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		return prometheusQuery(c, restrictedQuery, api)
 	}
@@ -114,13 +114,13 @@ func prometheusQuery(c echo.Context, query string, apiClient PrometheusAPI) erro
 	defaultTime := time.Now()
 	queryTime, err := utils.ParseTime(c.QueryParam(utils.ParamTime), &defaultTime)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("unable to parse %s parameter: %v", utils.ParamTime, err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("unable to parse %s parameter: %v", utils.ParamTime, err))
 	}
 
 	// TODO: catch the warnings replacing _
 	res, _, err := apiClient.Query(c.Request().Context(), query, queryTime)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, wrapPrometheusResult(res))
 }
@@ -133,7 +133,7 @@ func GetPrometheusQueryRangeHandler(api PrometheusAPI) func(c echo.Context) erro
 		}
 		restrictedQuery, err := preparePrometheusQuery(c, networkQueryRestrictorProvider(nID))
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		return prometheusQueryRange(c, restrictedQuery, api)
 	}
@@ -142,25 +142,25 @@ func GetPrometheusQueryRangeHandler(api PrometheusAPI) func(c echo.Context) erro
 func prometheusQueryRange(c echo.Context, query string, apiClient PrometheusAPI) error {
 	startTime, err := utils.ParseTime(c.QueryParam(utils.ParamRangeStart), nil)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("unable to parse %s parameter: %v", utils.ParamRangeStart, err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("unable to parse %s parameter: %v", utils.ParamRangeStart, err))
 	}
 
 	defaultTime := time.Now()
 	endTime, err := utils.ParseTime(c.QueryParam(utils.ParamRangeEnd), &defaultTime)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("unable to parse %s parameter: %v", utils.ParamRangeEnd, err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("unable to parse %s parameter: %v", utils.ParamRangeEnd, err))
 	}
 
 	step, err := utils.ParseDuration(c.QueryParam(utils.ParamStepWidth), defaultStepWidth)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("unable to parse %s parameter: %v", utils.ParamStepWidth, err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("unable to parse %s parameter: %v", utils.ParamStepWidth, err))
 	}
 	timeRange := v1.Range{Start: startTime, End: endTime, Step: step}
 
 	// TODO: catch the warnings replacing _
 	res, _, err := apiClient.QueryRange(c.Request().Context(), query, timeRange)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, wrapPrometheusResult(res))
 }
@@ -177,7 +177,7 @@ func GetTenantQueryHandler(api PrometheusAPI) func(c echo.Context) error {
 		}
 		restrictedQuery, err := preparePrometheusQuery(c, tenantRestrictor)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		return prometheusQuery(c, restrictedQuery, api)
 	}
@@ -195,11 +195,11 @@ func GetTenantQueryRangeHandler(api PrometheusAPI) func(c echo.Context) error {
 		}
 		orgRestrictor, err := tenantQueryRestrictorProvider(c.Request().Context(), tID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		restrictedQuery, err := preparePrometheusQuery(c, orgRestrictor)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		return prometheusQueryRange(c, restrictedQuery, api)
 	}
@@ -254,7 +254,7 @@ func GetPrometheusSeriesHandler(api PrometheusAPI) func(c echo.Context) error {
 		}
 		seriesMatches, err := getSeriesMatches(c, paramMatch, networkQueryRestrictorProvider(nID))
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("Error parsing series matchers: %v", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Error parsing series matchers: %v", err))
 		}
 		series, err := prometheusSeries(c, seriesMatches, api)
 		if err != nil {
@@ -272,11 +272,11 @@ func TenantSeriesHandlerProvider(api PrometheusAPI) func(c echo.Context) error {
 		}
 		queryRestrictor, err := tenantQueryRestrictorProvider(c.Request().Context(), oID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		seriesMatches, err := getSeriesMatches(c, paramMatch, queryRestrictor)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("Error parsing series matchers: %v", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Error parsing series matchers: %v", err))
 		}
 
 		series, err := prometheusSeries(c, seriesMatches, api)
@@ -319,11 +319,11 @@ func GetTenantPromSeriesHandler(api PrometheusAPI, useCache bool) func(c echo.Co
 		reqCtx := c.Request().Context()
 		queryRestrictor, err := tenantQueryRestrictorProvider(reqCtx, oID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		seriesMatches, err := getSeriesMatches(c, paramPromMatch, queryRestrictor)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("Error parsing series matchers: %v", err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Error parsing series matchers: %v", err))
 		}
 
 		// Check the cache for stored responses
@@ -339,17 +339,17 @@ func GetTenantPromSeriesHandler(api PrometheusAPI, useCache bool) func(c echo.Co
 		startStr := c.QueryParam(utils.ParamRangeStart)
 		startTime, err := utils.ParseTime(startStr, &defaultStartTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse start time: %s: %w", startStr, err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("parse start time: %s: %v", startStr, err))
 		}
 		endStr := c.QueryParam(utils.ParamRangeEnd)
 		endTime, err := utils.ParseTime(endStr, &defaultEndTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse end time: %s: %w", endStr, err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("parse end time: %s: %v", endStr, err))
 		}
 
 		res, _, err := api.Series(reqCtx, seriesMatches, startTime, endTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		if seriesCache != nil {
 			seriesCache.Set(seriesMatches, res)
@@ -361,18 +361,18 @@ func GetTenantPromSeriesHandler(api PrometheusAPI, useCache bool) func(c echo.Co
 func prometheusSeries(c echo.Context, seriesMatches []string, apiClient PrometheusAPI) ([]model.LabelSet, error) {
 	startTime, err := utils.ParseTime(c.QueryParam(utils.ParamRangeStart), &minTime)
 	if err != nil {
-		return []model.LabelSet{}, echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("unable to parse %s parameter: %v", utils.ParamRangeStart, err))
+		return []model.LabelSet{}, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("unable to parse %s parameter: %v", utils.ParamRangeStart, err))
 	}
 
 	endTime, err := utils.ParseTime(c.QueryParam(utils.ParamRangeEnd), &maxTime)
 	if err != nil {
-		return []model.LabelSet{}, echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("unable to parse %s parameter: %v", utils.ParamRangeEnd, err))
+		return []model.LabelSet{}, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("unable to parse %s parameter: %v", utils.ParamRangeEnd, err))
 	}
 
 	// TODO: catch the warnings replacing _
 	res, _, err := apiClient.Series(c.Request().Context(), seriesMatches, startTime, endTime)
 	if err != nil {
-		return []model.LabelSet{}, echo.NewHTTPError(http.StatusInternalServerError, err)
+		return []model.LabelSet{}, echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return res, nil
 }
@@ -387,7 +387,7 @@ func getSeriesMatches(c echo.Context, matchParam string, queryRestrictor restric
 		}
 		restricted, err := queryRestrictor.RestrictQuery(match)
 		if err != nil {
-			return []string{}, echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("unable to secure match parameter: %v", err))
+			return []string{}, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("unable to secure match parameter: %v", err))
 		}
 		seriesMatchers = append(seriesMatchers, restricted)
 	}
@@ -410,18 +410,18 @@ func GetTenantPromValuesHandler(api PrometheusAPI) func(c echo.Context) error {
 		}
 		labelName := c.Param("label_name")
 		if labelName == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("label_name is required"))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("label_name is required"))
 		}
 
 		reqCtx := c.Request().Context()
 		queryRestrictor, err := tenantQueryRestrictorProvider(reqCtx, oID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 
 		restrictedQuery, err := queryRestrictor.RestrictQuery(fmt.Sprintf("{%s=~\".+\"}", labelName))
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 
 		seriesMatchers := []string{restrictedQuery}
@@ -434,16 +434,16 @@ func GetTenantPromValuesHandler(api PrometheusAPI) func(c echo.Context) error {
 		endStr := c.QueryParam(utils.ParamRangeEnd)
 		startTime, err := utils.ParseTime(startStr, &defaultStartTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse start time: %s: %w", startStr, err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("parse start time: %s: %v", startStr, err))
 		}
 		endTime, err := utils.ParseTime(endStr, &maxTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("parse end time: %s: %w", endStr, err))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("parse end time: %s: %v", endStr, err))
 		}
 
 		res, _, err := api.Series(reqCtx, seriesMatchers, startTime, endTime)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		data := getSetOfValuesFromLabel(res, model.LabelName(labelName))
 

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
@@ -410,7 +410,7 @@ func GetTenantPromValuesHandler(api PrometheusAPI) func(c echo.Context) error {
 		}
 		labelName := c.Param("label_name")
 		if labelName == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("label_name is required"))
+			return echo.NewHTTPError(http.StatusBadRequest, "label_name is required")
 		}
 
 		reqCtx := c.Request().Context()

--- a/orc8r/cloud/go/services/obsidian/handler.go
+++ b/orc8r/cloud/go/services/obsidian/handler.go
@@ -203,7 +203,7 @@ func CheckNetworkAccess(c echo.Context, networkId string) *echo.HTTPError {
 	cert := getCert(c)
 	if cert == nil {
 		err := fmt.Errorf("Client certificate with valid SANs is required for network: %s", networkId)
-		return echo.NewHTTPError(http.StatusForbidden, err)
+		return echo.NewHTTPError(http.StatusForbidden, err.Error())
 	}
 
 	if cert.Subject.CommonName == wildcard ||
@@ -252,7 +252,7 @@ func CheckTenantAccess(c echo.Context) *echo.HTTPError {
 	cert := getCert(c)
 	if cert == nil {
 		err := errors.New("Client certificate with valid SANs is required for tenant access")
-		return echo.NewHTTPError(http.StatusForbidden, err)
+		return echo.NewHTTPError(http.StatusForbidden, err.Error())
 	}
 
 	if cert.Subject.CommonName == wildcard || cert.Subject.CommonName == networkWildcard {
@@ -294,7 +294,7 @@ func GetParamValues(c echo.Context, paramNames ...string) ([]string, *echo.HTTPE
 	for _, paramName := range paramNames {
 		val := c.Param(paramName)
 		if val == "" {
-			return []string{}, echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("invalid/missing param %s", paramName))
+			return []string{}, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid/missing param %s", paramName))
 		}
 		ret = append(ret, val)
 	}
@@ -312,11 +312,11 @@ func GetOperatorId(c echo.Context) (string, *echo.HTTPError) {
 }
 
 func NetworkIdHttpErr() *echo.HTTPError {
-	return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("Missing Network ID"))
+	return echo.NewHTTPError(http.StatusBadRequest, "Missing Network ID")
 }
 
 func TenantIdHttpErr() *echo.HTTPError {
-	return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("Missing Tenant ID"))
+	return echo.NewHTTPError(http.StatusBadRequest, "Missing Tenant ID")
 }
 
 // GetPaginationParams returns page size and token params.
@@ -329,7 +329,7 @@ func GetPaginationParams(c echo.Context) (uint64, string, error) {
 	pageSize, err := strconv.ParseUint(pageSizeStr, 10, 32)
 	if err != nil {
 		err := fmt.Errorf("invalid page size parameter: %w", err)
-		return 0, pageToken, echo.NewHTTPError(http.StatusBadRequest, err)
+		return 0, pageToken, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	return pageSize, pageToken, nil
 }

--- a/orc8r/cloud/go/services/obsidian/swagger/handlers/handlers.go
+++ b/orc8r/cloud/go/services/obsidian/swagger/handlers/handlers.go
@@ -15,7 +15,6 @@ package handlers
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -75,7 +74,7 @@ func GetCombinedSpecHandler(yamlCommon string) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		combined, err := swagger.GetCombinedSpec(yamlCommon)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		return c.String(http.StatusOK, combined)
 	}
@@ -87,15 +86,15 @@ func GetSpecHandler() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		service, ok, err := getServiceName(c.Param("service"))
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		if !ok {
-			return echo.NewHTTPError(http.StatusNotFound, errors.New("service not found"))
+			return echo.NewHTTPError(http.StatusNotFound, "service not found")
 		}
 
 		yamlSpec, err := swagger.GetServiceSpec(service)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 
 		return c.String(http.StatusOK, yamlSpec)
@@ -107,15 +106,15 @@ func GetUIHandler(tmpl *template.Template) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		service, ok, err := getServiceName(c.Param("service"))
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		if !ok {
-			return echo.NewHTTPError(http.StatusNotFound, errors.New("service not found"))
+			return echo.NewHTTPError(http.StatusNotFound, "service not found")
 		}
 
 		services, err := registry.FindServices(orc8r.SwaggerSpecLabel)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		sort.Strings(services)
 
@@ -128,7 +127,7 @@ func GetUIHandler(tmpl *template.Template) echo.HandlerFunc {
 		var buf bytes.Buffer
 		err = tmpl.Execute(&buf, uiInfo)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 
 		return c.HTML(http.StatusOK, buf.String())

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/about_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/about_handlers.go
@@ -14,7 +14,6 @@
 package handlers
 
 import (
-	"errors"
 	"net/http"
 	"os"
 
@@ -26,11 +25,11 @@ import (
 func getVersionHandler(c echo.Context) error {
 	version, ok := os.LookupEnv("VERSION_TAG")
 	if !ok {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.New("Failed to get Orc8r version"))
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get Orc8r version")
 	}
 	chartVersion, ok := os.LookupEnv("HELM_VERSION_TAG")
 	if !ok {
-		return echo.NewHTTPError(http.StatusInternalServerError, errors.New("Failed to get Helm chart version"))
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get Helm chart version")
 	}
 	versionInfo := models.VersionInfo{
 		ContainerImageVersion: version,

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/common.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/common.go
@@ -33,11 +33,11 @@ import (
 func GetAndValidatePayload(c echo.Context, model interface{}) (serde.ValidatableModel, *echo.HTTPError) {
 	iModel := reflect.New(reflect.TypeOf(model).Elem()).Interface().(serde.ValidatableModel)
 	if err := c.Bind(iModel); err != nil {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, err)
+		return nil, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	// Run validations specified by the swagger spec
 	if err := iModel.ValidateModel(c.Request().Context()); err != nil {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, err)
+		return nil, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	return iModel, nil
 }

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_command_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_command_handlers.go
@@ -47,9 +47,9 @@ func rebootGateway(c echo.Context) error {
 	err := magmad.GatewayReboot(c.Request().Context(), networkID, gatewayID)
 	if err != nil {
 		if err == merrors.ErrNotFound {
-			return echo.NewHTTPError(http.StatusNotFound, err)
+			return echo.NewHTTPError(http.StatusNotFound, err.Error())
 		}
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.NoContent(http.StatusOK)
@@ -64,14 +64,14 @@ func restartServices(c echo.Context) error {
 	var services []string
 	err := c.Bind(&services)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	err = magmad.GatewayRestartServices(c.Request().Context(), networkID, gatewayID, services)
 	if err != nil {
 		if err == merrors.ErrNotFound {
-			return echo.NewHTTPError(http.StatusNotFound, err)
+			return echo.NewHTTPError(http.StatusNotFound, err.Error())
 		}
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.NoContent(http.StatusOK)
@@ -86,14 +86,14 @@ func gatewayPing(c echo.Context) error {
 	pingRequest := magmadModels.PingRequest{}
 	err := c.Bind(&pingRequest)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	response, err := magmad.GatewayPing(c.Request().Context(), networkID, gatewayID, pingRequest.Packets, pingRequest.Hosts)
 	if err != nil {
 		if err == merrors.ErrNotFound {
-			return echo.NewHTTPError(http.StatusNotFound, err)
+			return echo.NewHTTPError(http.StatusNotFound, err.Error())
 		}
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	var pingResponse magmadModels.PingResponse
 	for _, ping := range response.Pings {
@@ -119,11 +119,11 @@ func gatewayGenericCommand(c echo.Context) error {
 	request := magmadModels.GenericCommandParams{}
 	err := c.Bind(&request)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	params, err := models2.JSONMapToProtobufStruct(request.Params)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	genericCommandParams := protos.GenericCommandParams{
 		Command: *request.Command,
@@ -136,13 +136,13 @@ func gatewayGenericCommand(c echo.Context) error {
 		if st.Code() == codes.InvalidArgument {
 			return echo.NewHTTPError(http.StatusNotFound, st.Message())
 		} else {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 	}
 
 	resp, err := models2.ProtobufStructToJSONMap(response.Response)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	genericCommandResponse := magmadModels.GenericCommandResponse{
 		Response: resp,
@@ -159,12 +159,12 @@ func tailGatewayLogs(c echo.Context) error {
 	request := magmadModels.TailLogsRequest{}
 	err := c.Bind(&request)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	stream, err := magmad.TailGatewayLogs(c.Request().Context(), networkID, gatewayID, request.Service)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	go func() {
@@ -180,11 +180,11 @@ func tailGatewayLogs(c echo.Context) error {
 			break
 		}
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 
 		if _, err := c.Response().Write([]byte(line.Line)); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		c.Response().Flush()
 	}

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers.go
@@ -31,7 +31,7 @@ import (
 func listNetworks(c echo.Context) error {
 	networks, err := configurator.ListNetworkIDs(c.Request().Context())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	if networks == nil {
 		networks = []string{}
@@ -51,7 +51,7 @@ func registerNetwork(c echo.Context) error {
 		serdes.Network,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	return c.JSON(http.StatusCreated, createdNetworks[0].ID)
 }
@@ -66,7 +66,7 @@ func getNetwork(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound)
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	ret := (&models.Network{}).FromConfiguratorNetwork(network)
 	return c.JSON(http.StatusOK, ret)
@@ -80,7 +80,7 @@ func updateNetwork(c echo.Context) error {
 	update := network.(*models.Network).ToUpdateCriteria()
 	err := configurator.UpdateNetworks(c.Request().Context(), []configurator.NetworkUpdateCriteria{update}, serdes.Network)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -92,7 +92,7 @@ func deleteNetwork(c echo.Context) error {
 	}
 	err := configurator.DeleteNetwork(c.Request().Context(), networkID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -117,7 +117,7 @@ func CreateDNSRecord(c echo.Context) error {
 	// check the domain is not already registered
 	for _, record := range dnsConfig.Records {
 		if record.Domain == domain {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("A record with domain:%s already exists", domain))
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("A record with domain:%s already exists", domain))
 		}
 	}
 
@@ -218,7 +218,7 @@ func updateDNSConfig(ctx context.Context, networkID string, dnsConfig *models.Ne
 		serdes.Network,
 	)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return nil
 }
@@ -236,7 +236,7 @@ func getExistingDNSConfig(ctx context.Context, networkID string) (*models.Networ
 	if err == merrors.ErrNotFound {
 		return nil, echo.NewHTTPError(http.StatusNotFound)
 	} else if err != nil {
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return iDNSConfig.(*models.NetworkDNSConfig), nil
 }
@@ -249,7 +249,7 @@ func getRecordAndValidate(c echo.Context, domain string) (*models.DNSConfigRecor
 	record := payload.(*models.DNSConfigRecord)
 
 	if record.Domain != domain {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("Domain name in param and record don't match"))
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Domain name in param and record don't match")
 	}
 	return record, nil
 }

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers.go
@@ -15,7 +15,6 @@ package handlers
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"sort"
 
@@ -33,7 +32,7 @@ import (
 func listChannelsHandler(c echo.Context) error {
 	channelNames, err := configurator.ListInternalEntityKeys(c.Request().Context(), orc8r.UpgradeReleaseChannelEntityType)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	sort.Strings(channelNames)
 	return c.JSON(http.StatusOK, channelNames)
@@ -54,7 +53,7 @@ func createChannelHandler(c echo.Context) error {
 	}
 	_, err := configurator.CreateInternalEntity(c.Request().Context(), entity, serdes.Entity)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -71,10 +70,10 @@ func readChannelHandler(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusNotFound, err)
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, entity.Config)
 }
@@ -99,7 +98,7 @@ func updateChannelHandler(c echo.Context) error {
 	}
 	_, err := configurator.UpdateInternalEntity(c.Request().Context(), update, serdes.Entity)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -111,7 +110,7 @@ func deleteChannelHandler(c echo.Context) error {
 	}
 	err := configurator.DeleteInternalEntity(c.Request().Context(), orc8r.UpgradeReleaseChannelEntityType, channelID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -123,7 +122,7 @@ func listTiersHandler(c echo.Context) error {
 	}
 	tiers, err := configurator.ListEntityKeys(c.Request().Context(), networkID, orc8r.UpgradeTierEntityType)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	sort.Strings(tiers)
 	return c.JSON(http.StatusOK, tiers)
@@ -159,12 +158,12 @@ func updateTierHandler(c echo.Context) error {
 	tier := payload.(*models.Tier)
 
 	if string(tier.ID) != tierID {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("TierID in URL and payload do not match."))
+		return echo.NewHTTPError(http.StatusBadRequest, "TierID in URL and payload do not match.")
 	}
 	update := tier.ToUpdateCriteria()
 	_, err := configurator.UpdateEntity(c.Request().Context(), networkID, update, serdes.Entity)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -181,10 +180,10 @@ func readTierHandler(c echo.Context) error {
 		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusNotFound, err)
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	tier := &models.Tier{}
 	return c.JSON(http.StatusOK, tier.FromBackendModel(entity))
@@ -197,7 +196,7 @@ func deleteTierHandler(c echo.Context) error {
 	}
 	err := configurator.DeleteEntity(c.Request().Context(), networkID, orc8r.UpgradeTierEntityType, tierID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -214,14 +213,14 @@ func createTierImage(c echo.Context) error {
 
 	updates, err := image.(*models.TierImage).ToUpdateCriteria(c.Request().Context(), networkID, tierID)
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusNotFound, err)
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	_, err = configurator.UpdateEntities(c.Request().Context(), networkID, updates, serdes.Entity)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -238,14 +237,14 @@ func deleteImage(c echo.Context) error {
 	reqCtx := c.Request().Context()
 	update, err := (&models.TierImage{}).ToDeleteImageUpdateCriteria(reqCtx, networkID, tierID, params[0])
 	if err == merrors.ErrNotFound {
-		return echo.NewHTTPError(http.StatusNotFound, err)
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	_, err = configurator.UpdateEntity(reqCtx, networkID, update, serdes.Entity)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -257,7 +256,7 @@ func createTierGateway(c echo.Context) error {
 	}
 	var gatewayID string
 	if err := c.Bind(&gatewayID); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	update := (&models.TierGateways{}).ToAddGatewayUpdateCriteria(tierID, gatewayID)
@@ -280,7 +279,7 @@ func deleteTierGateway(c echo.Context) error {
 	update := (&models.TierGateways{}).ToDeleteGatewayUpdateCriteria(tierID, gatewayID)
 	_, err := configurator.UpdateEntity(c.Request().Context(), networkID, update, serdes.Entity)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/orc8r/cloud/go/services/tenants/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/tenants/obsidian/handlers/handlers.go
@@ -77,7 +77,7 @@ func GetObsidianHandlers() []obsidian.Handler {
 func GetTenantsHandler(c echo.Context) error {
 	tenants, err := tenants.GetAllTenants(c.Request().Context())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	tenantsAndIDs := make([]models.Tenant, 0)
 	for _, tenant := range tenants.Tenants {
@@ -93,10 +93,10 @@ func CreateTenantHandler(c echo.Context) error {
 	var tenantInfo = models.Tenant{}
 	err := json.NewDecoder(c.Request().Body).Decode(&tenantInfo)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("error decoding request: %v", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error decoding request: %v", err))
 	}
 	if tenantInfo.ID == nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("must provide tenant ID"))
+		return echo.NewHTTPError(http.StatusBadRequest, "must provide tenant ID")
 	}
 
 	_, err = tenants.CreateTenant(c.Request().Context(), *tenantInfo.ID, &protos.Tenant{
@@ -104,7 +104,7 @@ func CreateTenantHandler(c echo.Context) error {
 		Networks: tenantInfo.Networks,
 	})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error creating tenant: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("error creating tenant: %v", err))
 	}
 	return c.NoContent(http.StatusCreated)
 }
@@ -132,7 +132,7 @@ func SetTenantHandler(c echo.Context) error {
 	var tenantInfo = protos.Tenant{}
 	err := json.NewDecoder(c.Request().Body).Decode(&tenantInfo)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("error decoding request: %v", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error decoding request: %v", err))
 	}
 
 	err = tenants.SetTenant(c.Request().Context(), tenantID, &tenantInfo)
@@ -190,17 +190,17 @@ func CreateOrUpdateControlProxyHandler(c echo.Context) error {
 	req.Id = tenantID
 	data := &models.ControlProxy{}
 	if err := c.Bind(data); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("error decoding request: %v", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("error decoding request: %v", err))
 	}
 	if err := data.Validate(strfmt.Default); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	req.ControlProxy = *data.ControlProxy
 
 	err = tenants.CreateOrUpdateControlProxy(c.Request().Context(), &req)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("error setting control_proxy contents: %v", err))
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("error setting control_proxy contents: %v", err))
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -209,9 +209,9 @@ func CreateOrUpdateControlProxyHandler(c echo.Context) error {
 func mapErr(err error, notFoundErr error, nonNilErr error) error {
 	switch {
 	case err == merrors.ErrNotFound:
-		return echo.NewHTTPError(http.StatusNotFound, notFoundErr)
+		return echo.NewHTTPError(http.StatusNotFound, notFoundErr.Error())
 	case err != nil:
-		return echo.NewHTTPError(http.StatusInternalServerError, nonNilErr)
+		return echo.NewHTTPError(http.StatusInternalServerError, nonNilErr.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Sebastian Wolf <sebastian.wolf@tngtech.com>
Part of #14707.

## Summary

The method `echo.NewHTTPError` takes the error as a string. Currently, however, it is passed as an error object. This PR fixes this in the orc8r codebase. The following changes are made:

* `err` --> `err.Error()`
* `fmt.Errorf("text: %w", err)` --> `fmtSprintf("text: %v", err)`
* `fmt.Errorf(...)` --> `fmt.Sprintf(...)`
* `fmt.Errorf("%s", sendErr.Message)`, `sendErr`, etc --> `fmt.Sprintf("%s", sendErr.Message)`
* `fmt.Errors("...")`, `errors.New("...")` --> `"..."`


## Additional Information

- [ ] This change is backwards-breaking
