### PR TITLE
fix(agw): change remote location of liblfds

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -107,9 +107,9 @@ def cpp_repositories():
     new_git_repository(
         name = "liblfds",
         build_file = "//bazel/external:liblfds.BUILD",
-        commit = "b813a0e546ed54e54b3873bdf180cf885c39bbca",
-        remote = "https://github.com/liblfds/liblfds.git",
-        shallow_since = "1464682027 +0300",
+        commit = "b36a48014574225723779c7e1e9fb8cb6fa8f7f4",
+        remote = "https://liblfds.org/git/liblfds",
+        shallow_since = "1657356839 +0000",
     )
 
     new_git_repository(


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

`liblfds` is not hosted on GitHub anymore, but on their own servers, see https://www.liblfds.org/pages/git.html. This PR changes its remote location for the AGW build.

## Test Plan

- Spin up fresh `magma-dev` VM and build AGW using `cd $MAGMA_ROOT && bazel/scripts/build_and_run_bazelified_agw.sh`
- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
