### PR TITLE
fix(agw): add LTE_ROOT to icmpv6 imports

### DIFF
--- a/lte/gateway/python/scripts/BUILD.bazel
+++ b/lte/gateway/python/scripts/BUILD.bazel
@@ -273,6 +273,7 @@ py_binary(
 py_binary(
     name = "icmpv6",
     srcs = ["icmpv6.py"],
+    imports = [LTE_ROOT],
     legacy_create_init = False,
     tags = TAG_UTIL_SCRIPT,
     deps = [


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Import of LTE_ROOT was missing, leading to a `ModuleNotFoundError: No module named 'magma'` in some tests.

## Test Plan

- Bazel based LTE integ tests

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
