### PR TITLE
fix(ci): adapt prefix for CWF images to the one expected in the fabfile

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -32,12 +32,12 @@ jobs:
         run: |
           mkdir images
           cd images
-          docker save cwf-gateway_sessiond:latest | gzip > cwf_gateway_sessiond.tar.gz
-          docker save cwf-nginx:latest  | gzip > cwf_nginx.tar.gz
-          docker save cwf-gateway_python:latest | gzip > cwf_gateway_python.tar.gz
-          docker save cwf-cwag_go:latest  | gzip > cwf_cwag_go.tar.gz
-          docker save cwf-gateway_go:latest | gzip > cwf_gateway_go.tar.gz
-          docker save cwf-gateway_pipelined:latest | gzip > cwf_gateway_pipelined.tar.gz
+          docker save cwf-gateway_sessiond:latest | gzip > cwf-gateway_sessiond.tar.gz
+          docker save cwf-nginx:latest  | gzip > cwf-nginx.tar.gz
+          docker save cwf-gateway_python:latest | gzip > cwf-gateway_python.tar.gz
+          docker save cwf-cwag_go:latest  | gzip > cwf-cwag_go.tar.gz
+          docker save cwf-gateway_go:latest | gzip > cwf-gateway_go.tar.gz
+          docker save cwf-gateway_pipelined:latest | gzip > cwf-gateway_pipelined.tar.gz
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: docker-images
@@ -94,7 +94,7 @@ jobs:
             gzip -d $IMAGES
           done
           mkdir -p /tmp/cwf-images
-          cp cwf_*.tar /tmp/cwf-images
+          cp cwf-*.tar /tmp/cwf-images
       - name: Open up network interfaces for VM
         run: |
           sudo mkdir -p /etc/vbox/


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fixes the CWF integ tests to use the image prefixes expected in the corresponding fabfile. Closes #13938.

## Test Plan

- [CI](https://github.com/mpfirrmann/magma/actions/runs/3806328454)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
