### PR TITLE
fix(ci): remove print typo in package.sh

### DIFF
--- a/orc8r/tools/helm/package.sh
+++ b/orc8r/tools/helm/package.sh
@@ -175,8 +175,8 @@ else
   fi
 
   if [[ $ONLY_PACKAGE = false ]]; then
-      if [[ -z $HELM_CHART_MUSEUM_REPO ]]; then
-    exitmsg "Environment variable $HELM_CHART_MUSEUM_REPO must be set"
+    if [[ -z $HELM_CHART_MUSEUM_REPO ]]; then
+      exitmsg "Environment variable HELM_CHART_MUSEUM_REPO must be set"
     fi
 
     if [[ -z $HELM_CHART_MUSEUM_USERNAME ]]; then


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR fixes a typo where a non-existing variable is printed instead of its name.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
