### PR TITLE
fix(pipelined): Set timeout for socket when getting mac address

### DIFF
--- a/lte/gateway/python/magma/pipelined/gw_mac_address.py
+++ b/lte/gateway/python/magma/pipelined/gw_mac_address.py
@@ -180,6 +180,7 @@ def _send_packet_and_receive_response(pkt: dpkt.arp.ARP, vlan: str, non_nat_arp_
     packet_aux_data = 8
     with socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(0x0003)) as s:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, buffsize)
+        s.settimeout(2)
         if vlan.isdigit():
             s.setsockopt(sol_packet, packet_aux_data, 1)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, 1)


### PR DESCRIPTION
## Summary

In some test cases, it's possible for the code to get stuck. A timeout on the socket avoids this, and is consistent with the behavior before the refactoring in #14405 as the original `srp1` call set a 1s timeout. (I used a larger timeout just to be conservative.)

Related to #14748.

## Test Plan

The changes from #14700 caused a sudo test to get stuck and were later reverted. With these changes and a timeout, the test is red and no longer gets stuck.

## Additional Information

- [ ] This change is backwards-breaking