### PR TITLE
feat(ci): reduce docker stdout

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -461,7 +461,7 @@ def _start_gateway_containerized():
 
     with cd(AGW_ROOT + "/docker"):
         # The `docker compose up` times are machine dependent, such that a retry is needed here for resilience.
-        run_with_retry('DOCKER_REGISTRY=%s docker compose --compatibility -f docker-compose.yaml up -d --quiet-pull' % (env.DOCKER_REGISTRY))
+        run_with_retry('DOCKER_REGISTRY=%s docker compose --compatibility -f docker-compose.yaml up -d --quiet-pull 2> /dev/null' % (env.DOCKER_REGISTRY))
 
 
 def run_with_retry(command, retries=10):

--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -90,7 +90,7 @@ def start_orc8r(on_vagrant='False'):
     Start orc8r locally on Docker
     """
     on_vagrant = strtobool(on_vagrant)
-    command = './run.py'
+    command = './run.py --quiet'
     if not on_vagrant:
         subprocess.check_call(command, shell=True, cwd=orc8_docker_path)
     else:

--- a/orc8r/cloud/docker/run.py
+++ b/orc8r/cloud/docker/run.py
@@ -64,12 +64,19 @@ def main() -> None:
     pathlib.Path(HOST_BUILD_CTX).mkdir(parents=True, exist_ok=True)
 
     cmd = ['docker', 'compose', '--compatibility', 'up', '-d']
+
+    stdout = None
+    stderr = None
+    if args.quiet:
+        stdout = subprocess.DEVNULL
+        stderr = subprocess.STDOUT
+
     if args.down:
         cmd = ['docker', 'compose', 'down']
 
     print("Running '%s'..." % ' '.join(cmd))
     try:
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True, stdout=stdout, stderr=stderr)
     except subprocess.CalledProcessError as err:
         exit(err.returncode)
 
@@ -141,6 +148,12 @@ def _parse_args() -> argparse.Namespace:
         '--clear-db',
         action='store_true',
         help='Clear all content on the database',
+    )
+
+    parser.add_argument(
+        '--quiet',
+        action='store_true',
+        help='Disable stdout for container pull',
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

With the recent switch from Docker Compose V1 to V2, images are now build in parallel which reduces the overall build time. However, the amount / high frequency of `stdout` output coming from `docker compose` is a lot to handle for the GitHub action CI. This results in the output lagging and prolonging the overall workflow, see a [first analysis](https://github.com/magma/magma/issues/14783#issuecomment-1368965432). 
This PR suppresses the `stdout` output from `docker compose up` commands in CI to significantly decrease workflow times by well over one hour.
Closes #14783.

## Test Plan

- See workflows linked in the corresponding issue.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
