### PR TITLE
feat(agw): create new base images `magma-dev`, `magma-test`, and `magma-trfserver`

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20221012
+          key: vagrant-box-magma-dev-v1.3.20221230
       - name: Log in to vagrant cloud
         run: |
           if [[ -n "${{ secrets.VAGRANT_TOKEN }}" ]]

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes
-          key: vagrant-boxes-cwf-v20220722
+          key: vagrant-boxes-cwf-v1.3.20221230
       - name: Log in to vagrant cloud
         run: |
           if [[ -n "${{ secrets.VAGRANT_TOKEN }}" ]]

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -105,17 +105,17 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20221012
+          key: vagrant-box-magma-dev-v1.3.20221230
       - name: Cache magma-test-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test-v1.2.20221012
+          key: vagrant-box-magma-test-v1.3.20221230
       - name: Cache magma-trfserver-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
-          key: vagrant-box-magma-trfserver-v20220722
+          key: vagrant-box-magma-trfserver-v1.3.20221230
       - name: Log in to vagrant cloud
         run: |
           if [[ -n "${{ secrets.VAGRANT_TOKEN }}" ]]

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -34,12 +34,12 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test-v1.2.20221012
+          key: vagrant-box-magma-test-v1.3.20221230
       - name: Cache magma-trfserver-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
-          key: vagrant-box-magma-trfserver-v20220722
+          key: vagrant-box-magma-trfserver-v1.3.20221230
 
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -68,17 +68,17 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20221012
+          key: vagrant-box-magma-dev-v1.3.20221230
       - name: Cache magma-test-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test-v1.2.20221012
+          key: vagrant-box-magma-test-v1.3.20221230
       - name: Cache magma-trfserver-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
-          key: vagrant-box-magma-trfserver-v20220722
+          key: vagrant-box-magma-trfserver-v1.3.20221230
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:
           python-version: '3.8.10'

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -33,12 +33,12 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test-v1.2.20221012
+          key: vagrant-box-magma-test-v1.3.20221230
       - name: Cache magma-trfserver-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
-          key: vagrant-box-magma-trfserver-v20220722
+          key: vagrant-box-magma-trfserver-v1.3.20221230
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:
           python-version: '3.8.10'

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -24,17 +24,17 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20221012
+          key: vagrant-box-magma-dev-v1.3.20221230
       - name: Cache magma-test-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
-          key: vagrant-box-magma-test-v1.2.20221012
+          key: vagrant-box-magma-test-v1.3.20221230
       - name: Cache magma-trfserver-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
-          key: vagrant-box-magma-trfserver-v20220722
+          key: vagrant-box-magma-trfserver-v1.3.20221230
       - name: Log in to vagrant cloud
         run: |
           if [[ -n "${{ secrets.VAGRANT_TOKEN }}" ]]

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.2.20221012
+          key: vagrant-box-magma-dev-v1.3.20221230
       - name: Log in to vagrant cloud
         run: |
           if [[ -n "${{ secrets.VAGRANT_TOKEN }}" ]]

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :magma, primary: true do |magma|
     magma.vm.box = "magmacore/magma_dev"
-    magma.vm.box_version = "1.2.20221012"
+    magma.vm.box_version = "1.3.20221230"
     magma.disksize.size = '75GB'
 
      # Enable Dynamic Swap Space to prevent Out of Memory crashes
@@ -71,7 +71,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :magma_trfserver, autostart: false do |magma_trfserver|
     magma_trfserver.vm.box = "magmacore/magma_trfserver"
-    magma_trfserver.vm.box_version = "1.1.20220722"
+    magma_trfserver.vm.box_version = "1.3.20221230"
     magma_trfserver.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine
@@ -125,7 +125,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define :magma_test, autostart: false do |magma_test|
     magma_test.vm.box = "magmacore/magma_test"
-    magma_test.vm.box_version = "1.2.20221012"
+    magma_test.vm.box_version = "1.3.20221230"
     magma_test.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine

--- a/lte/gateway/deploy/roles/bazel/tasks/main.yml
+++ b/lte/gateway/deploy/roles/bazel/tasks/main.yml
@@ -17,6 +17,7 @@
     state: link
     force: yes
     follow: false
+  when: full_provision
 
 - name: Symlink bazel disk cache configuration into the VM
   file:
@@ -25,6 +26,7 @@
     state: link
     force: yes
     follow: false
+  when: full_provision
 
 - name: Symlink bazel disk repository cache configuration into the VM
   file:
@@ -32,3 +34,4 @@
     path: '/var/cache/bazel-cache-repo'
     state: link
     force: yes
+  when: full_provision

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -252,6 +252,7 @@
   ansible.builtin.shell: "{{ magma_root }}/bazel/scripts/setup_bazel_bash_completion.sh $(cat {{ magma_root }}/.bazelversion)"
   become: yes
   become_user: "{{ ansible_user }}"
+  when: full_provision
 
 ########################################
 # Install common Magma dev dependencies

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -82,7 +82,7 @@
       leak:libczmq.so.4
       leak:libzmq.so.5
       leak:fluid_base::BaseOFConnection::OFReadBuffer::read_notify
-  when: full_provision
+  when: preburn
 
 - name: "Go export"
   lineinfile:
@@ -361,7 +361,7 @@
     url: https://linuxfoundation.jfrog.io/artifactory/magma-blob/ghz
     dest: /usr/local/bin/ghz
     mode: 0755
-  when: full_provision
+  when: preburn
 
 - name: Fix kernel commandline for interface naming.
   shell: |

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -18,11 +18,11 @@
   when: preburn
 
 - name: Install ansible for Ubuntu systems
-  when: preburn
   apt:
-    state: present
     name: ansible
+    state: present
   retries: 5
+  when: preburn
 
 - name: Copy over the timesyncd config
   become: yes
@@ -115,12 +115,12 @@
 
 - name: Install convenience packages for development
   apt:
-    state: present
-    update_cache: no
     name:
       - byobu
       - vim
       - aptitude
+    state: present
+    update_cache: no
   retries: 5
   when: preburn
 
@@ -134,27 +134,25 @@
 
 - name: Install monitoring packages
   apt:
-    state: present
-    update_cache: no
     name:
       - htop
       - iotop
+    state: present
+    update_cache: no
   retries: 5
   when: preburn
 
 # TODO: remove this after migrating magma_test box image to plain Debian
 - name: Install lxml
   apt:
+    name: python3-lxml
     state: present
     update_cache: no
-    name: python3-lxml
   when: preburn
 
 - name: Install prereqs for FPM
   tags: dev
   apt:
-    state: present
-    update_cache: no
     name:
       - ruby
       - ruby-dev
@@ -165,6 +163,8 @@
       - python-setuptools
       - libssl-dev
       - apt-transport-https
+    state: present
+    update_cache: no
   retries: 5
   when: preburn
 
@@ -176,8 +176,6 @@
 - name: Common install dependencies for building and shipping client release
   tags: dev
   apt:
-    state: present
-    update_cache: no
     name:
       - autogen
       - autoconf
@@ -193,21 +191,23 @@
       - net-tools # ifconfig
       - tcpdump
       - curl
+    state: present
+    update_cache: no
   retries: 5
   when: preburn
 
 - name: Install build requirements for Ubuntu systems
   # python3-aioeventlet manually built with fpm and uploaded to jfrog focal-dev repo
   # due to upstream versioning bug
-  when: preburn
   apt:
-    state: present
     name:
       - clang
       - cmake
       - make
       - python3-aioeventlet
+    state: present
   retries: 5
+  when: preburn
 
 # /etc/environment doesn't expand variables, so if we want to modify the path,
 # we need to do it in profile.d
@@ -253,8 +253,6 @@
 
 - name: Install common Magma gateway dev dependencies
   apt:
-    state: present
-    update_cache: yes
     name:
       # install gRPC
       - grpc-dev
@@ -275,31 +273,33 @@
       - libtins-dev
       - libmnl-dev
       - libcurl4-openssl-dev
+    state: present
+    update_cache: yes
   retries: 5
   when: preburn
 
 - name: Install Ubuntu Magma gateway dev dependencies
   retries: 5
-  when: preburn
   apt:
-    state: present
-    update_cache: no
     name:
       - libprotobuf17
       - libprotobuf-lite17
       - libprotoc17
       - libssl-dev
+    state: present
+    update_cache: no
+  when: preburn
 
 ###############################################
 # Download and build sentry-native
 ###############################################
 
 - name: Install Sentry Native SDK
-  vars:
-    sentry_native_version: "0.4.12"
   get_url:
     url: "https://github.com/getsentry/sentry-native/releases/download/{{ sentry_native_version }}/sentry-native.zip"
     dest: "{{ tmp_directory }}/sentry-native.zip"
+  vars:
+    sentry_native_version: "0.4.12"
   when: preburn
 
 - name: Create a directory for Sentry Native
@@ -380,11 +380,11 @@
   when: preburn
 
 - name: Patch multipath conf
-  when: preburn
+  become: yes
   patch:
     src: patches/multipath-conf.patch
     dest: /etc/multipath.conf
-  become: yes
+  when: preburn
   ignore_errors: true
 
 - name: Copy Interface file.

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -189,21 +189,12 @@
       - python3-requests
       - python3-pip
       - python3-debian
+      - python3-venv
       - net-tools # ifconfig
       - tcpdump
       - curl
   retries: 5
   when: preburn
-
-- name: Install python3-venv for creating dev venvs (used by rules_pyvenv)
-  # TODO: move to preburn
-  tags: dev
-  apt:
-    state: present
-    update_cache: no
-    pkg:
-      - python3-venv
-  retries: 5
 
 - name: Install build requirements for Ubuntu systems
   # python3-aioeventlet manually built with fpm and uploaded to jfrog focal-dev repo

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -21,8 +21,7 @@
   when: preburn
   apt:
     state: present
-    pkg:
-      - ansible
+    name: ansible
   retries: 5
 
 - name: Copy over the timesyncd config
@@ -37,10 +36,10 @@
     state: started
 
 - name: Copy ssh keepAlive configs
-  copy: src={{ item.src }} dest={{ item.dest }}
   become: yes
-  with_items:
-    - {src: 'sshd_config', dest: '/etc/ssh/sshd_config'}
+  copy:
+    src: sshd_config
+    dest: /etc/ssh/sshd_config
 
 - name: Restart service ssh
   become: yes
@@ -58,7 +57,7 @@
 
 - name: Set build environment variables
   lineinfile:
-    dest: /etc/environment
+    path: /etc/environment
     state: present
     line: "{{ item }}"
   with_items:
@@ -86,11 +85,9 @@
 
 - name: "Go export"
   lineinfile:
-    dest: "/home/{{ ansible_user }}/.profile"
+    path: "/home/{{ ansible_user }}/.profile"
     state: present
-    line: "{{ item }}"
-  with_items:
-    - export PATH=$PATH:"/usr/local/go/bin"
+    line: export PATH=$PATH:"/usr/local/go/bin"
   when: preburn
 
 - name: Create the ccache directory
@@ -107,7 +104,7 @@
 
 - name: Set a convenience function for disabling TCP checksumming for traffic test
   lineinfile:
-    dest: /home/{{ ansible_user }}/.bashrc
+    path: /home/{{ ansible_user }}/.bashrc
     state: present
     line: "alias disable-tcp-checksumming='sudo ethtool --offload eth1 rx off tx off; sudo ethtool --offload eth2 rx off tx off'"
   when: preburn
@@ -120,7 +117,7 @@
   apt:
     state: present
     update_cache: no
-    pkg:
+    name:
       - byobu
       - vim
       - aptitude
@@ -129,7 +126,7 @@
 
 - name: Install debugger packages
   apt:
-    pkg: gdb
+    name: gdb
     state: present
     update_cache: no
   retries: 5
@@ -139,7 +136,7 @@
   apt:
     state: present
     update_cache: no
-    pkg:
+    name:
       - htop
       - iotop
   retries: 5
@@ -147,7 +144,10 @@
 
 # TODO: remove this after migrating magma_test box image to plain Debian
 - name: Install lxml
-  apt: pkg=python3-lxml state=present update_cache=no
+  apt:
+    state: present
+    update_cache: no
+    name: python3-lxml
   when: preburn
 
 - name: Install prereqs for FPM
@@ -155,7 +155,7 @@
   apt:
     state: present
     update_cache: no
-    pkg:
+    name:
       - ruby
       - ruby-dev
       - build-essential
@@ -178,7 +178,7 @@
   apt:
     state: present
     update_cache: no
-    pkg:
+    name:
       - autogen
       - autoconf
       - ccache
@@ -202,7 +202,7 @@
   when: preburn
   apt:
     state: present
-    pkg:
+    name:
       - clang
       - cmake
       - make
@@ -211,19 +211,12 @@
 
 # /etc/environment doesn't expand variables, so if we want to modify the path,
 # we need to do it in profile.d
-- name: Create the env script
-  file:
-    path: /etc/profile.d/env.sh
-    state: touch
-  when: preburn
-
 - name: Override the default compiler with cache
   lineinfile:
-    dest: /etc/profile.d/env.sh
+    path: /etc/profile.d/env.sh
     state: present
-    line: "{{ item }}"
-  with_items:
-    - PATH="/usr/lib/ccache:{{ ansible_env.PATH }}"
+    create: true
+    line: PATH="/usr/lib/ccache:{{ ansible_env.PATH }}"
   when: full_provision
 
 ########################################
@@ -262,7 +255,7 @@
   apt:
     state: present
     update_cache: yes
-    pkg:
+    name:
       # install gRPC
       - grpc-dev
       # install protobuf
@@ -291,7 +284,7 @@
   apt:
     state: present
     update_cache: no
-    pkg:
+    name:
       - libprotobuf17
       - libprotobuf-lite17
       - libprotoc17
@@ -338,7 +331,7 @@
 - name: Setup build requirements for python sdk
   become: yes
   apt:
-    pkg: openjdk-8-jdk
+    name: openjdk-8-jdk
     state: present
     update_cache: yes
   retries: 5
@@ -380,7 +373,7 @@
 - name: Install multipath-tools
   become: yes
   apt:
-    pkg: multipath-tools
+    name: multipath-tools
     state: present
     update_cache: yes
   retries: 5
@@ -415,7 +408,7 @@
 
 - name: Install LLDB debugger
   apt:
-    pkg: lldb
+    name: lldb
     state: present
     update_cache: no
   retries: 5

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -146,7 +146,7 @@
     dest: /usr/local/bin/configure_envoy_namespace.sh
   when: full_provision
 
-- name: Create symlink binaries
+- name: Create symlinks for binaries
   file:
     src: "{{ item.src }}"
     path: /usr/local/{{ item.path }}
@@ -220,11 +220,7 @@
   when: full_provision
 
 - name: Install OpenAirInterface (OAI) dependencies
-  retries: 5
-  when: preburn
   apt:
-    state: present
-    update_cache: yes
     name:
       - check
       - libgtest-dev
@@ -241,13 +237,17 @@
       - libczmq-dev
       - libczmq-dev
       - libsqlite3-dev
-
-- name: Install LI Agent dependencies
-  retries: 5
-  apt:
     state: present
     update_cache: yes
+  retries: 5
+  when: preburn
+
+- name: Install LI Agent dependencies
+  apt:
     name: uuid-dev
+    state: present
+    update_cache: yes
+  retries: 5
   when: preburn
 
 - name: Fix vport-gtp kernel module for Ubuntu Focal
@@ -259,19 +259,15 @@
       ignore_errors: yes
 
 - name: Install Ubuntu Magma gateway dev dependencies
-  retries: 5
-  when: preburn
   apt:
+    name: libconfig-dev
     state: present
     update_cache: no
-    name: libconfig-dev
-
-- name: Install common Magma dependencies
   retries: 5
   when: preburn
+
+- name: Install common Magma dependencies
   apt:
-    state: present
-    update_cache: yes
     name:
       # install openvswitch
       - libopenvswitch
@@ -302,25 +298,29 @@
       - tshark
       - getenvoy-envoy
       - bcc-tools
-
-- name: Install ubuntu Magma dependencies
-  retries: 5
-  when: preburn
-  apt:
     state: present
     update_cache: yes
+  retries: 5
+  when: preburn
+
+- name: Install ubuntu Magma dependencies
+  apt:
     name:
       - nlohmann-json3-dev
       # managing gtp interface
       - ifupdown
-
-- name: Install scapy
-  retries: 5
-  when: preburn
-  apt:
     state: present
     update_cache: yes
+  retries: 5
+  when: preburn
+
+- name: Install scapy
+  apt:
     name: python3-scapy
+    state: present
+    update_cache: yes
+  retries: 5
+  when: preburn
 
 - name: Copy the gtp interface initialization definition
   copy:
@@ -343,17 +343,20 @@
   when: full_provision
 
 - name: Specific Magma dependencies from backports
-  apt: pkg=cmake state=present update_cache=yes
+  apt:
+    name: cmake
+    state: present
+    update_cache: yes
   retries: 5
   when: preburn
 
 - name: Install gmock and gtest for C++ testing
   become: yes
-  ignore_errors: yes
   shell: cmake . && cmake --build . --target install
   args:
     chdir: /usr/src/googletest
   when: preburn
+  ignore_errors: yes
 
 - name: Download golang tar
   get_url:
@@ -381,9 +384,9 @@
 
 - name: Install dnsmasq
   apt:
+    name: dnsmasq
     state: present
     update_cache: yes
-    name: dnsmasq
   retries: 5
   when: preburn
 
@@ -396,9 +399,9 @@
 
 - name: Install lighttpd
   apt:
+    name: lighttpd
     state: present
     update_cache: yes
-    name: lighttpd
   retries: 5
   when: preburn
 
@@ -448,13 +451,13 @@
     recurse: yes
 
 - name: Install dev requirements only used for Magma VM
-  retries: 5
   apt:
-    state: latest
     name:
       - clangd-12
       - lld
       - clang-format-11
+    state: latest
+  retries: 5
   when: preburn
 
 - name: Create a symlink for clangd
@@ -470,10 +473,10 @@
 
 # TODO: Fix magma-dev VM box and remove this step.
 - name: Install Magma dependencies
-  retries: 5
   apt:
-    state: latest
     name: magma-libfluid
+    state: latest
+  retries: 5
   when: preburn
 
 - name: Create eBPF code dir
@@ -482,9 +485,9 @@
 
 - name: Prepare AGW for eBPF
   apt:
+    name: linux-headers-5.4.0-74-generic
     state: present
     update_cache: yes
-    name: linux-headers-5.4.0-74-generic
   when: preburn
 
 - name: Copy eBPF code

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -115,8 +115,10 @@
     value: unlimited
 
 - name: Create the /var/core directory
-  file: path=/var/core state=directory
-  when: full_provision
+  file:
+    path: /var/core
+    state: directory
+  when: preburn
 
 - name: Copy lte scripts
   copy:
@@ -190,14 +192,14 @@
   file:
     path: '{{ magma_repo }}/'
     state: directory
-  when: full_provision
+  when: preburn
 
 - name: Add Magma dependency package directory
   become: no
   file:
     path: '{{ magma_deps }}/'
     state: directory
-  when: full_provision
+  when: preburn
 
 - name: Enable IP forwarding
   sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
@@ -311,16 +313,13 @@
       # managing gtp interface
       - ifupdown
 
-# TODO move to preburn
-# dependency for the dhcp helper cli
 - name: Install scapy
   retries: 5
-  when: full_provision
+  when: preburn
   apt:
     state: present
     update_cache: yes
-    pkg:
-      - python3-scapy
+    name: python3-scapy
 
 - name: Copy the gtp interface initialization definition
   copy:

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -355,28 +355,19 @@
     chdir: /usr/src/googletest
   when: preburn
 
-# TODO: remove this step for next base image
-- name: Remove Old Golang
-  file:
-    path: "/usr/local/go/"
-    state: absent
-  when: full_provision
-
-# TODO: for the next base image it should be done in the preburn step
 - name: Download golang tar
   get_url:
     url: "https://linuxfoundation.jfrog.io/artifactory/magma-blob/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
     dest: "{{ all_vars.WORK_DIR }}"
     mode: 0440
-  when: full_provision
+  when: preburn
 
-# TODO: for the next base image it should be done in the preburn step
 - name: Extract Go tarball
   unarchive:
     src: "{{all_vars.WORK_DIR}}/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
     dest: /usr/local
     copy: no
-  when: full_provision
+  when: preburn
 
 - name: Set Go environment vars in profile
   lineinfile:

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -23,7 +23,6 @@
     name: magma-dev
   when: full_provision
 
-
 - name: Include vars of all.yaml
   include_vars:
     file: all.yaml
@@ -54,52 +53,52 @@
     - liagentd
   when: full_provision
 
-- name: Copy sctpd service file
+- name: Copy service files
   copy:
-    src: systemd/sctpd.service
-    dest: /etc/systemd/system/sctpd.service
+    src: systemd/{{ item.src }}.service
+    dest: /etc/systemd/system/{{ item.dest }}.service
+  with_items:
+    - { src: sctpd, dest: sctpd }
+    - { src: magma_dp_envoy, dest: magma_dp@envoy }
   when: full_provision
 
-- name: Copy envoy service file
+- name: Copy config files
   copy:
-    src: systemd/magma_dp_envoy.service
-    dest: /etc/systemd/system/magma_dp@envoy.service
-  when: full_provision
-
-- name: Copy syslog logrotate config file
-  copy:
-    src: logrotate_rsyslog.conf
-    dest: /etc/logrotate.d/rsyslog
-  when: full_provision
-
-- name: Copy OAI logrotate config file
-  copy:
-    src: logrotate_oai.conf
-    dest: /etc/logrotate.d/oai
+    src: logrotate_{{ item }}.conf
+    dest: /etc/logrotate.d/{{ item }}
+  with_items:
+    - rsyslog
+    - oai
   when: full_provision
 
 - name: Copy preferences file for backports
-  copy: src=magma-preferences dest=/etc/apt/preferences.d/magma-preferences
+  copy:
+    src: magma-preferences
+    dest: /etc/apt/preferences.d/magma-preferences
   when: full_provision
 
 - name: Copy sysctl file for core dumps
-  copy: src=99-magma.conf dest=/etc/sysctl.d/99-magma.conf
+  copy:
+    src: 99-magma.conf
+    dest: /etc/sysctl.d/99-magma.conf
   when: full_provision
 
 - name: Copy set_irq_affinity
-  copy: src=set_irq_affinity dest=/usr/local/bin/set_irq_affinity mode=751
+  copy:
+    src: set_irq_affinity
+    dest: /usr/local/bin/set_irq_affinity
+    mode: 751
   when: full_provision
 
-- name: Copy magma-bridge-reset.sh
-  copy: src=magma-bridge-reset.sh dest=/usr/local/bin/magma-bridge-reset.sh mode=751
-  when: full_provision
-
-- name: Copy magma-setup-wg.sh
-  copy: src=magma-setup-wg.sh dest=/usr/local/bin/magma-setup-wg.sh mode=751
-  when: full_provision
-
-- name: Copy magma-create-gtp-port.sh
-  copy: src=magma-create-gtp-port.sh dest=/usr/local/bin/magma-create-gtp-port.sh mode=751
+- name: Copy shell scripts
+  copy:
+    src: '{{ item }}'
+    dest: /usr/local/bin/{{ item }}
+    mode: 751
+  with_items:
+    - magma-bridge-reset.sh
+    - magma-setup-wg.sh
+    - magma-create-gtp-port.sh
   when: full_provision
 
 - name: Add the sysctl config from the step before
@@ -136,55 +135,56 @@
   when: full_provision
 
 - name: Copy Envoy config
-  copy: src=envoy.yaml dest=/var/opt/magma/envoy.yaml
+  copy:
+    src: envoy.yaml
+    dest: /var/opt/magma/envoy.yaml
   when: full_provision
 
 - name: Copy Envoy configuration script
-  copy: src=configure_envoy_namespace.sh dest=/usr/local/bin/configure_envoy_namespace.sh
+  copy:
+    src: configure_envoy_namespace.sh
+    dest: /usr/local/bin/configure_envoy_namespace.sh
   when: full_provision
 
-- name: Create symlink for sctpd binary
-  file: src='{{ c_build }}/sctpd/src/sctpd' path=/usr/local/sbin/sctpd state=link force=yes follow=no
+- name: Create symlink binaries
+  file:
+    src: "{{ item.src }}"
+    path: /usr/local/{{ item.path }}
+    state: link
+    force: yes
+    follow: no
+  with_items:
+    - { src: '{{ c_build }}/connection_tracker/src/connectiond', path: bin/connectiond }
+    - { src: '{{ c_build }}/dpi/dpid', path: bin/dpid }
+    - { src: '{{ c_build }}/li_agent/src/liagentd', path: bin/liagentd }
+    - { src: '{{ c_build }}/session_manager/sessiond', path: bin/sessiond }
+    - { src: '{{ c_build }}/sctpd/src/sctpd', path: sbin/sctpd }
+    - { src: '{{ go_build }}/envoy_controller', path: envoy_controller }
+    - { src: '{{ oai_build }}/oai_mme/mme', path: bin/mme }
   when: full_provision
 
 - name: Create symlink for DHCP helper CLI binary
-  file: src='/home/{{ ansible_user }}/magma/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py' path=/usr/local/bin/dhcp_helper_cli.py state=link force=yes follow=no
-  when: full_provision
-
-- name: Create symlink for OAI mme binary
-  file: src='{{ oai_build }}/oai_mme/mme' path=/usr/local/bin/mme state=link force=yes follow=no
-  when: full_provision
-
-- name: Create symlink for session_manager binary
-  file: src='{{ c_build }}/session_manager/sessiond' path=/usr/local/bin/sessiond state=link force=yes follow=no
-  when: full_provision
-
-- name: Create symlink for envoy controller binary
-  file: src='{{ go_build }}/envoy_controller' path=/usr/local/bin/envoy_controller state=link force=yes follow=no
-  when: full_provision
-
-- name: Create symlink for dpid binary
-  file: src='{{ c_build }}/dpi/dpid' path=/usr/local/bin/dpid state=link force=yes follow=no
-  when: full_provision
-
-- name: Create symlink for connectiond binary
-  file: src='{{ c_build }}/connection_tracker/src/connectiond' path=/usr/local/bin/connectiond state=link force=yes follow=no
-  when: full_provision
-
-- name: Create symlink for li agent binary
-  file: src='{{ c_build }}/li_agent/src/liagentd' path=/usr/local/bin/liagentd state=link force=yes follow=no
+  file:
+    src: '{{ magma_root }}/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py'
+    path: /usr/local/bin/dhcp_helper_cli.py
+    state: link
+    force: yes
+    follow: no
   when: full_provision
 
 - name: Create symlink for corefile collection script
-  file: src='{{ magma_root }}/lte/gateway/deploy/roles/magma/files/coredump' path=/usr/local/bin/coredump state=link force=yes follow=no
+  file:
+    src: '{{ magma_root }}/lte/gateway/deploy/roles/magma/files/coredump'
+    path: /usr/local/bin/coredump
+    state: link
+    force: yes
+    follow: no
   when: full_provision
 
-- name: Create the /var/www/local-cdn directory
-  file: path=/var/www/local-cdn state=directory
-  when: preburn
-
 - name: Create the /var/www/local-cdn/store directory
-  file: path=/var/www/local-cdn/store state=directory
+  file:
+    path: /var/www/local-cdn/store
+    state: directory
   when: preburn
 
 - name: Add Magma package directory
@@ -202,7 +202,12 @@
   when: preburn
 
 - name: Enable IP forwarding
-  sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    sysctl_set: yes
+    state: present
+    reload: yes
   when: full_provision
 
 # Explicitly set policy to stop docker from blocking everything
@@ -220,7 +225,7 @@
   apt:
     state: present
     update_cache: yes
-    pkg:
+    name:
       - check
       - libgtest-dev
       - liblfds710
@@ -242,8 +247,7 @@
   apt:
     state: present
     update_cache: yes
-    pkg:
-      - uuid-dev
+    name: uuid-dev
   when: preburn
 
 - name: Fix vport-gtp kernel module for Ubuntu Focal
@@ -260,8 +264,7 @@
   apt:
     state: present
     update_cache: no
-    pkg:
-      - libconfig-dev
+    name: libconfig-dev
 
 - name: Install common Magma dependencies
   retries: 5
@@ -269,7 +272,7 @@
   apt:
     state: present
     update_cache: yes
-    pkg:
+    name:
       # install openvswitch
       - libopenvswitch
       - libopenvswitch-dev
@@ -298,8 +301,6 @@
       # For call tracing
       - tshark
       - getenvoy-envoy
-      # eBPF compile and load tools for kernsnoopd and AGW datapath
-      # Ubuntu bcc lib (bpfcc-tools) is pretty old, use magma repo package
       - bcc-tools
 
 - name: Install ubuntu Magma dependencies
@@ -308,7 +309,7 @@
   apt:
     state: present
     update_cache: yes
-    pkg:
+    name:
       - nlohmann-json3-dev
       # managing gtp interface
       - ifupdown
@@ -372,28 +373,40 @@
   lineinfile:
     dest: "/home/{{ ansible_user }}/.profile"
     state: present
-    line: "{{ item }}"
+    line: "export PATH=$PATH:{{ item }}"
   with_items:
-    - export PATH=$PATH:/usr/local/bin/go/
-    - export PATH=$PATH:$(go env GOPATH)/bin/
+    - /usr/local/bin/go/
+    - $(go env GOPATH)/bin/
   when: full_provision
 
 - name: Install dnsmasq
-  apt: pkg=dnsmasq state=present update_cache=yes
+  apt:
+    state: present
+    update_cache: yes
+    name: dnsmasq
   retries: 5
   when: preburn
 
 - name: Stop dnsmasq service
-  service: name=dnsmasq state=stopped enabled=no
+  service:
+    name: dnsmasq
+    state: stopped
+    enabled: no
   when: preburn
 
 - name: Install lighttpd
-  apt: pkg=lighttpd state=present update_cache=yes
+  apt:
+    state: present
+    update_cache: yes
+    name: lighttpd
   retries: 5
   when: preburn
 
 - name: Stop lighttpd service
-  service: name=lighttpd state=stopped enabled=no
+  service:
+    name: lighttpd
+    state: stopped
+    enabled: no
   when: preburn
 
 - name: Restart networking to bring up linux bridge
@@ -438,7 +451,7 @@
   retries: 5
   apt:
     state: latest
-    pkg:
+    name:
       - clangd-12
       - lld
       - clang-format-11
@@ -446,18 +459,13 @@
 
 - name: Create a symlink for clangd
   file:
-    src: '/usr/bin/clangd-12'
-    path: '/usr/bin/clangd'
+    src: '/usr/bin/{{ item.src }}'
+    path: '/usr/bin/{{ item.path }}'
     state: link
     force: yes
-  when: preburn
-
-- name: Create a symlink for clang-format
-  file:
-    src: '/usr/bin/clang-format-11'
-    path: '/usr/bin/clang-format'
-    state: link
-    force: yes
+  with_items:
+    - { src: clangd-12, path: clangd }
+    - { src: clang-format-11, path: clang-format }
   when: preburn
 
 # TODO: Fix magma-dev VM box and remove this step.
@@ -465,8 +473,7 @@
   retries: 5
   apt:
     state: latest
-    pkg:
-      - magma-libfluid
+    name: magma-libfluid
   when: preburn
 
 - name: Create eBPF code dir
@@ -477,10 +484,8 @@
   apt:
     state: present
     update_cache: yes
-    pkg:
-      - linux-headers-5.4.0-74-generic
+    name: linux-headers-5.4.0-74-generic
   when: preburn
-
 
 - name: Copy eBPF code
   copy:
@@ -493,7 +498,6 @@
     - ebpf_dl_handler.c
   when: full_provision
 
-
 - name: Copy eBPF code
   copy:
     src: '{{ magma_root }}/orc8r/gateway/c/common/ebpf/EbpfMap.h'
@@ -502,22 +506,17 @@
     remote_src: yes
   when: full_provision
 
-- name: Extend sda2
+# Remove this for base image testing with a Ubuntu base image
+- name: Extend sda2 and sda5
   community.general.parted:
     device: /dev/sda
-    number: 2
+    number: '{{ item }}'
     part_end: "100%"
     resize: true
     state: present
-  when: full_provision
-
-- name: Extend sda5
-  community.general.parted:
-    device: /dev/sda
-    number: 5
-    part_end: "100%"
-    resize: true
-    state: present
+  with_items:
+    - 2
+    - 5
   when: full_provision
 
 - name: Extend lvm volumes

--- a/lte/gateway/deploy/roles/magma_test/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_test/tasks/main.yml
@@ -87,7 +87,11 @@
 
 - name: Install MySQL client for OAI upstreaming
   become: yes
-  apt: pkg=default-libmysqlclient-dev state=present update_cache=yes
+  apt:
+    state: present
+    update_cache: yes
+    pkg:
+      - default-libmysqlclient-dev
   when: preburn
 
 - name: Check whether swagger.yml exists

--- a/lte/gateway/deploy/roles/magma_test/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_test/tasks/main.yml
@@ -86,9 +86,9 @@
 - name: Install MySQL client for OAI upstreaming
   become: yes
   apt:
+    name: default-libmysqlclient-dev
     state: present
     update_cache: yes
-    name: default-libmysqlclient-dev
   when: preburn
 
 - name: Check whether swagger.yml exists

--- a/lte/gateway/deploy/roles/magma_test/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_test/tasks/main.yml
@@ -24,14 +24,17 @@
   when: full_provision
 
 - name: Set up S1AP tester build directory
-  file: path={{ s1ap_tester_root }}/bin state=directory recurse=yes
+  file:
+    path: "{{ s1ap_tester_root }}/bin"
+    state: directory
+    recurse: yes
   when: preburn
 
 - name: Set a convenience function for starting the S1AP tester
-  lineinfile: >
-    dest=/home/{{ ansible_user }}/.bashrc
-    state=present
-    line="alias s1aptester='mkdir -p /tmp/fw; cd $S1AP_TESTER_ROOT; venvsudo LD_LIBRARY_PATH=$S1AP_TESTER_ROOT/bin PATH=$PATH:/sbin bin/testCntrlr'"
+  lineinfile:
+    path: "/home/{{ ansible_user }}/.bashrc"
+    state: present
+    line: "alias s1aptester='mkdir -p /tmp/fw; cd $S1AP_TESTER_ROOT; venvsudo LD_LIBRARY_PATH=$S1AP_TESTER_ROOT/bin PATH=$PATH:/sbin bin/testCntrlr'"
   when: preburn
 
 - name: Add integ test scripts to path
@@ -65,16 +68,11 @@
     S1AP_TESTER_ROOT: "{{ s1ap_tester_root }}"
   when: full_provision
 
-- name: Install pyparsing
+- name: Install pyparsing and flaky
   pip:
-    name: pyparsing
-    extra_args: --cache-dir $PIP_CACHE_HOME
-    executable: pip3
-  when: full_provision
-
-- name: Install flaky
-  pip:
-    name: flaky
+    name:
+      - pyparsing
+      - flaky
     extra_args: --cache-dir $PIP_CACHE_HOME
     executable: pip3
   when: full_provision
@@ -90,8 +88,7 @@
   apt:
     state: present
     update_cache: yes
-    pkg:
-      - default-libmysqlclient-dev
+    name: default-libmysqlclient-dev
   when: preburn
 
 - name: Check whether swagger.yml exists
@@ -103,7 +100,7 @@
 - name: Add the test controller DNS entry
   become: yes
   lineinfile:
-    dest: /etc/hosts
+    path: /etc/hosts
     regexp: '.*controller.magma.test$'
     line: "10.0.2.2 controller.magma.test"
     state: present

--- a/lte/gateway/deploy/roles/pyvenv/tasks/main.yml
+++ b/lte/gateway/deploy/roles/pyvenv/tasks/main.yml
@@ -24,20 +24,15 @@
   apt:
     state: present
     update_cache: yes
-    pkg:
-      - virtualenvwrapper
-  when: preburn
-
-- name: Configure login shell for virtualenv location
-  lineinfile:
-    path: /home/{{ ansible_user }}/.bashrc
-    line: export WORKON_HOME=$HOME/.virtualenvs
-    state: present
+    name: virtualenvwrapper
   when: preburn
 
 - name: Configure login shell for virtualenv
   lineinfile:
     path: /home/{{ ansible_user }}/.bashrc
-    line: source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
+    line: "{{ item }}"
     state: present
+  with_items:
+    - export WORKON_HOME=$HOME/.virtualenvs
+    - source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
   when: preburn

--- a/lte/gateway/deploy/roles/pyvenv/tasks/main.yml
+++ b/lte/gateway/deploy/roles/pyvenv/tasks/main.yml
@@ -22,9 +22,9 @@
 
 - name: Install virtualenvwrapper
   apt:
+    name: virtualenvwrapper
     state: present
     update_cache: yes
-    name: virtualenvwrapper
   when: preburn
 
 - name: Configure login shell for virtualenv

--- a/lte/gateway/deploy/roles/service_aliases/tasks/main.yml
+++ b/lte/gateway/deploy/roles/service_aliases/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Create convenient aliases for magma services
   lineinfile:
-    dest: /home/{{ ansible_user }}/.bashrc
+    path: /home/{{ ansible_user }}/.bashrc
     state: present
     line: "{{ item }}"
   with_items:

--- a/lte/gateway/deploy/roles/trfserver/tasks/main.yml
+++ b/lte/gateway/deploy/roles/trfserver/tasks/main.yml
@@ -97,16 +97,15 @@
     - iperf3_3.9-1_amd64.deb
   when: preburn
 
-# TODO Can be moved to preburn
 - name: configure dhcpd
   become: yes
   copy: src=udhcpd.conf dest=/etc/
-  when: full_provision
+  when: preburn
 
 - name: install udhcpd
   apt:
     name: udhcpd
-  when: full_provision
+  when: preburn
 
 - name: configure udhcpd
   become: yes
@@ -114,14 +113,14 @@
     path: /etc/default/udhcpd
     regexp: 'DHCPD_ENABLED="no"'
     replace: 'DHCPD_ENABLED="yes"'
-  when: full_provision
+  when: preburn
 
 - name: Restart service udhcpd
   become: yes
   service:
     name: udhcpd
     state: restarted
-  when: full_provision
+  when: preburn
 
 - name: configure sshd_config
   become: yes

--- a/lte/gateway/deploy/roles/trfserver/tasks/main.yml
+++ b/lte/gateway/deploy/roles/trfserver/tasks/main.yml
@@ -76,11 +76,13 @@
       - git+https://github.com/thiezn/iperf3-python#egg=iperf3-python
   when: preburn
 
-- name: remove preinstalled iperf3 and libiperf0
+- name: Remove preinstalled iperf3 and libiperf0
   apt:
-    name: ['iperf3', 'libiperf0']
     state: absent
     update_cache: yes
+    name:
+      - iperf3
+      - libiperf0
     purge: yes
   when: preburn
 
@@ -89,7 +91,7 @@
     name: libsctp1
   when: preburn
 
-- name: install iperf3 and libiperf0
+- name: Install iperf3 and libiperf0
   apt:
     deb: "https://iperf.fr/download/ubuntu/{{ item }}"
   with_items:
@@ -97,17 +99,19 @@
     - iperf3_3.9-1_amd64.deb
   when: preburn
 
-- name: configure dhcpd
+- name: Configure dhcpd
   become: yes
-  copy: src=udhcpd.conf dest=/etc/
+  copy:
+    src: udhcpd.conf
+    dest: /etc/
   when: preburn
 
-- name: install udhcpd
+- name: Install udhcpd
   apt:
     name: udhcpd
   when: preburn
 
-- name: configure udhcpd
+- name: Configure udhcpd
   become: yes
   replace:
     path: /etc/default/udhcpd
@@ -122,7 +126,7 @@
     state: restarted
   when: preburn
 
-- name: configure sshd_config
+- name: Configure sshd_config
   become: yes
   replace:
     path: /etc/ssh/sshd_config

--- a/lte/gateway/deploy/roles/trfserver/tasks/main.yml
+++ b/lte/gateway/deploy/roles/trfserver/tasks/main.yml
@@ -43,8 +43,6 @@
 
 - name: Install common Magma dev dependencies
   apt:
-    state: present
-    update_cache: yes
     name:
       - python3-pip
       - git
@@ -52,6 +50,8 @@
       - net-tools
       # install ethtool for disabling TCP checksumming
       - ethtool
+    state: present
+    update_cache: yes
   when: preburn
 
 - name: Rename interfaces to ethx-scheme
@@ -69,20 +69,20 @@
 
 - name: Install the trfgen-server python dependencies
   pip:
-    executable: pip3
     name:
       - pyroute2
       - scapy-python3
       - git+https://github.com/thiezn/iperf3-python#egg=iperf3-python
+    executable: pip3
   when: preburn
 
 - name: Remove preinstalled iperf3 and libiperf0
   apt:
-    state: absent
-    update_cache: yes
     name:
       - iperf3
       - libiperf0
+    state: absent
+    update_cache: yes
     purge: yes
   when: preburn
 

--- a/orc8r/tools/ansible/roles/docker/tasks/install.yml
+++ b/orc8r/tools/ansible/roles/docker/tasks/install.yml
@@ -10,14 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Next base image: "when: ansible_distribution == 'Ubuntu' and preburn"
 - name: Ubuntu install tasks
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == 'Ubuntu' and preburn
   include_tasks: install_debian.yml
 
-# TODO: Next base image: "when: ansible_distribution == 'CentOS' and preburn"
 - name: Red Hat install tasks
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' and preburn
   include_tasks: install_redhat.yml
 
 - name: Add the user to the docker group

--- a/orc8r/tools/ansible/roles/docker/tasks/install.yml
+++ b/orc8r/tools/ansible/roles/docker/tasks/install.yml
@@ -27,6 +27,6 @@
 
 - name: Install python docker module
   pip:
-    executable: /usr/bin/pip3
+    executable: pip3
     name: docker
   when: preburn

--- a/orc8r/tools/ansible/roles/docker/tasks/install.yml
+++ b/orc8r/tools/ansible/roles/docker/tasks/install.yml
@@ -27,6 +27,6 @@
 
 - name: Install python docker module
   pip:
-    executable: pip3
     name: docker
+    executable: pip3
   when: preburn

--- a/orc8r/tools/ansible/roles/docker/tasks/install_debian.yml
+++ b/orc8r/tools/ansible/roles/docker/tasks/install_debian.yml
@@ -17,8 +17,6 @@
 
 - name: Install packages to allow apt to use a repository over HTTPS
   apt:
-    state: present
-    update_cache: true
     name:
       - apt-transport-https
       - ca-certificates
@@ -27,6 +25,8 @@
       - software-properties-common
       - python3-pip
       - lsb-release
+    state: present
+    update_cache: true
 
 - name: Copy docker gpg key from codebase
   copy:
@@ -38,17 +38,17 @@
     file: /tmp/docker.key
     state: present
 
-- name: Add the focal repository for Docker
+- name: Add the stable repository for Docker
   apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ docker_host_distribution }} stable
     state: present
 
 - name: Install the latest version of Docker CE
   apt:
-    state: present
-    update_cache: true
     name:
       - docker-ce
       - docker-ce-cli
       - containerd.io
       - docker-compose-plugin
+    state: present
+    update_cache: true

--- a/orc8r/tools/ansible/roles/docker/tasks/install_debian.yml
+++ b/orc8r/tools/ansible/roles/docker/tasks/install_debian.yml
@@ -15,57 +15,11 @@
 # Install Docker based on instructions in:
 # https://docs.docker.com/install/linux/docker-ce/ubuntu
 
-# TODO: Remove with next base image release
-- name: Remove Docker install from base image
-  apt:
-    name: "{{ packages }}"
-    state: absent
-    update_cache: true
-    purge: true
-  vars:
-    packages:
-      - docker-ce
-      - docker-ce-cli
-      - docker-ce-rootless-extra
-      - containerd.io
-      - docker-scan-plugin
-
-# TODO: Remove with next base image release
-- name: Remove Docker Compose V1 install from base image
-  file:
-    name: /usr/local/bin/docker-compose
-    state: absent
-
-# TODO: Remove with next base image release
-- name: Purge docker libs
-  file:
-    name: /var/lib/docker
-    state: absent
-
-# TODO: Remove with next base image release
-- name: Purge docker
-  file:
-    name: /etc/docker
-    state: absent
-
-# TODO: Remove with next base image release
-- name: Purge containerd libs
-  file:
-    name: /var/lib/containerd
-    state: absent
-
-# TODO: Remove with next base image release
-- name: Stop running docker.socket
-  shell: sudo systemctl stop docker.socket
-  ignore_errors: true # for the cwag dev VM
-
 - name: Install packages to allow apt to use a repository over HTTPS
   apt:
-    name: "{{ packages }}"
     state: present
     update_cache: true
-  vars:
-    packages:
+    name:
       - apt-transport-https
       - ca-certificates
       - curl
@@ -79,15 +33,10 @@
     src: docker.key
     dest: /tmp/docker.key
 
-- name: Add Docker’s official GPG key
+- name: Add Docker's official GPG key
   apt_key:
     file: /tmp/docker.key
     state: present
-
-- name: Remove the xenial repository for Docker
-  apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
-    state: absent
 
 - name: Add the focal repository for Docker
   apt_repository:
@@ -96,11 +45,9 @@
 
 - name: Install the latest version of Docker CE
   apt:
-    name: "{{ packages }}"
     state: present
     update_cache: true
-  vars:
-    packages:
+    name:
       - docker-ce
       - docker-ce-cli
       - containerd.io

--- a/orc8r/tools/ansible/roles/docker/tasks/install_redhat.yml
+++ b/orc8r/tools/ansible/roles/docker/tasks/install_redhat.yml
@@ -12,44 +12,20 @@
 # limitations under the License.
 ################################################################################
 
-# TODO: Remove with next base image release
-- name: Remove Docker install from base image
-  yum:
-    name: "{{ packages }}"
-    state: absent
-  vars:
-    packages:
-      - docker
-      - docker-client
-      - docker-client-latest
-      - docker-common
-      - docker-latest
-      - docker-latest-logrotate
-      - docker-logrotate
-      - docker-engine
-
-# TODO: Remove with next base image release
-- name: Remove Docker Compose V1 install from base image
-  file:
-    name: /usr/local/bin/docker-compose
-    state: absent
-
 # Install Docker based on instructions in:
 # https://docs.docker.com/install/linux/docker-ce/ubuntu
 
 - name: Install utilities
   yum:
-    name: "{{ packages }}"
     state: present
-  vars:
-    packages:
+    name:
       - ca-certificates
       - curl
       - python3-pip
       - python3-setuptools
       - yum-utils
 
-- name: Add Docker’s official GPG key
+- name: Add Docker's official GPG key
   rpm_key:
     key: https://download.docker.com/linux/centos/gpg
     state: present
@@ -59,10 +35,8 @@
 
 - name: Install the latest version of Docker CE
   yum:
-    name: "{{ packages }}"
     state: present
-  vars:
-    packages:
+    name:
       - docker-ce
       - docker-ce-cli
       - containerd.io

--- a/orc8r/tools/ansible/roles/docker/tasks/install_redhat.yml
+++ b/orc8r/tools/ansible/roles/docker/tasks/install_redhat.yml
@@ -17,13 +17,13 @@
 
 - name: Install utilities
   yum:
-    state: present
     name:
       - ca-certificates
       - curl
       - python3-pip
       - python3-setuptools
       - yum-utils
+    state: present
 
 - name: Add Docker's official GPG key
   rpm_key:
@@ -35,10 +35,10 @@
 
 - name: Install the latest version of Docker CE
   yum:
-    state: present
     name:
       - docker-ce
       - docker-ce-cli
       - containerd.io
       - docker-compose-plugin
+    state: present
 

--- a/orc8r/tools/ansible/roles/gateway_dev/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/gateway_dev/tasks/main.yml
@@ -28,15 +28,25 @@
 #################################
 
 - name: Create a symlink for the service configs
-  file: src={{ magma_root }}/{{ config_dir }} path=/etc/magma state=link force=yes
+  file:
+    src: "{{ magma_root }}/{{ config_dir }}"
+    path: /etc/magma
+    state: link
+    force: yes
   when: full_provision
 
 - name: Create the /var/opt/magma directory
-  file: path=/var/opt/magma state=directory
+  file:
+    path: /var/opt/magma
+    state: directory
   when: full_provision
 
 - name: Create a symlink for the basic orc8r templates
-  file: src={{ magma_root }}/orc8r/gateway/configs/templates path=/var/opt/magma/templates state=link force=yes
+  file:
+    src: "{{ magma_root }}/orc8r/gateway/configs/templates"
+    path: /var/opt/magma/templates
+    state: link
+    force: yes
   when: full_provision
 
 ##################################
@@ -45,7 +55,7 @@
 
 - name: Set build environment variables
   lineinfile:
-    dest: /etc/environment
+    path: /etc/environment
     state: present
     line: "{{ item }}"
   with_items:

--- a/orc8r/tools/ansible/roles/gateway_services/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/gateway_services/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Install basic tools
   apt:
     state: present
-    pkg:
+    name:
       - zip
       - unzip
       - curl
@@ -34,7 +34,7 @@
 - name: Install python dependencies
   apt:
     state: present
-    pkg:
+    name:
       - python3-pip
       - pkg-config
       - libsystemd-dev
@@ -48,7 +48,7 @@
 - name: Install nghttpx and its deps for Ubuntu
   apt:
     state: present
-    pkg:
+    name:
       - gcc
       - libssl-dev
       - libev-dev

--- a/orc8r/tools/ansible/roles/gateway_services/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/gateway_services/tasks/main.yml
@@ -16,7 +16,6 @@
 
 - name: Install basic tools
   apt:
-    state: present
     name:
       - zip
       - unzip
@@ -24,6 +23,7 @@
       - daemontools
       - git
       - vim
+    state: present
   retries: 5
   when: preburn
 
@@ -33,11 +33,11 @@
 
 - name: Install python dependencies
   apt:
-    state: present
     name:
       - python3-pip
       - pkg-config
       - libsystemd-dev
+    state: present
   retries: 5
   when: preburn
 
@@ -47,7 +47,6 @@
 
 - name: Install nghttpx and its deps for Ubuntu
   apt:
-    state: present
     name:
       - gcc
       - libssl-dev
@@ -57,6 +56,7 @@
       - libjemalloc-dev
       - libc-ares-dev
       - magma-nghttpx=1.31.1-1
+    state: present
   retries: 5
   when: preburn
 

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -10,34 +10,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO move to preburn
+# These steps are executed in preburn and full_provision to make
+# registry switches e.g. for upcoming releases easier.
+
 - name: Collect all registries
   ansible.builtin.find:
     paths: /etc/apt/sources.list.d/
     patterns: "*.list*"
   register: registries_to_be_delete
-  when: full_provision
 
-# TODO move to preburn
 - name: Remove all old registries
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: absent
   with_items: "{{ registries_to_be_delete.files }}"
 
-# TODO move to preburn
 - name: Adding the key for the registry
   ansible.builtin.copy:
     src: linux_foundation_registry_key.asc
     dest: /etc/apt/trusted.gpg.d/magma.asc
   become: true
-  when: full_provision
 
-# TODO move to preburn
 - name: Configuring the registry in sources.list.d
   ansible.builtin.apt_repository:
     repo: deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main
     filename: magma
     state: present
     update_cache: true
-  when: full_provision

--- a/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Set Python environment variables
   lineinfile:
-    dest: /etc/environment
+    path: /etc/environment
     state: present
     line: "{{ item }}"
   with_items:
@@ -33,14 +33,14 @@
 
 - name: Add PATH line if it doesn't exist
   lineinfile:
-    dest: /etc/environment
+    path: /etc/environment
     state: present
     line: 'PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
   when: preburn and test_path.rc != 0
 
 - name: Append virtual env python3 bin if path exists
   lineinfile:
-    dest: /etc/environment
+    path: /etc/environment
     state: present
     backrefs: yes
     regexp: 'PATH=(["]*)((?!.*?{{ python_bin }}).*?)(["]*)$'
@@ -51,18 +51,14 @@
 # Add common convenience aliases
 #################################
 
-- name: Set a convenience function for activating the virtualenv
+- name: Set a convenience functions for virtualenv
   lineinfile:
-    dest: /home/{{ ansible_user }}/.bashrc
+    path: /home/{{ ansible_user }}/.bashrc
     state: present
-    line: "alias magtivate='source {{ python_build }}/bin/activate'"
-  when: preburn
-
-- name: Set a convenience function for running things with sudo in the virtualenv
-  lineinfile:
-    dest: /home/{{ ansible_user }}/.bashrc
-    state: present
-    line: "alias venvsudo='sudo -E PATH=$PATH PYTHONPATH=$PYTHONPATH env'"
+    line: "{{ item }}"
+  with_items:
+    - alias magtivate='source {{ python_build }}/bin/activate'
+    - alias venvsudo='sudo -E PATH=$PATH PYTHONPATH=$PYTHONPATH env'
   when: preburn
 
 ##############################
@@ -74,7 +70,7 @@
   when: preburn
   apt:
     state: present
-    pkg:
+    name:
       # Build requirements
       - virtualenv
       - python-babel

--- a/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
@@ -51,7 +51,7 @@
 # Add common convenience aliases
 #################################
 
-- name: Set a convenience functions for virtualenv
+- name: Set convenience functions for virtualenv
   lineinfile:
     path: /home/{{ ansible_user }}/.bashrc
     state: present

--- a/orc8r/tools/packer/magma-dev-virtualbox.json
+++ b/orc8r/tools/packer/magma-dev-virtualbox.json
@@ -51,7 +51,6 @@
           "4"
         ]
       ],
-      "name": "magma",
       "memory": 8192,
       "cpus": 4,
       "hard_drive_interface": "scsi",
@@ -88,6 +87,7 @@
       "playbook_file": "../../../lte/gateway/deploy/magma_dev.yml",
       "role_paths": [
         "../../../lte/gateway/deploy/roles/bazel",
+        "../../../lte/gateway/deploy/roles/bazel_aliases",
         "../../../lte/gateway/deploy/roles/dev_common",
         "../../../lte/gateway/deploy/roles/gai_config",
         "../../../lte/gateway/deploy/roles/magma",

--- a/orc8r/tools/packer/magma-test-virtualbox.json
+++ b/orc8r/tools/packer/magma-test-virtualbox.json
@@ -51,7 +51,6 @@
           "2"
         ]
       ],
-      "name": "magma",
       "memory": 2048,
       "ssh_handshake_attempts": "20",
       "boot_wait": "5s",
@@ -82,10 +81,7 @@
       "expect_disconnect": true
     },
     {
-      "extra_arguments": [
-        "--extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false}'"
-      ],
-      "inventory_groups": "test",
+      "type": "ansible-local",
       "playbook_file": "../../../lte/gateway/deploy/magma_test.yml",
       "role_paths": [
         "../../../lte/gateway/deploy/roles/bazel",
@@ -95,7 +91,10 @@
         "../../../orc8r/tools/ansible/roles/pkgrepo",
         "../../../orc8r/tools/ansible/roles/python_dev"
       ],
-      "type": "ansible-local"
+      "inventory_groups": "test",
+      "extra_arguments": [
+        "--extra-vars '{\"ansible_user\": \"vagrant\", \"preburn\": true, \"full_provision\": false}'"
+      ]
     },
     {
       "type": "shell",

--- a/orc8r/tools/packer/magma-trfserver-virtualbox.json
+++ b/orc8r/tools/packer/magma-trfserver-virtualbox.json
@@ -4,7 +4,7 @@
       "type": "virtualbox-iso",
       "guest_os_type": "Ubuntu_64",
       "headless": true,
-      "vm_name": "magma-dev",
+      "vm_name": "magma-trfserver",
       "iso_url": "https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
       "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
       "ssh_password": "vagrant",
@@ -37,7 +37,6 @@
         " -- <wait>",
         "<enter><wait>"
       ],
-      "name": "magma",
       "memory": 2048,
       "ssh_handshake_attempts": "20",
       "boot_wait": "5s",
@@ -81,6 +80,7 @@
     {
       "type": "shell",
       "scripts": [
+        "scripts/cleanup.sh",
         "scripts/third_party/chef_bento/cleanup_ubuntu.sh",
         "scripts/third_party/aspyatkin/minimize_ubuntu.sh"
       ],

--- a/orc8r/tools/packer/scripts/ubuntu_setup.sh
+++ b/orc8r/tools/packer/scripts/ubuntu_setup.sh
@@ -25,9 +25,9 @@ add-apt-repository -y ppa:ansible/ansible
 apt-get update
 apt-get install -y ansible
 
-# Mark ca-certificates-java to not have it removed via autoremove;
+# Install ca-certificates-java;
 # needed for swagger_codegen_jar
-apt-mark manual ca-certificates-java 
+apt-get install -y ca-certificates-java
 
 # Mount the guest additions iso and run the install script
 mkdir -p /mnt/iso


### PR DESCRIPTION
## Summary

This PR changes several Ansible playbooks to update Magma's `dev`, `test`, and `trfserver` VMs. With these changes the new base images ...

- ... contain go 1.19.3.
- ... contain all prerequisites for the DHCP cli tool.
- ... contain Docker Compose V2.
- ... contain the LF artifactory as installation source.
- ... will execute less steps during provisioning to improve boot times.

Additionally:

- The packing scripts for the VMs are unified and the `trfserver` is cleaned up after packing now as well.
- All box caches are adapted.

Closes:
- #14541 
- #14080 

## Test Plan

locally:
- [x] Unit tests - `bazel test --cache_test_results=no //...`
- [x] Sudo tests - `./bazel/scripts/run_sudo_tests.sh`
- [x] AGW build
- [x] LTE integration tests
- [x] AGW build containerized
- [x] LTE integration tests containerized
- [x] Build Orc8r, SwaggerAPI, NMS along the [Quick Start Guide](https://magma.github.io/magma/docs/next/basics/quick_start_guide)
- [x] Federated integration tests
- [x] CWAG integration tests

CI:
- [x] [Sudo tests](https://github.com/mpfirrmann/magma/actions/runs/3808032073)
- [x] [LTE integration tests debian](https://github.com/mpfirrmann/magma/actions/runs/3821672324)
    - 1st run: ` s1aptests/test_attach_detach_flaky_retry_success.py` failed with a segmentation fault
- [x] LTE integration tests containerized
    - [x] [precommit](https://github.com/mpfirrmann/magma/actions/runs/3808041756)
    - [x] [extended](https://github.com/mpfirrmann/magma/actions/runs/3808042409)
- [x] [Federated integration tests](https://github.com/mpfirrmann/magma/actions/runs/3808033113)
- [x] [CWAG integration tests](https://github.com/mpfirrmann/magma/actions/runs/3808032648)

## Additional Information

- The sudo tests are quite flaky (also in CI on master) but they passed eventually. The culprits are `/pipelined/tests/test_inout_non_nat.py`'s `testFlowVlanSnapshotMatch_static1` and `testFlowVlanSnapshotMatch_static2` tests.
- :warning: #14673 had to be reverted for the LTE integ tests to all pass locally. This needs to be monitored in CI.