### PR TITLE
[WIP] feat(ci): add CI job for build and upload AGW VMs

### DIFF
--- a/.github/workflows/agw-build-publish-virtual-machines.yml
+++ b/.github/workflows/agw-build-publish-virtual-machines.yml
@@ -1,0 +1,67 @@
+# Copyright 2022 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: AGW Build, Publish & Release Virtual Machines
+
+on:
+  workflow_dispatch:
+    inputs:
+      vm_name:
+        type: choice
+        options:
+          - dev
+          - test
+          - trfserver
+        description: Name of the AGW virtual machine.
+        required: true
+      VAGRANT_CLOUD_TOKEN:
+        # It may also be possible to test / use the checked-in
+        # `secrets.VAGRANT_TOKEN`. This would require appropriate user
+        # restriction to execute this workflow and access to the secret.
+        type: string
+        description: Access token to magmacore's vagrant cloud account.
+        required: true
+
+
+jobs:
+  build-publish-vm:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+
+      - name: Setup `packer`
+        uses: hashicorp/setup-packer@ae6b3ed3bec089bbfb576ab7d714df7cbc4b88a4 # pin@v2.0.0
+        id: setup
+        with:
+          version: "latest"
+
+      - name: Mask Token
+        id: mask
+        run: |
+          TOKEN=$(cat $GITHUB_EVENT_PATH | jq -r ".inputs.VAGRANT_CLOUD_TOKEN" )
+          echo "::add-mask::$TOKEN"
+          echo "VAGRANT_TOKEN=$TOKEN" >> $GITHUB_OUTPUT
+
+      - name: Pack virtual machine
+        id: pack
+        env:
+          VM_NAME: ${{ inputs.vm_name }}
+        working-directory: orc8r/tools/packer
+        run: "packer build magma-${{ env.VM_NAME }}-virtualbox.json"
+        shell: bash
+
+      - name: Upload virtual machine
+        id: upload
+        env:
+          VM_NAME: ${{ inputs.vm_name }}
+          VAGRANT_CLOUD_TOKEN: ${{ steps.mask.outputs.VAGRANT_TOKEN }}
+        working-directory: orc8r/tools/packer
+        run: ./vagrant-box-upload.sh builds/magma_${{ env.VM_NAME }}_virtualbox.box -f


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

First draft for a CI job to build and upload AGW VMs to the Vagrant cloud. The steps carried out here are described in the [respective wiki entry](https://github.com/magma/magma/wiki/Creation,-Testing,-and-Publishing-of-Magma-VM-Base-Images). One security issue is the input and handling of Magma's access token to the Vagrant Cloud. We may be able to [mask the token](https://stackoverflow.com/questions/67608874/github-actions-how-to-mask-workflow-dispatch-inputs-like-secrets), see also the respective test run, but maybe more research is needed before using this in production.

Closes #14398.
## Test Plan

- **Due to security implications, all tests were conducted without using Magma's Vagrant Cloud Token.** Either a dummy value `test_token` was used or a temporary token of a non-Magma account was used.
- The workflow was [tested with an adapted upload scrip](https://github.com/mpfirrmann/magma/actions/runs/3835847190)t. Instead of uploading and releasing the built VM, a [rudimentary authentication request](https://developer.hashicorp.com/vagrant/docs/cli/cloud#cloud-auth-whoami) was sent to test the correct handling of the access token, `vagrant cloud auth whoami $TOKEN`.
- The request was successfully sent and confirmed. The used cloud token was not found in plain text in the log output or the raw logs. Nevertheless, the token was deleted after the test run.
- However, this is no proof that the token handling is fully properly done here! :warning: 

## Additional Information

It may also be possible to test / use the checked-in `secrets.VAGRANT_TOKEN`. This would require appropriate user restriction to execute this workflow and access to the secret.
