### PR TITLE
fix(agw): Broken Python CLI scripts in containerized AGW

### DIFF
--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -170,7 +170,9 @@ COPY --from=builder /build /build
 COPY --from=builder /var/tmp/python3-aioeventlet*.deb /var/tmp/
 
 # The Python scripts in /build/bin are broken inside the container
-RUN rm -f /build/bin/dhcp_helper_cli.py
+# Remove all Python scripts already exist in /usr/local/bin
+WORKDIR /usr/local/bin
+RUN find ./*.py -exec rm -rf /build/bin/{} \;
 
 RUN chmod -R +x /usr/local/bin/generate* /usr/local/bin/set_irq_affinity /usr/local/bin/checkin_cli.py && \
   dpkg -i /var/tmp/python3-aioeventlet* && \


### PR DESCRIPTION
Signed-off-by: Alex Jahl <alexander.jahl@tngtech.com>

## Summary
This PR fixes an error when calling AGW CLI scripts in the AGW containers. The issue is described  in #14705.
The broken scripts in `/build/bin` are generated during the docker build process using the Builder image.  The generated scripts contain python script references to the actual files located in `magma/orc8r` or `magma/lte`. While the Builder image includes links to these folders the Production image includes only a copy of the generated scripts and has now connection to folders in `magma`. This leads to  broken CLI scripts. 

However, the original Python CLI scripts are also copied into the Production image and stored in `/usr/local/bin` and their calls work. Modifying the PYTHONPATH to prefer the `/usr/local/bin` folder does not work because the active `virtualenv` always seems to give the highest priority to its own working directory `build`  that includes the `bin` folder. 

Since the scripts do not work and the originals exist in `/usr/local/bin`, the PR adds a script in the Dockerfile that deletes all relevant scripts from `/build/bin` in the AGW containers.

closes #14705

## Test Plan
- Built containerized AGW in the Magma VM
       `vagrant@magma-dev:~/magma/lte/gateway/docker$ docker-compose build && docker-compose up`
- Open bash in one running python container, for example 
       `vagrant@magma-dev:~/magma/lte/gateway/docker$ docker exec -i -t magmad bash`
- Execute a CLI script, for example
       `vagrant@magma-dev:~/magma/lte/gateway/docker$ ctraced_cli.py`