### PR TITLE
chore(ci): Magma apt repository is validated

### DIFF
--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -64,19 +64,6 @@
     - agwc
     - base
 
-- name: Ignore server ssl cert
-  copy:
-    dest: /etc/apt/apt.conf.d/99insecurehttpsrepo
-    content: |
-      Acquire::https::{{ magma_pkgrepo_host }} {
-      Verify-Peer "false";
-      Verify-Host "false";
-      };
-  become: true
-  tags:
-    - agwc
-    - base
-
 - name: Configuring the registry in sources.list.d
   ansible.builtin.apt_repository:
     repo: "deb {{ magma_pkgrepo_proto }}://{{ magma_pkgrepo_host }}{{ magma_pkgrepo_path }} {{ magma_pkgrepo_dist }} {{ magma_pkgrepo_component }}"


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Magma's apt repository is now validated by Ansible's `apt_repository` module when we add the repo to a VM. Its SSL verification was previously ignored.
Closes #14629.

## Test Plan

The `magma_deploy` Ansible role is used to install magma from the artifactory on the `magma_deb` virtual machine. The [LTE integration tests](https://github.com/mpfirrmann/magma/actions/runs/3823532564) show an installed magma.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
