### PR TITLE
chore: mme compile warnings are reduced

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,10 @@ build --cxxopt=-std=c++14
 # https://bazel.build/docs/user-manual#strip
 build --strip=never
 build --per_file_copt=^lte/gateway/c/.*$@-g
+# Exclude a couple of warnings from compiling external libraries (note: the external folder
+# does not belong to the magma repo, only exists for a build and contains the external
+# c/c++ libraries)
+build --per_file_copt=^external/.*$@-Wno-all,-Wno-format-security,-Wno-deprecated-declarations
 
 # DEFAULT TEST CONFIGURATION
 # Please read the GH issue #13073 before adding "test" options.

--- a/lte/gateway/c/core/oai/common/log.c
+++ b/lte/gateway/c/core/oai/common/log.c
@@ -975,7 +975,7 @@ void log_message_add_async(struct shared_log_queue_item_s* messageP,
   }
 }
 //------------------------------------------------------------------------------
-void log_message_add_sync(log_queue_item_t* messageP, char* format, ...) {
+void log_message_add_sync(log_queue_item_t* messageP, const char* format, ...) {
   va_list args;
   int rv = 0;
 
@@ -1053,7 +1053,8 @@ void log_message_start_sync(log_thread_ctxt_t* thread_ctxtP,
                             const log_proto_t protoP,
                             log_queue_item_t** messageP,  // Out parameter
                             const char* const source_fileP,
-                            const unsigned int line_numP, char* format, ...) {
+                            const unsigned int line_numP, const char* format,
+                            ...) {
   va_list args;
 
   va_start(args, format);

--- a/lte/gateway/c/core/oai/common/log.h
+++ b/lte/gateway/c/core/oai/common/log.h
@@ -322,7 +322,7 @@ void log_message_add_async(struct shared_log_queue_item_s* contextP,
                            char* format, ...)
     __attribute__((format(printf, 2, 3)));
 
-void log_message_add_sync(log_queue_item_t* messageP, char* format, ...);
+void log_message_add_sync(log_queue_item_t* messageP, const char* format, ...);
 
 void log_message_finish(void* contextP);
 
@@ -338,8 +338,8 @@ void log_message_start_sync(log_thread_ctxt_t* const thread_ctxtP,
                             const log_proto_t protoP,
                             log_queue_item_t** messageP,  // Out parameter
                             const char* const source_fileP,
-                            const unsigned int line_numP, char* format, ...)
-    __attribute__((format(printf, 7, 8)));
+                            const unsigned int line_numP, const char* format,
+                            ...) __attribute__((format(printf, 7, 8)));
 
 void log_func(bool is_entering, const log_proto_t protoP,
               const char* const source_fileP, const unsigned int line_numP,

--- a/lte/gateway/c/core/oai/include/map.h
+++ b/lte/gateway/c/core/oai/include/map.h
@@ -85,7 +85,7 @@ typedef enum map_return_code_e {
 **                                                                        **
 ***************************************************************************/
 
-static std::string map_rc_code2string(map_rc_t rc) {
+static inline std::string map_rc_code2string(map_rc_t rc) {
   switch (rc) {
     case MAP_OK:
       return "MAP_OK";

--- a/lte/gateway/c/core/oai/include/proto_map.hpp
+++ b/lte/gateway/c/core/oai/include/proto_map.hpp
@@ -45,7 +45,7 @@ typedef enum proto_map_return_code_e {
 **                                                                        **
 ***************************************************************************/
 
-static char* map_rc_code2string(proto_map_rc_t rc) {
+static inline const char* map_rc_code2string(proto_map_rc_t rc) {
   switch (rc) {
     case PROTO_MAP_OK:
       return "MAP_OK";

--- a/lte/gateway/c/core/oai/lib/directoryd/directoryd.cpp
+++ b/lte/gateway/c/core/oai/lib/directoryd/directoryd.cpp
@@ -54,7 +54,7 @@ bool directoryd_update_location(char* imsi, char* location) {
   return true;
 }
 
-bool directoryd_update_record_field(char* imsi, char* key, char* value) {
+bool directoryd_update_record_field(char* imsi, const char* key, char* value) {
   // Actual GW_ID will be filled in the cloud
   magma::GatewayDirectoryServiceClient::UpdateRecordField(
       "IMSI" + std::string(imsi), std::string(key), std::string(value),

--- a/lte/gateway/c/core/oai/lib/directoryd/directoryd.cpp
+++ b/lte/gateway/c/core/oai/lib/directoryd/directoryd.cpp
@@ -65,7 +65,7 @@ bool directoryd_update_record_field(char* imsi, const char* key, char* value) {
 }
 
 void directoryd_rpc_call_done(const grpc::Status& status) {
-  if (!status.ok() || !grpc::StatusCode::NOT_FOUND) {
+  if (!status.ok() && status.error_code() != grpc::StatusCode::NOT_FOUND) {
     std::cerr << "Directoryd RPC failed with code " << status.error_code()
               << ", msg: " << status.error_message() << std::endl;
   }

--- a/lte/gateway/c/core/oai/lib/directoryd/directoryd.hpp
+++ b/lte/gateway/c/core/oai/lib/directoryd/directoryd.hpp
@@ -36,7 +36,7 @@ bool directoryd_remove_location(char* imsi);
 
 bool directoryd_update_location(char* imsi, char* location);
 
-bool directoryd_update_record_field(char* imsi, char* key, char* value);
+bool directoryd_update_record_field(char* imsi, const char* key, char* value);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/core/oai/lib/openflow/controller/GTPApplication.cpp
@@ -291,7 +291,7 @@ static void add_downlink_match(of13::FlowMod& downlink_fm,
 
 static void mask_ipv6_address(uint8_t* dst, const uint8_t* src,
                               const uint8_t* mask) {
-  for (int i = 0; i < sizeof(struct in6_addr); i++) {
+  for (int i = 0; static_cast<unsigned>(i) < sizeof(struct in6_addr); i++) {
     dst[i] = src[i] & mask[i];
   }
 }

--- a/lte/gateway/c/core/oai/lib/store/sqlite.cpp
+++ b/lte/gateway/c/core/oai/lib/store/sqlite.cpp
@@ -52,7 +52,6 @@ std::vector<std::string> SqliteStore::_create_db_locations(
 }
 
 void SqliteStore::_create_store() {
-  int rc;
   for (auto db_location_s : _db_locations) {
     sqlite3* db;
     int rc;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context.cpp
@@ -732,7 +732,7 @@ static int amf_app_handle_mobile_reachability_timer_expiry(zloop_t* loop,
     OAILOG_DEBUG_UE(
         LOG_AMF_APP, ue_context_p->amf_context.imsi64,
         "Started Implicit Deregistration timer for UE id: " AMF_UE_NGAP_ID_FMT
-        ", Timer Id: %ld, Timer Val: %u (ms) ",
+        ", Timer Id: %ld, Timer Val: %ld (ms) ",
         ue_context_p->amf_ue_ngap_id,
         ue_context_p->m5_implicit_deregistration_timer.id,
         ue_context_p->m5_implicit_deregistration_timer.sec);
@@ -803,7 +803,7 @@ void amf_ue_context_update_ue_sig_connection_state(
         OAILOG_DEBUG_UE(
             LOG_AMF_APP, ue_context_p->amf_context.imsi64,
             "Started Mobile Reachability timer for UE id " AMF_UE_NGAP_ID_FMT
-            ", Timer Id: %ld, Timer Val: %u (s) ",
+            ", Timer Id: %ld, Timer Val: %ld (s) ",
             ue_context_p->amf_ue_ngap_id,
             ue_context_p->m5_mobile_reachability_timer.id,
             ue_context_p->m5_mobile_reachability_timer.sec);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -567,8 +567,8 @@ status_code_e amf_handle_registration_request(
         " is_amf_ctx_new = %d and identity type = %d ",
         is_amf_ctx_new,
         msg->m5gs_mobile_identity.mobile_identity.imsi.type_of_identity);
-    if ((msg->m5gs_mobile_identity.mobile_identity.guti.type_of_identity ==
-         M5GSMobileIdentityMsg_GUTI)) {
+    if (msg->m5gs_mobile_identity.mobile_identity.guti.type_of_identity ==
+        M5GSMobileIdentityMsg_GUTI) {
       /* Copying PLMN to local supi which is imsi*/
       supi_imsi.plmn.mcc_digit1 =
           msg->m5gs_mobile_identity.mobile_identity.guti.mcc_digit1;

--- a/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_recv.cpp
@@ -51,7 +51,6 @@ status_code_e amf_handle_service_request(
   uint16_t pdu_session_status = 0;
   uint32_t tmsi_stored;
   paging_context_t* paging_ctx = nullptr;
-  guti_and_amf_id_t guti_and_amf_id;
 
   OAILOG_DEBUG(LOG_AMF_APP, "Received TMSI in message : %02x%02x%02x%02x",
                msg->m5gs_mobile_identity.mobile_identity.tmsi.m5g_tmsi[0],
@@ -700,8 +699,6 @@ status_code_e amf_handle_identity_response(
       // accept message
 
       amf_ctx_guti = reinterpret_cast<guti_m5_t*>(&amf_guti);
-
-      imsi64_t imsi64 = amf_imsi_to_imsi64(&imsi);
 
       if (ue_context) {
         ue_context->amf_context.reg_id_type = M5GSMobileIdentityMsg_SUCI_IMSI;

--- a/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -121,16 +121,9 @@ Status AmfServiceImpl::SetSmfSessionContext(
 bool AmfServiceImpl::SetSmfSessionContext_itti(
     const SetSMSessionContextAccess* request,
     itti_n11_create_pdu_session_response_t* itti_msg_p) {
-  struct in_addr ip_addr = {0};
-  char ip_str[INET_ADDRSTRLEN] = {0};
-  uint32_t ip_int = 0;
   uint32_t i = 0;
-  uint32_t index1 = 0;
-  uint32_t index2 = 0;
   traffic_flow_template_t* ul_tft = NULL;
-  traffic_flow_template_t* dl_tft = NULL;
   int ul_count_packetfilters = 0;
-  int dl_count_packetfilters = 0;
   OAILOG_INFO(LOG_UTIL,
               "Received GRPC SetSmfSessionContext request from SMF\n");
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.cpp
@@ -93,7 +93,7 @@ extern task_zmq_ctx_t mme_app_task_zmq_ctx;
 extern int pdn_connectivity_delete(emm_context_t* emm_context, pdn_cid_t pid);
 
 static void handle_ics_failure(struct ue_mm_context_s* ue_context_p,
-                               char* error_msg);
+                               const char* error_msg);
 
 static void send_s11_modify_bearer_request(ue_mm_context_t* ue_context_p,
                                            pdn_context_t* pdn_context_p,
@@ -2903,7 +2903,7 @@ int mme_app_handle_ue_context_modification_timer_expiry(zloop_t* loop,
  * In case of of MO CS call, send Service Reject to UE
  */
 status_code_e handle_csfb_s1ap_procedure_failure(ue_mm_context_t* ue_context_p,
-                                                 char* failed_statement,
+                                                 const char* failed_statement,
                                                  uint8_t failed_procedure) {
   OAILOG_FUNC_IN(LOG_MME_APP);
 
@@ -4238,7 +4238,7 @@ void mme_app_update_paging_tai_list(paging_tai_list_t* p_tai_list,
 
 // Fetch UE context based on mme_ue_s1ap_id and return pointer to UE context
 ue_mm_context_t* mme_app_get_ue_context_for_timer(
-    mme_ue_s1ap_id_t mme_ue_s1ap_id, char* timer_name) {
+    mme_ue_s1ap_id_t mme_ue_s1ap_id, const char* timer_name) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   OAILOG_INFO(LOG_MME_APP, "Expired- %s for ue_id " MME_UE_S1AP_ID_FMT "\n",
               timer_name, mme_ue_s1ap_id);
@@ -4607,7 +4607,7 @@ void mme_app_handle_modify_bearer_rsp(
 }
 
 static void handle_ics_failure(struct ue_mm_context_s* ue_context_p,
-                               char* error_msg) {
+                               const char* error_msg) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   ue_context_p->initial_context_setup_rsp_timer.id = MME_APP_TIMER_INACTIVE_ID;
   ue_context_p->time_ics_rsp_timer_started = 0;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.cpp
@@ -449,7 +449,7 @@ void mme_ue_context_update_coll_keys(
   } else {
     OAILOG_ERROR_UE(
         LOG_MME_APP, imsi,
-        "Did not insert enb_s1ap_id_key %u to enb_ue_s1ap_key2mme_ueid_map "
+        "Did not insert enb_s1ap_id_key %lu to enb_ue_s1ap_key2mme_ueid_map "
         "enb_ue_s1ap_ue_id " ENB_UE_S1AP_ID_FMT
         " mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT,
         enb_s1ap_id_key, ue_context_p->enb_ue_s1ap_id,
@@ -622,11 +622,12 @@ status_code_e mme_insert_ue_context(
   if (mme_ue_context_p->enb_ue_s1ap_key2mme_ueid_map.get(
           ue_context_p->enb_s1ap_id_key, &mme_ue_s1ap_id) ==
       magma::PROTO_MAP_OK) {
-    OAILOG_WARNING_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "enb_s1ap_id_key-%u already exists in enb_ue_s1ap_key2mme_ueid_map for "
-        "enb_ue_s1ap_id " ENB_UE_S1AP_ID_FMT "\n",
-        ue_context_p->enb_s1ap_id_key, ue_context_p->mme_ue_s1ap_id);
+    OAILOG_WARNING_UE(LOG_MME_APP, ue_context_p->emm_context._imsi64,
+                      "enb_s1ap_id_key-%lu already exists in "
+                      "enb_ue_s1ap_key2mme_ueid_map for "
+                      "enb_ue_s1ap_id " ENB_UE_S1AP_ID_FMT "\n",
+                      ue_context_p->enb_s1ap_id_key,
+                      ue_context_p->mme_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
   }
   // Insert enb_s1ap_id_key to enb_ue_s1ap_key2mme_ueid_map
@@ -853,7 +854,7 @@ void mme_ue_context_update_ue_sig_connection_state(
     if ((mme_ue_context_p->enb_ue_s1ap_key2mme_ueid_map.remove(
             ue_context_p->enb_s1ap_id_key)) != magma::PROTO_MAP_OK) {
       OAILOG_WARNING_UE(LOG_MME_APP, ue_context_p->emm_context._imsi64,
-                        "Failed to remove enb_ue_s1ap_ue_id_key %u "
+                        "Failed to remove enb_ue_s1ap_ue_id_key %lu "
                         "mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT
                         ", from enb_ue_s1ap_key2mme_ueid_map",
                         ue_context_p->enb_s1ap_id_key,
@@ -949,7 +950,7 @@ void mme_ue_context_update_ue_sig_connection_state(
     if ((mme_ue_context_p->enb_ue_s1ap_key2mme_ueid_map.remove(
             ue_context_p->enb_s1ap_id_key)) != magma::PROTO_MAP_OK) {
       OAILOG_WARNING_UE(LOG_MME_APP, ue_context_p->emm_context._imsi64,
-                        "Failed to remove enb_ue_s1ap_ue_id_key %u "
+                        "Failed to remove enb_ue_s1ap_ue_id_key %lu "
                         "mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT
                         ", from enb_ue_s1ap_key2mme_ueid_map",
                         ue_context_p->enb_s1ap_id_key,
@@ -1301,7 +1302,7 @@ static void mme_app_handle_s1ap_ue_context_release(
     OAILOG_WARNING(
         LOG_MME_APP,
         "Invalid mme_ue_s1ap_ue_id " MME_UE_S1AP_ID_FMT
-        " received from S1AP. Using enb_s1ap_id_key %u to get the context \n",
+        " received from S1AP. Using enb_s1ap_id_key %lu to get the context \n",
         mme_ue_s1ap_id, enb_s1ap_id_key);
   }
   if (!ue_mm_context) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_context.cpp
@@ -1422,7 +1422,7 @@ bool is_mme_ue_context_network_access_mode_packet_only(
   OAILOG_FUNC_IN(LOG_MME_APP);
   if (ue_context_p == NULL) {
     OAILOG_CRITICAL(LOG_MME_APP, "**** Abnormal- UE context is null.****\n");
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
+    OAILOG_FUNC_RETURN(LOG_MME_APP, false);
   }
   if (ue_context_p->network_access_mode == NAM_ONLY_PACKET) {
     OAILOG_FUNC_RETURN(LOG_MME_APP, true);
@@ -1462,7 +1462,7 @@ bool mme_ue_context_get_ue_sgs_vlr_reliable(mme_ue_s1ap_id_t mme_ue_s1ap_id) {
   ue_context_p = mme_ue_context_exists_mme_ue_s1ap_id(mme_ue_s1ap_id);
   if (ue_context_p == NULL) {
     OAILOG_CRITICAL(LOG_MME_APP, "**** Abnormal- UE context is null.****\n");
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
+    OAILOG_FUNC_RETURN(LOG_MME_APP, false);
   }
   if ((ue_context_p->sgs_context) &&
       (ue_context_p->sgs_context->vlr_reliable == true)) {
@@ -1500,7 +1500,7 @@ bool mme_ue_context_get_ue_sgs_neaf(mme_ue_s1ap_id_t mme_ue_s1ap_id) {
   ue_context_p = mme_ue_context_exists_mme_ue_s1ap_id(mme_ue_s1ap_id);
   if (ue_context_p == NULL) {
     OAILOG_CRITICAL(LOG_MME_APP, "**** Abnormal- UE context is null.****\n");
-    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
+    OAILOG_FUNC_RETURN(LOG_MME_APP, false);
   }
   if ((ue_context_p->sgs_context) &&
       (ue_context_p->sgs_context->neaf == true)) {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.hpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_defs.hpp
@@ -78,7 +78,7 @@ status_code_e mme_app_send_s6a_update_location_req(
     struct ue_mm_context_s* const ue_context_pP);
 
 ue_mm_context_t* mme_app_get_ue_context_for_timer(
-    mme_ue_s1ap_id_t mme_ue_s1ap_id, char* timer_name);
+    mme_ue_s1ap_id_t mme_ue_s1ap_id, const char* timer_name);
 
 void mme_app_handle_detach_req(mme_ue_s1ap_id_t ue_id);
 
@@ -290,7 +290,7 @@ void mme_app_notify_service_reject_to_nas(mme_ue_s1ap_id_t ue_id,
                                           uint8_t failed_procedure);
 
 status_code_e handle_csfb_s1ap_procedure_failure(ue_mm_context_t* ue_context_p,
-                                                 char* failed_statement,
+                                                 const char* failed_statement,
                                                  uint8_t failed_procedure);
 
 status_code_e mme_app_handle_sgsap_service_abort_request(

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_embedded_spgw.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/include/pgw_config.h"
 #include "lte/gateway/c/core/oai/include/sgw_config.h"
 
-char* USAGE_TEXT =
+const char* USAGE_TEXT =
     "==== EURECOM %s version: %s ====\n"  // PACKAGE_NAME, PACKAGE_VERSION
     "Please report any bug to: %s\n"      // PACKAGE_BUGREPORT
     "Usage: %s [options]\n"               // exe_path

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachAccept.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachAccept.cpp
@@ -99,7 +99,7 @@ int decode_attach_accept(attach_accept_msg* attach_accept, uint8_t* buffer,
       case ATTACH_ACCEPT_LOCATION_AREA_IDENTIFICATION_IEI:
         if ((decoded_result = decode_location_area_identification_ie(
                  &attach_accept->locationareaidentification,
-                 ATTACH_ACCEPT_LOCATION_AREA_IDENTIFICATION_IEI,
+                 ATTACH_ACCEPT_LOCATION_AREA_IDENTIFICATION_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -113,7 +113,7 @@ int decode_attach_accept(attach_accept_msg* attach_accept, uint8_t* buffer,
 
       case ATTACH_ACCEPT_MS_IDENTITY_IEI:
         if ((decoded_result = decode_mobile_identity_ie(
-                 &attach_accept->msidentity, ATTACH_ACCEPT_MS_IDENTITY_IEI,
+                 &attach_accept->msidentity, ATTACH_ACCEPT_MS_IDENTITY_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -166,7 +166,7 @@ int decode_attach_accept(attach_accept_msg* attach_accept, uint8_t* buffer,
       case ATTACH_ACCEPT_EQUIVALENT_PLMNS_IEI:
         if ((decoded_result =
                  decode_plmn_list_ie(&attach_accept->equivalentplmns,
-                                     ATTACH_ACCEPT_EQUIVALENT_PLMNS_IEI,
+                                     ATTACH_ACCEPT_EQUIVALENT_PLMNS_IEI != 0,
                                      buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -180,7 +180,7 @@ int decode_attach_accept(attach_accept_msg* attach_accept, uint8_t* buffer,
       case ATTACH_ACCEPT_EMERGENCY_NUMBER_LIST_IEI:
         if ((decoded_result = decode_emergency_number_list_ie(
                  &attach_accept->emergencynumberlist,
-                 ATTACH_ACCEPT_EMERGENCY_NUMBER_LIST_IEI, buffer + decoded,
+                 ATTACH_ACCEPT_EMERGENCY_NUMBER_LIST_IEI != 0, buffer + decoded,
                  len - decoded)) <= 0)
           return decoded_result;
 
@@ -288,8 +288,8 @@ int encode_attach_accept(attach_accept_msg* attach_accept, uint8_t* buffer,
       ATTACH_ACCEPT_LOCATION_AREA_IDENTIFICATION_PRESENT) {
     if ((encode_result = encode_location_area_identification_ie(
              &attach_accept->locationareaidentification,
-             ATTACH_ACCEPT_LOCATION_AREA_IDENTIFICATION_IEI, buffer + encoded,
-             len - encoded)) < 0) {
+             ATTACH_ACCEPT_LOCATION_AREA_IDENTIFICATION_IEI != 0,
+             buffer + encoded, len - encoded)) < 0) {
       OAILOG_ERROR(LOG_NAS_EMM,
                    "Failed encode_location_area_identification_ie\n");
       // Return in case of error
@@ -301,7 +301,7 @@ int encode_attach_accept(attach_accept_msg* attach_accept, uint8_t* buffer,
   if ((attach_accept->presencemask & ATTACH_ACCEPT_MS_IDENTITY_PRESENT) ==
       ATTACH_ACCEPT_MS_IDENTITY_PRESENT) {
     if ((encode_result = encode_mobile_identity_ie(
-             &attach_accept->msidentity, ATTACH_ACCEPT_MS_IDENTITY_IEI,
+             &attach_accept->msidentity, ATTACH_ACCEPT_MS_IDENTITY_IEI != 0,
              buffer + encoded, len - encoded)) < 0) {
       OAILOG_ERROR(LOG_NAS_EMM, "Failed encode_mobile_identity_ie\n");
       // Return in case of error
@@ -349,10 +349,10 @@ int encode_attach_accept(attach_accept_msg* attach_accept, uint8_t* buffer,
 
   if ((attach_accept->presencemask & ATTACH_ACCEPT_EQUIVALENT_PLMNS_PRESENT) ==
       ATTACH_ACCEPT_EQUIVALENT_PLMNS_PRESENT) {
-    if ((encode_result = encode_plmn_list_ie(&attach_accept->equivalentplmns,
-                                             ATTACH_ACCEPT_EQUIVALENT_PLMNS_IEI,
-                                             buffer + encoded, len - encoded)) <
-        0) {
+    if ((encode_result =
+             encode_plmn_list_ie(&attach_accept->equivalentplmns,
+                                 ATTACH_ACCEPT_EQUIVALENT_PLMNS_IEI != 0,
+                                 buffer + encoded, len - encoded)) < 0) {
       OAILOG_ERROR(LOG_NAS_EMM, "Failed encode_plmn_list_ie\n");
       // Return in case of error
       OAILOG_FUNC_RETURN(LOG_NAS_EMM, encode_result);
@@ -365,7 +365,7 @@ int encode_attach_accept(attach_accept_msg* attach_accept, uint8_t* buffer,
       ATTACH_ACCEPT_EMERGENCY_NUMBER_LIST_PRESENT) {
     if ((encode_result = encode_emergency_number_list_ie(
              &attach_accept->emergencynumberlist,
-             ATTACH_ACCEPT_EMERGENCY_NUMBER_LIST_IEI, buffer + encoded,
+             ATTACH_ACCEPT_EMERGENCY_NUMBER_LIST_IEI != 0, buffer + encoded,
              len - encoded)) < 0) {
       OAILOG_ERROR(LOG_NAS_EMM, "Failed encode_emergency_number_list\n");
       // Return in case of error

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.cpp
@@ -234,7 +234,7 @@ int decode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
       case ATTACH_REQUEST_SUPPORTED_CODECS_IEI:
         if ((decoded_result = decode_supported_codec_list_ie(
                  &attach_request->supportedcodecs,
-                 ATTACH_REQUEST_SUPPORTED_CODECS_IEI, buffer + decoded,
+                 ATTACH_REQUEST_SUPPORTED_CODECS_IEI != 0, buffer + decoded,
                  len - decoded)) <= 0) {
           OAILOG_FUNC_RETURN(LOG_NAS_EMM, decoded_result);
         }
@@ -311,7 +311,7 @@ int decode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
       case ATTACH_REQUEST_MS_NETWORK_FEATURE_SUPPORT_IEI:
         if ((decoded_result = decode_ms_network_feature_support_ie(
                  &attach_request->msnetworkfeaturesupport,
-                 ATTACH_REQUEST_MS_NETWORK_FEATURE_SUPPORT_IEI,
+                 ATTACH_REQUEST_MS_NETWORK_FEATURE_SUPPORT_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0) {
           //         return decoded_result;
           OAILOG_FUNC_RETURN(LOG_NAS_EMM, decoded_result);
@@ -400,10 +400,10 @@ int encode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
   if ((attach_request->presencemask &
        ATTACH_REQUEST_OLD_PTMSI_SIGNATURE_PRESENT) ==
       ATTACH_REQUEST_OLD_PTMSI_SIGNATURE_PRESENT) {
-    if ((encode_result =
-             encode_p_tmsi_signature_ie(attach_request->oldptmsisignature,
-                                        ATTACH_REQUEST_OLD_PTMSI_SIGNATURE_IEI,
-                                        buffer + encoded, len - encoded)) < 0) {
+    if ((encode_result = encode_p_tmsi_signature_ie(
+             attach_request->oldptmsisignature,
+             ATTACH_REQUEST_OLD_PTMSI_SIGNATURE_IEI != 0, buffer + encoded,
+             len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
     } else {
@@ -440,9 +440,10 @@ int encode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
 
   if ((attach_request->presencemask & ATTACH_REQUEST_DRX_PARAMETER_PRESENT) ==
       ATTACH_REQUEST_DRX_PARAMETER_PRESENT) {
-    if ((encode_result = encode_drx_parameter_ie(
-             &attach_request->drxparameter, ATTACH_REQUEST_DRX_PARAMETER_IEI,
-             buffer + encoded, len - encoded)) < 0) {
+    if ((encode_result =
+             encode_drx_parameter_ie(&attach_request->drxparameter,
+                                     ATTACH_REQUEST_DRX_PARAMETER_IEI != 0,
+                                     buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
     } else {
@@ -455,7 +456,7 @@ int encode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
       ATTACH_REQUEST_MS_NETWORK_CAPABILITY_PRESENT) {
     if ((encode_result = encode_ms_network_capability_ie(
              &attach_request->msnetworkcapability,
-             ATTACH_REQUEST_MS_NETWORK_CAPABILITY_IEI, buffer + encoded,
+             ATTACH_REQUEST_MS_NETWORK_CAPABILITY_IEI != 0, buffer + encoded,
              len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -469,7 +470,7 @@ int encode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
       ATTACH_REQUEST_OLD_LOCATION_AREA_IDENTIFICATION_PRESENT) {
     if ((encode_result = encode_location_area_identification_ie(
              &attach_request->oldlocationareaidentification,
-             ATTACH_REQUEST_OLD_LOCATION_AREA_IDENTIFICATION_IEI,
+             ATTACH_REQUEST_OLD_LOCATION_AREA_IDENTIFICATION_IEI != 0,
              buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -481,7 +482,7 @@ int encode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
   if ((attach_request->presencemask & ATTACH_REQUEST_TMSI_STATUS_PRESENT) ==
       ATTACH_REQUEST_TMSI_STATUS_PRESENT) {
     if ((encode_result = encode_tmsi_status(
-             &attach_request->tmsistatus, ATTACH_REQUEST_TMSI_STATUS_IEI,
+             &attach_request->tmsistatus, ATTACH_REQUEST_TMSI_STATUS_IEI != 0,
              buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -495,8 +496,8 @@ int encode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
       ATTACH_REQUEST_MOBILE_STATION_CLASSMARK_2_PRESENT) {
     if ((encode_result = encode_mobile_station_classmark_2_ie(
              &attach_request->mobilestationclassmark2,
-             ATTACH_REQUEST_MOBILE_STATION_CLASSMARK_2_IEI, buffer + encoded,
-             len - encoded)) < 0) {
+             ATTACH_REQUEST_MOBILE_STATION_CLASSMARK_2_IEI != 0,
+             buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
     } else {
@@ -509,8 +510,8 @@ int encode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
       ATTACH_REQUEST_MOBILE_STATION_CLASSMARK_3_PRESENT) {
     if ((encode_result = encode_mobile_station_classmark_3_ie(
              &attach_request->mobilestationclassmark3,
-             ATTACH_REQUEST_MOBILE_STATION_CLASSMARK_3_IEI, buffer + encoded,
-             len - encoded)) < 0) {
+             ATTACH_REQUEST_MOBILE_STATION_CLASSMARK_3_IEI != 0,
+             buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
     } else {
@@ -523,7 +524,7 @@ int encode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
       ATTACH_REQUEST_SUPPORTED_CODECS_PRESENT) {
     if ((encode_result = encode_supported_codec_list_ie(
              &attach_request->supportedcodecs,
-             ATTACH_REQUEST_SUPPORTED_CODECS_IEI, buffer + encoded,
+             ATTACH_REQUEST_SUPPORTED_CODECS_IEI != 0, buffer + encoded,
              len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -576,8 +577,8 @@ int encode_attach_request(attach_request_msg* attach_request, uint8_t* buffer,
       ATTACH_REQUEST_MS_NETWORK_FEATURE_SUPPORT_PRESENT) {
     if ((encode_result = encode_ms_network_feature_support_ie(
              &attach_request->msnetworkfeaturesupport,
-             ATTACH_REQUEST_MS_NETWORK_FEATURE_SUPPORT_IEI, buffer + encoded,
-             len - encoded)) < 0) {
+             ATTACH_REQUEST_MS_NETWORK_FEATURE_SUPPORT_IEI != 0,
+             buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
     } else {

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/AuthenticationFailure.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/AuthenticationFailure.cpp
@@ -109,7 +109,7 @@ int encode_authentication_failure(
       AUTHENTICATION_FAILURE_AUTHENTICATION_FAILURE_PARAMETER_PRESENT) {
     if ((encode_result = encode_authentication_failure_parameter_ie(
              authentication_failure->authenticationfailureparameter,
-             AUTHENTICATION_FAILURE_AUTHENTICATION_FAILURE_PARAMETER_IEI,
+             AUTHENTICATION_FAILURE_AUTHENTICATION_FAILURE_PARAMETER_IEI != 0,
              buffer + encoded, len - encoded)) < 0)
       // Return in case of error
       return encode_result;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/EmmInformation.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/EmmInformation.cpp
@@ -88,7 +88,7 @@ int decode_emm_information(emm_information_msg* emm_information,
       case EMM_INFORMATION_LOCAL_TIME_ZONE_IEI:
         if ((decoded_result =
                  decode_time_zone(&emm_information->localtimezone,
-                                  EMM_INFORMATION_LOCAL_TIME_ZONE_IEI,
+                                  EMM_INFORMATION_LOCAL_TIME_ZONE_IEI != 0,
                                   buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -103,7 +103,7 @@ int decode_emm_information(emm_information_msg* emm_information,
       case EMM_INFORMATION_UNIVERSAL_TIME_AND_LOCAL_TIME_ZONE_IEI:
         if ((decoded_result = decode_time_zone_and_time(
                  &emm_information->universaltimeandlocaltimezone,
-                 EMM_INFORMATION_UNIVERSAL_TIME_AND_LOCAL_TIME_ZONE_IEI,
+                 EMM_INFORMATION_UNIVERSAL_TIME_AND_LOCAL_TIME_ZONE_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -118,7 +118,7 @@ int decode_emm_information(emm_information_msg* emm_information,
       case MM_DAYLIGHT_SAVING_TIME_IEI:
         if ((decoded_result = decode_daylight_saving_time_ie(
                  &emm_information->networkdaylightsavingtime,
-                 MM_DAYLIGHT_SAVING_TIME_IEI, buffer + decoded,
+                 MM_DAYLIGHT_SAVING_TIME_IEI != 0, buffer + decoded,
                  len - decoded)) <= 0)
           return decoded_result;
 
@@ -179,9 +179,10 @@ int encode_emm_information(emm_information_msg* emm_information,
   if ((emm_information->presencemask &
        EMM_INFORMATION_LOCAL_TIME_ZONE_PRESENT) ==
       EMM_INFORMATION_LOCAL_TIME_ZONE_PRESENT) {
-    if ((encode_result = encode_time_zone(&emm_information->localtimezone,
-                                          EMM_INFORMATION_LOCAL_TIME_ZONE_IEI,
-                                          buffer + encoded, len - encoded)) < 0)
+    if ((encode_result =
+             encode_time_zone(&emm_information->localtimezone,
+                              EMM_INFORMATION_LOCAL_TIME_ZONE_IEI != 0,
+                              buffer + encoded, len - encoded)) < 0)
       // Return in case of error
       return encode_result;
     else
@@ -193,7 +194,7 @@ int encode_emm_information(emm_information_msg* emm_information,
       EMM_INFORMATION_UNIVERSAL_TIME_AND_LOCAL_TIME_ZONE_PRESENT) {
     if ((encode_result = encode_time_zone_and_time(
              &emm_information->universaltimeandlocaltimezone,
-             EMM_INFORMATION_UNIVERSAL_TIME_AND_LOCAL_TIME_ZONE_IEI,
+             EMM_INFORMATION_UNIVERSAL_TIME_AND_LOCAL_TIME_ZONE_IEI != 0,
              buffer + encoded, len - encoded)) < 0)
       // Return in case of error
       return encode_result;
@@ -206,7 +207,8 @@ int encode_emm_information(emm_information_msg* emm_information,
       EMM_INFORMATION_NETWORK_DAYLIGHT_SAVING_TIME_PRESENT) {
     if ((encode_result = encode_daylight_saving_time_ie(
              &emm_information->networkdaylightsavingtime,
-             MM_DAYLIGHT_SAVING_TIME_IEI, buffer + encoded, len - encoded)) < 0)
+             MM_DAYLIGHT_SAVING_TIME_IEI != 0, buffer + encoded,
+             len - encoded)) < 0)
       // Return in case of error
       return encode_result;
     else

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/SecurityModeCommand.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/SecurityModeCommand.cpp
@@ -87,8 +87,8 @@ int decode_security_mode_command(
       case SECURITY_MODE_COMMAND_IMEISV_REQUEST_IEI:
         if ((decoded_result = decode_imeisv_request_ie(
                  &security_mode_command->imeisvrequest,
-                 SECURITY_MODE_COMMAND_IMEISV_REQUEST_IEI, buffer + decoded,
-                 len - decoded)) <= 0)
+                 SECURITY_MODE_COMMAND_IMEISV_REQUEST_IEI != 0,
+                 buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
         decoded += decoded_result;
@@ -194,10 +194,10 @@ int encode_security_mode_command(
   if ((security_mode_command->presencemask &
        SECURITY_MODE_COMMAND_IMEISV_REQUEST_PRESENT) ==
       SECURITY_MODE_COMMAND_IMEISV_REQUEST_PRESENT) {
-    if ((encode_result =
-             encode_imeisv_request_ie(&security_mode_command->imeisvrequest,
-                                      SECURITY_MODE_COMMAND_IMEISV_REQUEST_IEI,
-                                      buffer + encoded, len - encoded)) < 0)
+    if ((encode_result = encode_imeisv_request_ie(
+             &security_mode_command->imeisvrequest,
+             SECURITY_MODE_COMMAND_IMEISV_REQUEST_IEI != 0, buffer + encoded,
+             len - encoded)) < 0)
       // Return in case of error
       return encode_result;
     else

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/SecurityModeComplete.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/SecurityModeComplete.cpp
@@ -59,7 +59,7 @@ int decode_security_mode_complete(
       case SECURITY_MODE_COMPLETE_IMEISV_IEI:
         if ((decoded_result = decode_mobile_identity_ie(
                  &security_mode_complete->imeisv,
-                 SECURITY_MODE_COMPLETE_IMEISV_IEI, buffer + decoded,
+                 SECURITY_MODE_COMPLETE_IMEISV_IEI != 0, buffer + decoded,
                  len - decoded)) <= 0)
           return decoded_result;
 
@@ -95,9 +95,10 @@ int encode_security_mode_complete(
   if ((security_mode_complete->presencemask &
        SECURITY_MODE_COMPLETE_IMEISV_PRESENT) ==
       SECURITY_MODE_COMPLETE_IMEISV_PRESENT) {
-    if ((encode_result = encode_mobile_identity_ie(
-             &security_mode_complete->imeisv, SECURITY_MODE_COMPLETE_IMEISV_IEI,
-             buffer + encoded, len - encoded)) < 0)
+    if ((encode_result =
+             encode_mobile_identity_ie(&security_mode_complete->imeisv,
+                                       SECURITY_MODE_COMPLETE_IMEISV_IEI != 0,
+                                       buffer + encoded, len - encoded)) < 0)
       // Return in case of error
       return encode_result;
     else

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/TrackingAreaUpdateAccept.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/TrackingAreaUpdateAccept.cpp
@@ -126,7 +126,7 @@ int decode_tracking_area_update_accept(
       case C_LOCATION_AREA_IDENTIFICATION_IEI:
         if ((decoded_result = decode_location_area_identification_ie(
                  &tracking_area_update_accept->locationareaidentification,
-                 C_LOCATION_AREA_IDENTIFICATION_IEI, buffer + decoded,
+                 C_LOCATION_AREA_IDENTIFICATION_IEI != 0, buffer + decoded,
                  len - decoded)) <= 0)
           return decoded_result;
 
@@ -141,8 +141,8 @@ int decode_tracking_area_update_accept(
       case TRACKING_AREA_UPDATE_ACCEPT_MS_IDENTITY_IEI:
         if ((decoded_result = decode_mobile_identity_ie(
                  &tracking_area_update_accept->msidentity,
-                 TRACKING_AREA_UPDATE_ACCEPT_MS_IDENTITY_IEI, buffer + decoded,
-                 len - decoded)) <= 0)
+                 TRACKING_AREA_UPDATE_ACCEPT_MS_IDENTITY_IEI != 0,
+                 buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
         decoded += decoded_result;
@@ -201,7 +201,7 @@ int decode_tracking_area_update_accept(
       case TRACKING_AREA_UPDATE_ACCEPT_EQUIVALENT_PLMNS_IEI:
         if ((decoded_result = decode_plmn_list_ie(
                  &tracking_area_update_accept->equivalentplmns,
-                 TRACKING_AREA_UPDATE_ACCEPT_EQUIVALENT_PLMNS_IEI,
+                 TRACKING_AREA_UPDATE_ACCEPT_EQUIVALENT_PLMNS_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -216,7 +216,7 @@ int decode_tracking_area_update_accept(
       case TRACKING_AREA_UPDATE_ACCEPT_EMERGENCY_NUMBER_LIST_IEI:
         if ((decoded_result = decode_emergency_number_list_ie(
                  &tracking_area_update_accept->emergencynumberlist,
-                 TRACKING_AREA_UPDATE_ACCEPT_EMERGENCY_NUMBER_LIST_IEI,
+                 TRACKING_AREA_UPDATE_ACCEPT_EMERGENCY_NUMBER_LIST_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -346,7 +346,7 @@ int encode_tracking_area_update_accept(
       TRACKING_AREA_UPDATE_ACCEPT_LOCATION_AREA_IDENTIFICATION_PRESENT) {
     if ((encode_result = encode_location_area_identification_ie(
              &tracking_area_update_accept->locationareaidentification,
-             C_LOCATION_AREA_IDENTIFICATION_IEI, buffer + encoded,
+             C_LOCATION_AREA_IDENTIFICATION_IEI != 0, buffer + encoded,
              len - encoded)) < 0)
       // Return in case of error
       return encode_result;
@@ -359,7 +359,7 @@ int encode_tracking_area_update_accept(
       TRACKING_AREA_UPDATE_ACCEPT_MS_IDENTITY_PRESENT) {
     if ((encode_result = encode_mobile_identity_ie(
              &tracking_area_update_accept->msidentity,
-             TRACKING_AREA_UPDATE_ACCEPT_MS_IDENTITY_IEI, buffer + encoded,
+             TRACKING_AREA_UPDATE_ACCEPT_MS_IDENTITY_IEI != 0, buffer + encoded,
              len - encoded)) < 0)
       // Return in case of error
       return encode_result;
@@ -411,8 +411,8 @@ int encode_tracking_area_update_accept(
       TRACKING_AREA_UPDATE_ACCEPT_EQUIVALENT_PLMNS_PRESENT) {
     if ((encode_result = encode_plmn_list_ie(
              &tracking_area_update_accept->equivalentplmns,
-             TRACKING_AREA_UPDATE_ACCEPT_EQUIVALENT_PLMNS_IEI, buffer + encoded,
-             len - encoded)) < 0)
+             TRACKING_AREA_UPDATE_ACCEPT_EQUIVALENT_PLMNS_IEI != 0,
+             buffer + encoded, len - encoded)) < 0)
       // Return in case of error
       return encode_result;
     else
@@ -424,7 +424,7 @@ int encode_tracking_area_update_accept(
       TRACKING_AREA_UPDATE_ACCEPT_EMERGENCY_NUMBER_LIST_PRESENT) {
     if ((encode_result = encode_emergency_number_list_ie(
              &tracking_area_update_accept->emergencynumberlist,
-             TRACKING_AREA_UPDATE_ACCEPT_EMERGENCY_NUMBER_LIST_IEI,
+             TRACKING_AREA_UPDATE_ACCEPT_EMERGENCY_NUMBER_LIST_IEI != 0,
              buffer + encoded, len - encoded)) < 0)
       // Return in case of error
       return encode_result;

--- a/lte/gateway/c/core/oai/tasks/nas/emm/msg/TrackingAreaUpdateRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/msg/TrackingAreaUpdateRequest.cpp
@@ -97,7 +97,8 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_GPRS_CIPHERING_KEY_SEQUENCE_NUMBER_IEI:
         if ((decoded_result = decode_ciphering_key_sequence_number_ie(
                  &tracking_area_update_request->gprscipheringkeysequencenumber,
-                 TRACKING_AREA_UPDATE_REQUEST_GPRS_CIPHERING_KEY_SEQUENCE_NUMBER_IEI,
+                 TRACKING_AREA_UPDATE_REQUEST_GPRS_CIPHERING_KEY_SEQUENCE_NUMBER_IEI !=
+                     0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -112,7 +113,7 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_OLD_PTMSI_SIGNATURE_IEI:
         if ((decoded_result = decode_p_tmsi_signature_ie(
                  &tracking_area_update_request->oldptmsisignature,
-                 TRACKING_AREA_UPDATE_REQUEST_OLD_PTMSI_SIGNATURE_IEI,
+                 TRACKING_AREA_UPDATE_REQUEST_OLD_PTMSI_SIGNATURE_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -187,7 +188,7 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_DRX_PARAMETER_IEI:
         if ((decoded_result = decode_drx_parameter_ie(
                  &tracking_area_update_request->drxparameter,
-                 TRACKING_AREA_UPDATE_REQUEST_DRX_PARAMETER_IEI,
+                 TRACKING_AREA_UPDATE_REQUEST_DRX_PARAMETER_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -233,7 +234,7 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_MS_NETWORK_CAPABILITY_IEI:
         if ((decoded_result = decode_ms_network_capability_ie(
                  &tracking_area_update_request->msnetworkcapability,
-                 TRACKING_AREA_UPDATE_REQUEST_MS_NETWORK_CAPABILITY_IEI,
+                 TRACKING_AREA_UPDATE_REQUEST_MS_NETWORK_CAPABILITY_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -248,7 +249,8 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_OLD_LOCATION_AREA_IDENTIFICATION_IEI:
         if ((decoded_result = decode_location_area_identification_ie(
                  &tracking_area_update_request->oldlocationareaidentification,
-                 TRACKING_AREA_UPDATE_REQUEST_OLD_LOCATION_AREA_IDENTIFICATION_IEI,
+                 TRACKING_AREA_UPDATE_REQUEST_OLD_LOCATION_AREA_IDENTIFICATION_IEI !=
+                     0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -263,8 +265,8 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_TMSI_STATUS_IEI:
         if ((decoded_result = decode_tmsi_status(
                  &tracking_area_update_request->tmsistatus,
-                 TRACKING_AREA_UPDATE_REQUEST_TMSI_STATUS_IEI, buffer + decoded,
-                 len - decoded)) <= 0)
+                 TRACKING_AREA_UPDATE_REQUEST_TMSI_STATUS_IEI != 0,
+                 buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
         decoded += decoded_result;
@@ -278,7 +280,8 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_2_IEI:
         if ((decoded_result = decode_mobile_station_classmark_2_ie(
                  &tracking_area_update_request->mobilestationclassmark2,
-                 TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_2_IEI,
+                 TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_2_IEI !=
+                     0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -293,7 +296,8 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_3_IEI:
         if ((decoded_result = decode_mobile_station_classmark_3_ie(
                  &tracking_area_update_request->mobilestationclassmark3,
-                 TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_3_IEI,
+                 TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_3_IEI !=
+                     0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -308,7 +312,7 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_SUPPORTED_CODECS_IEI:
         if ((decoded_result = decode_supported_codec_list_ie(
                  &tracking_area_update_request->supportedcodecs,
-                 TRACKING_AREA_UPDATE_REQUEST_SUPPORTED_CODECS_IEI,
+                 TRACKING_AREA_UPDATE_REQUEST_SUPPORTED_CODECS_IEI != 0,
                  buffer + decoded, len - decoded)) <= 0)
           return decoded_result;
 
@@ -371,7 +375,8 @@ int decode_tracking_area_update_request(
       case TRACKING_AREA_UPDATE_REQUEST_MS_NETWORK_FEATURE_SUPPORT_IEI:
         if ((decoded_result = decode_ms_network_feature_support_ie(
                  &tracking_area_update_request->msnetworkfeaturesupport,
-                 TRACKING_AREA_UPDATE_REQUEST_MS_NETWORK_FEATURE_SUPPORT_IEI,
+                 TRACKING_AREA_UPDATE_REQUEST_MS_NETWORK_FEATURE_SUPPORT_IEI !=
+                     0,
                  buffer + decoded, len - decoded)) <= 0) {
           // return decoded_result;
           OAILOG_FUNC_RETURN(LOG_NAS_EMM, decoded_result);
@@ -455,7 +460,8 @@ int encode_tracking_area_update_request(
       TRACKING_AREA_UPDATE_REQUEST_GPRS_CIPHERING_KEY_SEQUENCE_NUMBER_PRESENT) {
     if ((encode_result = encode_ciphering_key_sequence_number_ie(
              &tracking_area_update_request->gprscipheringkeysequencenumber,
-             TRACKING_AREA_UPDATE_REQUEST_GPRS_CIPHERING_KEY_SEQUENCE_NUMBER_IEI,
+             TRACKING_AREA_UPDATE_REQUEST_GPRS_CIPHERING_KEY_SEQUENCE_NUMBER_IEI !=
+                 0,
              buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -469,7 +475,7 @@ int encode_tracking_area_update_request(
       TRACKING_AREA_UPDATE_REQUEST_OLD_PTMSI_SIGNATURE_PRESENT) {
     if ((encode_result = encode_p_tmsi_signature_ie(
              tracking_area_update_request->oldptmsisignature,
-             TRACKING_AREA_UPDATE_REQUEST_OLD_PTMSI_SIGNATURE_IEI,
+             TRACKING_AREA_UPDATE_REQUEST_OLD_PTMSI_SIGNATURE_IEI != 0,
              buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -538,8 +544,8 @@ int encode_tracking_area_update_request(
       TRACKING_AREA_UPDATE_REQUEST_DRX_PARAMETER_PRESENT) {
     if ((encode_result = encode_drx_parameter_ie(
              &tracking_area_update_request->drxparameter,
-             TRACKING_AREA_UPDATE_REQUEST_DRX_PARAMETER_IEI, buffer + encoded,
-             len - encoded)) < 0) {
+             TRACKING_AREA_UPDATE_REQUEST_DRX_PARAMETER_IEI != 0,
+             buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
     } else {
@@ -581,7 +587,7 @@ int encode_tracking_area_update_request(
       TRACKING_AREA_UPDATE_REQUEST_MS_NETWORK_CAPABILITY_PRESENT) {
     if ((encode_result = encode_ms_network_capability_ie(
              &tracking_area_update_request->msnetworkcapability,
-             TRACKING_AREA_UPDATE_REQUEST_MS_NETWORK_CAPABILITY_IEI,
+             TRACKING_AREA_UPDATE_REQUEST_MS_NETWORK_CAPABILITY_IEI != 0,
              buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -595,7 +601,8 @@ int encode_tracking_area_update_request(
       TRACKING_AREA_UPDATE_REQUEST_OLD_LOCATION_AREA_IDENTIFICATION_PRESENT) {
     if ((encode_result = encode_location_area_identification_ie(
              &tracking_area_update_request->oldlocationareaidentification,
-             TRACKING_AREA_UPDATE_REQUEST_OLD_LOCATION_AREA_IDENTIFICATION_IEI,
+             TRACKING_AREA_UPDATE_REQUEST_OLD_LOCATION_AREA_IDENTIFICATION_IEI !=
+                 0,
              buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -607,10 +614,10 @@ int encode_tracking_area_update_request(
   if ((tracking_area_update_request->presencemask &
        TRACKING_AREA_UPDATE_REQUEST_TMSI_STATUS_PRESENT) ==
       TRACKING_AREA_UPDATE_REQUEST_TMSI_STATUS_PRESENT) {
-    if ((encode_result =
-             encode_tmsi_status(&tracking_area_update_request->tmsistatus,
-                                TRACKING_AREA_UPDATE_REQUEST_TMSI_STATUS_IEI,
-                                buffer + encoded, len - encoded)) < 0) {
+    if ((encode_result = encode_tmsi_status(
+             &tracking_area_update_request->tmsistatus,
+             TRACKING_AREA_UPDATE_REQUEST_TMSI_STATUS_IEI != 0,
+             buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
     } else {
@@ -623,7 +630,7 @@ int encode_tracking_area_update_request(
       TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_2_PRESENT) {
     if ((encode_result = encode_mobile_station_classmark_2_ie(
              &tracking_area_update_request->mobilestationclassmark2,
-             TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_2_IEI,
+             TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_2_IEI != 0,
              buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -637,7 +644,7 @@ int encode_tracking_area_update_request(
       TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_3_PRESENT) {
     if ((encode_result = encode_mobile_station_classmark_3_ie(
              &tracking_area_update_request->mobilestationclassmark3,
-             TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_3_IEI,
+             TRACKING_AREA_UPDATE_REQUEST_MOBILE_STATION_CLASSMARK_3_IEI != 0,
              buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;
@@ -651,7 +658,7 @@ int encode_tracking_area_update_request(
       TRACKING_AREA_UPDATE_REQUEST_SUPPORTED_CODECS_PRESENT) {
     if ((encode_result = encode_supported_codec_list_ie(
              &tracking_area_update_request->supportedcodecs,
-             TRACKING_AREA_UPDATE_REQUEST_SUPPORTED_CODECS_IEI,
+             TRACKING_AREA_UPDATE_REQUEST_SUPPORTED_CODECS_IEI != 0,
              buffer + encoded, len - encoded)) < 0) {
       // Return in case of error
       return encode_result;

--- a/lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextRequest.cpp
@@ -219,7 +219,8 @@ int encode_activate_dedicated_eps_bearer_context_request(
     if ((encode_result = encode_linked_ti_ie(
              &activate_dedicated_eps_bearer_context_request
                   ->transactionidentifier,
-             ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_REQUEST_TRANSACTION_IDENTIFIER_IEI,
+             ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_REQUEST_TRANSACTION_IDENTIFIER_IEI !=
+                 0,
              buffer + encoded, len - encoded)) < 0)
       // Return in case of error
       return encode_result;

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -2351,7 +2351,6 @@ status_code_e ngap_handle_gnb_initiated_reset_ack(
   Ngap_NGAP_PDU_t pdu;
   /** NGReset Acknowledgment. */
   Ngap_NGResetAcknowledge_t* out;
-  Ngap_NGResetAcknowledgeIEs_t* ie = NULL;
   int rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_NGAP);

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.cpp
@@ -65,7 +65,6 @@ static int handle_stats_timer(zloop_t* loop, int id, void* arg);
 static long epc_stats_timer_id;
 static size_t epc_stats_timer_sec = 60;
 
-static int indent = 0;
 task_zmq_ctx_t s1ap_task_zmq_ctx;
 
 bool s1ap_congestion_control_enabled = true;

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.cpp
@@ -5032,7 +5032,7 @@ bool is_all_erabId_same(S1ap_PathSwitchRequest_t* container) {
                              true);
   if (!ie) {
     OAILOG_ERROR(LOG_S1AP, "Incorrect IE \n");
-    return RETURNerror;
+    return false;
   }
   S1ap_E_RABToBeSwitchedDLList_t* e_rab_to_be_switched_dl_list =
       &ie->value.choice.E_RABToBeSwitchedDLList;

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme_handlers.cpp
@@ -437,8 +437,6 @@ void clean_stale_enb_state(oai::S1apState* state,
 static status_code_e s1ap_clear_ue_ctxt_for_unknown_mme_ue_s1ap_id(
     oai::S1apState* state, sctp_assoc_id_t sctp_assoc_id) {
   OAILOG_FUNC_IN(LOG_S1AP);
-  unsigned int i = 0;
-  unsigned int num_elements = 0;
   map_uint64_ue_description_t* s1ap_ue_state = get_s1ap_ue_state();
 
   if (!s1ap_ue_state) {
@@ -2393,7 +2391,6 @@ status_code_e s1ap_mme_handle_handover_cancel(oai::S1apState* state,
   S1ap_HandoverCancelAcknowledge_t* out;
   S1ap_HandoverCancelAcknowledgeIEs_t* hca_ie = NULL;
   oai::UeDescription* ue_ref_p = nullptr;
-  e_rab_admitted_list_t e_rab_admitted_list = {0};
   mme_ue_s1ap_id_t mme_ue_s1ap_id = INVALID_MME_UE_S1AP_ID;
   enb_ue_s1ap_id_t enb_ue_s1ap_id = INVALID_ENB_UE_S1AP_ID;
   S1ap_Cause_PR cause_type;
@@ -4495,7 +4492,6 @@ status_code_e s1ap_handle_paging_request(
   uint16_t tai_list_count = paging_request->tai_list_count;
 
   bool is_tai_found = false;
-  uint32_t idx = 0;
   uint8_t* buffer_p = NULL;
   uint32_t length = 0;
   S1ap_S1AP_PDU_t pdu = {S1ap_S1AP_PDU_PR_NOTHING, {0}};
@@ -4919,7 +4915,6 @@ status_code_e s1ap_mme_handle_enb_configuration_transfer(
   uint32_t target_enb_id = 0;
   uint8_t* buffer = NULL;
   uint32_t length = 0;
-  uint32_t idx = 0;
   status_code_e rc = RETURNok;
 
   // Not done according to Rel-15 (Target TAI and Source TAI)

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_handlers.cpp
@@ -322,7 +322,6 @@ status_code_e spgw_handle_nw_initiated_bearer_deactv_req(
   OAILOG_FUNC_IN(LOG_SPGW_APP);
   status_code_e rc = RETURNok;
   state_teid_map_t* state_teid_map = nullptr;
-  uint32_t num_elements = 0;
   s_plus_p_gw_eps_bearer_context_information_t* spgw_ctxt_p = nullptr;
   bool is_lbi_found = false;
   bool is_imsi_found = false;

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.cpp
@@ -592,7 +592,7 @@ static void insert_sgw_cp_and_up_teid_to_directoryd(sgw_state_t* sgw_state,
              sizeof(teidString) - strlen(teidString), "%u%c", teidlist[idx],
              separator);
   }
-  char* ptr = "sgw_c_teid";
+  const char* ptr = "sgw_c_teid";
   if (teid_type == UP_TEID) {
     ptr = "sgw_u_teid";
   }

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.cpp
@@ -82,7 +82,6 @@ static sgw_eps_bearer_context_information_t* update_sgw_context_to_s11_teid_map(
 void sgw_remove_sgw_bearer_context_information(sgw_state_t* sgw_state,
                                                teid_t teid, imsi64_t imsi64) {
   OAILOG_FUNC_IN(LOG_SGW_S8);
-  int rc = 0;
 
   map_uint32_sgw_eps_bearer_context_t* state_teid_map = get_s8_state_teid_map();
   if (!state_teid_map) {


### PR DESCRIPTION
## Summary

This change reduces compile warnings of mme. See different commits for different warnings.

For `bazel build //lte/gateway/c/core:lib_agw_of` this reduces the number of compile log lines from ~8.500 to ~890. See attached log files.

[01_before.txt](https://github.com/magma/magma/files/10310432/01_before.txt)
[02_after.txt](https://github.com/magma/magma/files/10310433/02_after.txt)

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
