### PR TITLE
fix: duplicated test log upload step is removed

### DIFF
--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -101,13 +101,6 @@ jobs:
           name: test-logs
           path: lte/gateway/logs.tar.gz
 
-      - name: Upload test logs
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: always()
-        with:
-          name: test-logs
-          path: lte/gateway/logs.tar.gz
-
       - name: Publish results to Firebase
         if: always() && github.event_name == 'repository_dispatch'
         env:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Small change to remove a duplicated step in the bazel debian integ tests - this had, as it seems, no negative effect, i.e., this is only clean-up.

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
