### PR TITLE
feat(ci): execute long extended tests in CI run

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -194,6 +194,20 @@ jobs:
       test_targets: extended_tests
     secrets: inherit
 
+  test-containers-extended-long:
+    needs: build-containers
+    # We only want to trigger the tests if the build-containers job uploaded the images.
+    # The following condition is a crude heuristic for this limitation.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/lte-integ-test-containerized.yml
+    with:
+      digest_c: ${{ needs.build-containers.outputs.digest_c }}
+      digest_python: ${{ needs.build-containers.outputs.digest_python }}
+      digest_go: ${{ needs.build-containers.outputs.digest_go }}
+      registry: ${{ needs.build-containers.outputs.registry }}
+      test_targets: extended_tests_long
+    secrets: inherit
+
   publish-container-test-results:
     runs-on: ubuntu-20.04
     if: always() && github.event_name == 'push'
@@ -227,11 +241,23 @@ jobs:
         with:
           name: test-status-extended_tests
 
+      - name: Download test results of long extended tests
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        with:
+          name: test-results-extended_tests_long
+          path: "${{ github.workspace }}/lte/gateway/test-results"
+
+      - name: Download final status of of long extended tests
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        with:
+          name: test-status-extended_tests_long
+
       - name: Determine end result for both tests
         run: |
           result_precommit=$(cat test_status_precommit.txt)
           result_extended=$(cat test_status_extended_tests.txt)
-          if [ $result_precommit == $result_extended ]
+          result_extended_long=$(cat test_status_extended_tests_long.txt)
+          if [ $result_precommit == $result_extended && $result_precommit == $result_extended_long ]
           then
             mv test_status_precommit.txt test_status.txt
           else

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -28,7 +28,7 @@ on:
         required: true
       test_targets:
         type: choice
-        options: [ precommit, extended_tests ]
+        options: [ precommit, extended_tests, extended_tests_long ]
         required: true
   workflow_call:
     inputs:

--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -95,7 +95,7 @@ extended_tests_long: prepare_environment
 integ_test: precommit precommit_tests_noncontainer extended_tests extended_tests_noncontainer extended_tests_long
 
 .PHONY: integ_test_containerized
-integ_test_containerized: precommit extended_tests
+integ_test_containerized: precommit extended_tests extended_tests_long
 
 .PHONY: federated_integ_test
 federated_integ_test: prepare_environment prepare_federation


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The extended LTE integration tests categorized as "long" due to their extended waiting periods are not executed in test runs based on a containerized AGW despite them in general being green. As we run the different integration test targets in parallel, the long waiting times should not be an issue and these tests should run in CI.

## Test Plan

- [CI run](https://github.com/mpfirrmann/magma/actions/runs/3839675754/jobs/6537764594)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
