### PR TITLE
chore: all precommit and extended tests are executed vs a docker agw environment

### DIFF
--- a/lte/gateway/python/integ_tests/Makefile
+++ b/lte/gateway/python/integ_tests/Makefile
@@ -75,24 +75,16 @@ selected_tests: prepare_environment
 precommit: prepare_environment
 	-$(foreach test,$(PRECOMMIT_TESTS),$(call execute_test,$(test));)
 
-.PHONY: precommit_tests_noncontainer
-precommit_tests_noncontainer: prepare_environment
-	-$(foreach test,$(PRECOMMIT_TESTS_NOT_CONTAINER) $(PRECOMMIT_TESTS_IPV6),$(call execute_test,$(test));)
-
 .PHONY: extended_tests
 extended_tests: prepare_environment
 	-$(foreach test,$(EXTENDED_TESTS),$(call execute_test,$(test));)
-
-.PHONY: extended_tests_noncontainer
-extended_tests_noncontainer: prepare_environment
-	-$(foreach test,$(EXTENDED_TESTS_NOT_CONTAINER),$(call execute_test,$(test));)
 
 .PHONY: extended_tests_long
 extended_tests_long: prepare_environment
 	-$(foreach test,$(EXTENDED_TESTS_LONG),$(call execute_test,$(test));)
 
 .PHONY: integ_test
-integ_test: precommit precommit_tests_noncontainer extended_tests extended_tests_noncontainer extended_tests_long
+integ_test: precommit extended_tests extended_tests_long
 
 .PHONY: integ_test_containerized
 integ_test_containerized: precommit extended_tests extended_tests_long

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -119,13 +119,7 @@ s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
 s1aptests/test_attach_detach_setsessionrules_tcp_data.py \
-s1aptests/test_attach_detach_with_non_nat_dhcp.py
-
-PRECOMMIT_TESTS_IPV6 = \
-s1aptests/test_enable_ipv6_iface.py \
-s1aptests/test_disable_ipv6_iface.py
-
-PRECOMMIT_TESTS_NOT_CONTAINER = \
+s1aptests/test_attach_detach_with_non_nat_dhcp.py \
 s1aptests/test_attach_detach_attach_dl_tcp_data.py \
 s1aptests/test_attach_detach_attach_ul_tcp_data.py \
 s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
@@ -137,7 +131,9 @@ s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_gateway_metrics_attach_detach.py \
-s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
+s1aptests/test_service_req_ul_udp_data_with_mme_restart.py \
+s1aptests/test_enable_ipv6_iface.py \
+s1aptests/test_disable_ipv6_iface.py
 
 EXTENDED_TESTS = s1aptests/test_modify_mme_config_for_sanity.py \
 s1aptests/test_attach_detach_flaky_retry_success.py \
@@ -176,9 +172,6 @@ s1aptests/test_tau_mixed_partial_lists.py \
 s1aptests/test_eps_bearer_context_status_multiple_ded_bearer_deact.py \
 s1aptests/test_guti_attach_with_zero_mtmsi.py \
 s1aptests/test_ics_timer_expiry_with_mme_restart.py \
-s1aptests/test_restore_mme_config_after_sanity.py
-
-EXTENDED_TESTS_NOT_CONTAINER = s1aptests/test_modify_mme_config_for_sanity.py \
 s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py \
 s1aptests/test_3485_timer_for_dedicated_bearer_with_mme_restart.py \
 s1aptests/test_attach_detach_rar_tcp_data.py \


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This change executes all remaining precommit and extended tests vs a dockerized agw environment.

Closes #14124

## Test Plan

Executed locally multiple times (before adding the changes!)
```
~/magma/lte/gateway/python/integ_tests$ make precommit_tests_noncontainer
~/magma/lte/gateway/python/integ_tests$ make extended_tests_noncontainer
```
vs an environment setup by https://github.com/magma/magma/tree/master/lte/gateway/docker.
The runs were sufficiently green - yes, there were flaky runs locally, but successful runs were the absolute majority. I would recommend to land this PR anyway in order to have flaky runs better visible in order to track and tackle them in issues.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
