### PR TITLE
chore: integ tests always wait for pipelined

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -96,7 +96,6 @@ class S1ApUtil(object):
     MAX_RESP_WAIT_TIME = 180
 
     MAX_NUM_RETRIES = 5
-    datapath = get_datapath()
     SPGW_TABLE = 0
     LOCAL_PORT = "LOCAL"
     LOCAL_PORT_NON_NAT_IPV6 = 2
@@ -126,6 +125,8 @@ class S1ApUtil(object):
         """
         Initialize the s1aplibrary and its callbacks.
         """
+        self.datapath = get_datapath()
+
         # Clear the message queue to delete already stored response messages
         S1ApUtil._msg.queue.clear()
         self._imsi_idx = 1
@@ -1696,6 +1697,18 @@ class MagmadUtil(object):
 
         self.restart_services(['sctpd'], wait_time=30)
         self.restart_magma_services()
+
+    def is_nat_enabled(self):
+        mconfig_conf = (
+            "/home/vagrant/magma/lte/gateway/configs/gateway.mconfig"
+        )
+        with open(mconfig_conf, "r") as json_file:
+            data = json.load(json_file)
+
+        in_mme_enabled = data["configs_by_key"]["mme"]["natEnabled"] == True
+        in_pipelined_enabled = data["configs_by_key"]["pipelined"]["natEnabled"] == True
+
+        return in_mme_enabled and in_pipelined_enabled
 
     def _validate_non_nat_datapath(self, ip_version: int = 4):
         # validate SGi interface is part of uplink-bridge.

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -80,9 +80,6 @@ class TestWrapper(object):
             "[Start time: " + str(current_time) + "]",
         )
 
-        self._s1_util = S1ApUtil()
-        self._enBConfig(ip_version)
-
         federated_mode = (os.environ.get("FEDERATED_MODE") == "True")
         print(
             f"\n *** Running the test in {'Non-' if not federated_mode else ''}"
@@ -110,6 +107,15 @@ class TestWrapper(object):
         self._magmad_util.config_stateless(stateless_mode)
         self._magmad_util.config_apn_correction(apn_correction)
         self._magmad_util.config_health_service(health_service)
+
+        if not self._magmad_util.is_nat_enabled():
+            self._magmad_util.enable_nat()
+
+        self._magmad_util._wait_for_pipelined_to_initialize()
+
+        self._s1_util = S1ApUtil()  # calls get_datapath, i.e., should run after we ensured pipelined is started
+        self._enBConfig(ip_version)
+
         # gateway tests don't require restart, just wait for healthy now
         self._gateway_services = GatewayServicesUtil()
         if not self.wait_gateway_healthy:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This change tries to tackle multiple issues. The main idea is to not fetch the current datapath during static initialization of the s1ap_utils, but in the constructor when an object is created.

### Tackling #14068

* Moving get_dapatath to the constructor of the s1ap_utils makes it possible to wait (before the s1ap_utils are initialized) for pipelined to actually initialize a datapath
* this should mitigate issues described in #14068
* for this the initialization of the s1ap_utils needs to be moved after the magmad_util is initialized (holds the functionality to wait for the start of pipelined)

### Working towards enabling again an ipv6 tests that was disable in #14682

* With the s1ap_utils initalization moved after initializing magmad_util we can check if nat is not enabled - and enabling it in this case (this can happen if a test that run with disabled nat failed with an error that prevents the re-enabling of nat in the teardown).
* If a test with disabled nat tries to call pipelined, then we see 6h workflow timeouts in ci.

### Tackling #14699

* This is basically the main issue that tracks the two issues above.

### Failures in re-runs of tests that re-initialize the datapath

* I have not seen this problem in recent logs - but iirc then we have seen issues where the current datapath id was not the expected id
* hypothesis: a test fails and the datapath is re-initialized - but the s1ap_util does not fetch the id again (because this happens during the static initialization)
* moving the datapath id fetch to the constructor should help with this issue

## Test Plan

executed precommit and extended tests locally

## Additional Information

Closes #14699
Closes #14068

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
