### PR TITLE
feat(ci): add default values to containerized LTE integ tests

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -67,8 +67,8 @@ jobs:
 
       - name: verify registry output
         run: |
-          echo Registry is ${{ steps.set-registry.outputs.registry }}
-          echo Image prefix is ${{ steps.set-registry.outputs.image_prefix }}
+          echo "Registry is ${{ steps.set-registry.outputs.registry }}"
+          echo "Image prefix is ${{ steps.set-registry.outputs.image_prefix }}"
 
       - id: get-short-git-sha
         name: Set short git sha output
@@ -77,7 +77,7 @@ jobs:
           echo commit_hash=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT
 
       - name: verify git sha output
-        run: echo git sha is ${{ steps.get-short-git-sha.outputs.commit_hash }}
+        run: echo "Git SHA is ${{ steps.get-short-git-sha.outputs.commit_hash }}"
 
       - name: Set agwc tags
         id: set-agwc-tags
@@ -155,8 +155,8 @@ jobs:
 
       - name: verify registry output
         run: |
-          echo Registry is ${{ steps.set-registry.outputs.registry }}
-          echo Image prefix is ${{ steps.set-registry.outputs.image_prefix }}
+          echo "Registry is ${{ steps.set-registry.outputs.registry }}"
+          echo "Image prefix is ${{ steps.set-registry.outputs.image_prefix }}"
 
       - id: get-short-git-sha
         run: echo commit_hash=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -9,6 +9,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This workflow utilizes a composite action and a second workflow to build
+# and test containers in CI
+#
+# - The 'build-containers' job sets the first eight digits of the commit hash
+#   (plus 'latest') as a image tag and calls the 'docker-builder-agw.yml'
+#   workflow for the C, Python, and go images.
+# - The three containers are built and uploaded with the 3rd party
+#   'docker/build-push-action' using their respective docker file, the tags,
+#   and the artifactory credentials.
+# - The 'lte-integ-test-containerized.yml' is executed for the 'precommit',
+#   'extended', and 'extended_long' test targets. These run in parallel and use
+#   the 8-char commit hash as a tag to pull the newly created Docker images
+#   from the artifactory to test them. Each returns their test reports and
+#   individual final status.
+# - The 'publish-container-test-results' job collects the results and uploads
+#   them with a combined pass/fail verdict to Firebase.
+
+
 name: AGW Build, Publish & Test Container
 
 on:

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -31,9 +31,7 @@ jobs:
 
   build-containers:
     outputs:
-      digest_c: ${{ steps.docker-builder-c.outputs.digest }}
-      digest_python: ${{ steps.docker-builder-python.outputs.digest }}
-      digest_go: ${{ steps.docker-builder-go.outputs.digest }}
+      image_tag: ${{ steps.get-short-git-sha.outputs.commit_hash }}
       registry: ${{ steps.set-registry.outputs.registry }}
     runs-on: ubuntu-20.04
     steps:
@@ -58,10 +56,10 @@ jobs:
         name: Set short git sha output
         run: |
           echo ${GITHUB_SHA:0:8}
-          echo sha=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT
+          echo commit_hash=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT
 
       - name: verify git sha output
-        run: echo git sha is ${{ steps.get-short-git-sha.outputs.sha }}
+        run: echo git sha is ${{ steps.get-short-git-sha.outputs.commit_hash }}
 
       - name: Set agwc tags
         id: set-agwc-tags
@@ -70,7 +68,7 @@ jobs:
           python_image=${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_python
           go_image=${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}gateway_go
 
-          commit_hash=${{ steps.get-short-git-sha.outputs.sha }}
+          commit_hash=${{ steps.get-short-git-sha.outputs.commit_hash }}
           if [[ ${{ github.ref_name }} = master ]]
           then
             echo c_image_tags=${c_image}:${commit_hash},${c_image}:latest >> $GITHUB_OUTPUT
@@ -97,7 +95,6 @@ jobs:
           FILE: lte/gateway/docker/services/c/Dockerfile
           TAGS: ${{ steps.set-agwc-tags.outputs.c_image_tags }}
           TARGET: gateway_c
-      - run: echo "C container image digest is ${{ steps.docker-builder-c.outputs.digest }}"
       - run: echo "docker-builder-c conclusion = ${{ steps.docker-builder-c.conclusion }}"
 
       - uses: ./.github/workflows/composite/docker-builder-agw
@@ -109,7 +106,6 @@ jobs:
           FILE: lte/gateway/docker/services/python/Dockerfile
           TAGS: ${{ steps.set-agwc-tags.outputs.python_image_tags }}
           TARGET: gateway_python
-      - run: echo "Python container image digest is ${{ steps.docker-builder-python.outputs.digest }}"
       - run: echo "docker-builder-python conclusion = ${{ steps.docker-builder-python.conclusion }}"
 
       - uses: ./.github/workflows/composite/docker-builder-agw
@@ -121,7 +117,6 @@ jobs:
           FILE: feg/gateway/docker/go/Dockerfile
           TAGS: ${{ steps.set-agwc-tags.outputs.go_image_tags }}
           TARGET: gateway_go
-      - run: echo "Go container image digest is ${{ steps.docker-builder-go.outputs.digest }}"
       - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
 
   build-containers-ghz:
@@ -146,14 +141,14 @@ jobs:
           echo Image prefix is ${{ steps.set-registry.outputs.image_prefix }}
 
       - id: get-short-git-sha
-        run: echo sha=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT
+        run: echo commit_hash=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT
 
       - uses: ./.github/workflows/composite/docker-builder-agw
         with:
           REGISTRY_USERNAME: ${{ secrets.LF_JFROG_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
           REGISTRY: ${{ env.registry }}
-          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_c:${{ steps.get-short-git-sha.outputs.sha }}
+          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_c:${{ steps.get-short-git-sha.outputs.commit_hash }}
           TARGET: agw_c_ghz
           CONTEXT: lte/gateway/docker/ghz
 
@@ -162,7 +157,7 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.LF_JFROG_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
           REGISTRY: ${{ env.registry }}
-          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_python:${{ steps.get-short-git-sha.outputs.sha }}
+          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_python:${{ steps.get-short-git-sha.outputs.commit_hash }}
           TARGET: agw_python_ghz
           CONTEXT: lte/gateway/docker/ghz
 
@@ -173,9 +168,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/lte-integ-test-containerized.yml
     with:
-      digest_c: ${{ needs.build-containers.outputs.digest_c }}
-      digest_python: ${{ needs.build-containers.outputs.digest_python }}
-      digest_go: ${{ needs.build-containers.outputs.digest_go }}
+      image_tag: ${{ needs.build-containers.outputs.image_tag }}
       registry: ${{ needs.build-containers.outputs.registry }}
       test_targets: precommit
     secrets: inherit
@@ -187,9 +180,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/lte-integ-test-containerized.yml
     with:
-      digest_c: ${{ needs.build-containers.outputs.digest_c }}
-      digest_python: ${{ needs.build-containers.outputs.digest_python }}
-      digest_go: ${{ needs.build-containers.outputs.digest_go }}
+      image_tag: ${{ needs.build-containers.outputs.image_tag }}
       registry: ${{ needs.build-containers.outputs.registry }}
       test_targets: extended_tests
     secrets: inherit
@@ -201,9 +192,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/lte-integ-test-containerized.yml
     with:
-      digest_c: ${{ needs.build-containers.outputs.digest_c }}
-      digest_python: ${{ needs.build-containers.outputs.digest_python }}
-      digest_go: ${{ needs.build-containers.outputs.digest_go }}
+      image_tag: ${{ needs.build-containers.outputs.image_tag }}
       registry: ${{ needs.build-containers.outputs.registry }}
       test_targets: extended_tests_long
     secrets: inherit

--- a/.github/workflows/composite/docker-builder-agw/action.yml
+++ b/.github/workflows/composite/docker-builder-agw/action.yml
@@ -37,11 +37,6 @@ inputs:
     description: Docker context
     default: .
 
-outputs:
-  digest:
-    description: Docker image digest
-    value: ${{ steps.build-docker.outputs.digest }}
-
 runs:
   using: composite
   steps:

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -14,17 +14,13 @@ name: AGW Test LTE Integration With Make Containerized Build
 on:
   workflow_dispatch:
     inputs:
-      digest_c:
+      image_tag:
         type: string
-        required: true
-      digest_python:
-        type: string
-        required: true
-      digest_go:
-        type: string
+        default: 'latest'
         required: true
       registry:
         type: string
+        default: 'linuxfoundation.jfrog.io/magma-docker-agw-test'
         required: true
       test_targets:
         type: choice
@@ -32,13 +28,7 @@ on:
         required: true
   workflow_call:
     inputs:
-      digest_c:
-        type: string
-        required: true
-      digest_python:
-        type: string
-        required: true
-      digest_go:
+      image_tag:
         type: string
         required: true
       registry:
@@ -54,11 +44,9 @@ jobs:
     steps:
       - name: Show inputs
         run: |
-          echo Docker image digest C      ${{ inputs.digest_c }}
-          echo Docker image digest Python ${{ inputs.digest_python }}
-          echo Docker image digest Go     ${{ inputs.digest_go }}
-          echo Docker registry            ${{ inputs.registry }}
-          echo test targets               ${{ inputs.test_targets }}
+          echo Docker image tag ${{ inputs.image_tag }}
+          echo Docker registry  ${{ inputs.registry }}
+          echo test targets     ${{ inputs.test_targets }}
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - id: set-registry
         name: Set registry and image_prefix
@@ -69,12 +57,12 @@ jobs:
           then
             echo image_prefix=${{ secrets.LF_JFROG_USERNAME }}/ >> $GITHUB_OUTPUT  # dockerhub image URLs have the form docker.io/<username>/image
           fi
-      - name: Write image digest to docker-compose.yaml
+      - name: Write image tag to docker-compose.yaml
         working-directory: lte/gateway/docker
         run: |
-          sed -i '' "s#image:.*gateway_c.*#image: ${{ inputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_c@${{ inputs.digest_c }}#" docker-compose.yaml
-          sed -i '' "s#image:.*gateway_python.*#image: ${{ inputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_python@${{ inputs.digest_python }}#" docker-compose.yaml
-          sed -i '' "s#image:.*gateway_go.*#image: ${{ inputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}gateway_go@${{ inputs.digest_go }}#" docker-compose.yaml
+          sed -i '' "s#image:.*gateway_c.*#image: ${{ inputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_c:${{ inputs.image_tag }}#" docker-compose.yaml
+          sed -i '' "s#image:.*gateway_python.*#image: ${{ inputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_python:${{ inputs.image_tag }}#" docker-compose.yaml
+          sed -i '' "s#image:.*gateway_go.*#image: ${{ inputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}gateway_go:${{ inputs.image_tag }}#" docker-compose.yaml
       - name: Show docker-compose yaml to verify correct docker images hashes
         run: cat lte/gateway/docker/docker-compose.yaml
       - name: Cache magma-dev-box

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -44,14 +44,13 @@ jobs:
     steps:
       - name: Show inputs
         run: |
-          echo Docker image tag ${{ inputs.image_tag }}
-          echo Docker registry  ${{ inputs.registry }}
-          echo test targets     ${{ inputs.test_targets }}
+          echo "Docker image tag ${{ inputs.image_tag }}"
+          echo "Docker registry ${{ inputs.registry }}"
+          echo "Test targets ${{ inputs.test_targets }}"
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - id: set-registry
         name: Set registry and image_prefix
         run: |
-          echo ${{ inputs.registry }}
           echo registry=${{ inputs.registry }} >> $GITHUB_OUTPUT
           if [ ${{ inputs.registry }} = docker.io ]
           then


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Instead of container digests, we select containers with their name (which consists of the corresponding 8-char commit hash / latest tag) to run containerized integ tests with. While this does not matter in CI, it improves the interface for manually executing these tests since we now provide default values for containers and registry.
Closes #14798.

## Test Plan

- [Containerized integ test](https://github.com/mpfirrmann/magma/actions/runs/3872399422/) with default (=`latest`) parameters

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
