### PR TITLE
docs: Replace NH_Network by Orc8r in Neutral Host architecture figure

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/howtos/inbound_roaming.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/howtos/inbound_roaming.md
@@ -59,10 +59,10 @@ but you will still need the Neutral Host Network.
 ```mermaid
 graph LR
 
-AGW_G --Any_PLMN--> NH_Network
-NH_Network --PLMN1--> FeG_Gateway_1
-NH_Network --PLMN2--> FeG_Gateway_2
-NH_Network --PLMN3--> FeG_Gateway_3
+AGW_G --Any_PLMN--> Orc8r
+Orc8r --PLMN1--> FeG_Gateway_1
+Orc8r --PLMN2--> FeG_Gateway_2
+Orc8r --PLMN3--> FeG_Gateway_3
 Optional_FeG_gateway --Other_PLMN--> Local_HSS
 FeG_Gateway_1 --> HSS_1
 FeG_Gateway_2 --> HSS_2
@@ -74,7 +74,7 @@ AGW_G
 end
 
 subgraph Neutral_Host_Network
-NH_Network & Optional_FeG_gateway
+Orc8r & Optional_FeG_gateway
 
 end
 

--- a/docs/docusaurus/versioned_docs/version-1.8.0/howtos/inbound_roaming.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/howtos/inbound_roaming.md
@@ -59,10 +59,10 @@ but you will still need the Neutral Host Network.
 ```mermaid
 graph LR
 
-AGW_G --Any_PLMN--> NH_Network
-NH_Network --PLMN1--> FeG_Gateway_1
-NH_Network --PLMN2--> FeG_Gateway_2
-NH_Network --PLMN3--> FeG_Gateway_3
+AGW_G --Any_PLMN--> Orc8r
+Orc8r --PLMN1--> FeG_Gateway_1
+Orc8r --PLMN2--> FeG_Gateway_2
+Orc8r --PLMN3--> FeG_Gateway_3
 Optional_FeG_gateway --Other_PLMN--> Local_HSS
 FeG_Gateway_1 --> HSS_1
 FeG_Gateway_2 --> HSS_2
@@ -74,7 +74,7 @@ AGW_G
 end
 
 subgraph Neutral_Host_Network
-NH_Network & Optional_FeG_gateway
+Orc8r & Optional_FeG_gateway
 
 end
 

--- a/docs/readmes/howtos/inbound_roaming.md
+++ b/docs/readmes/howtos/inbound_roaming.md
@@ -58,10 +58,10 @@ but you will still need the Neutral Host Network.
 ```mermaid
 graph LR
 
-AGW_G --Any_PLMN--> NH_Network
-NH_Network --PLMN1--> FeG_Gateway_1
-NH_Network --PLMN2--> FeG_Gateway_2
-NH_Network --PLMN3--> FeG_Gateway_3
+AGW_G --Any_PLMN--> Orc8r
+Orc8r --PLMN1--> FeG_Gateway_1
+Orc8r --PLMN2--> FeG_Gateway_2
+Orc8r --PLMN3--> FeG_Gateway_3
 Optional_FeG_gateway --Other_PLMN--> Local_HSS
 FeG_Gateway_1 --> HSS_1
 FeG_Gateway_2 --> HSS_2
@@ -73,7 +73,7 @@ AGW_G
 end
 
 subgraph Neutral_Host_Network
-NH_Network & Optional_FeG_gateway
+Orc8r & Optional_FeG_gateway
 
 end
 


### PR DESCRIPTION
This commit replaces the "NH_Network" block, shown in the middle of the Neutral Host architecture figure, by an Orc8r block, which is the item the diagram actually refers to.

@uri200, being the author of the original figure, might want to confirm this is correct.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@i2cat.net>