### PR TITLE
fix(ci): use correct prefix for CWF images

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -94,7 +94,7 @@ jobs:
             gzip -d $IMAGES
           done
           mkdir -p /tmp/cwf-images
-          cp cwf-*.tar /tmp/cwf-images
+          cp cwf_*.tar /tmp/cwf-images
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fixes a bug in the CWF integration tests from the Docker Compose V2 upgrade, #14415. See the [corresponding CI run](https://github.com/magma/magma/actions/runs/3800017458/jobs/6463671266#step:9:16). 
The uploaded `*.tar` images were not renamed and are uploaded using a `cwf_*.tar` naming scheme, see [here](https://github.com/magma/magma/actions/runs/3800017458/jobs/6463083210#step:4:4). We need to revert this change.

## Test Plan

- CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
