### PR TITLE
fix: long running tests are added as a dependency to result job for correct test result summary

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -211,7 +211,7 @@ jobs:
   publish-container-test-results:
     runs-on: ubuntu-20.04
     if: always() && github.event_name == 'push'
-    needs: [test-containers-precommit, test-containers-extended]
+    needs: [test-containers-precommit, test-containers-extended, test-containers-extended-long]
     steps:
       - name: Checkout repo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

In #14799 long running extended tests were added to the containerized integ tests. This change adds the respective job to the summary job as a dependency.

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
