### PR TITLE
feat(ci): enable publishing to Vagrant Cloud without user interaction

### DIFF
--- a/orc8r/tools/packer/vagrant-box-upload.sh
+++ b/orc8r/tools/packer/vagrant-box-upload.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 BOX_FILE=$1
+FORCE="--no-force"
 
 USER=magmacore
 BOX=$(basename $BOX_FILE | cut -d_ -f1-2 | cut -d. -f1)
@@ -18,9 +19,22 @@ if [ -z "$VAGRANT_CLOUD_TOKEN" ]; then
   exit 1
 fi
 
+shift
+while getopts ":f" opt; do
+  case $opt in
+    f)
+      FORCE="--force"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
+
 vagrant cloud auth login --token "$VAGRANT_CLOUD_TOKEN"
 vagrant cloud publish \
     --release \
+    "${FORCE}" \
     "${USER}/${BOX}" \
     "$VERSION" \
     "$BOX_PROVIDER" \


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Uploading and publishing VMs to the Vagrant Cloud requires a user interaction to confirm this step. This PR introduces a `-f` flag to the script to force this step. This is needed to run this script in a CI workflow. The force syntax was chosen according to the `vagrant cloud publish` API:
```
[magma]$ vagrant cloud publish --help
Usage: vagrant cloud publish [options] organization/box-name version provider-name [provider-file]

Create and release a new Vagrant Box on Vagrant Cloud

Options:
...
    -f, --[no-]force                 Disables confirmation to create or update box
...
```
Part of #14398.
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
