### PR TITLE
chore(ci): Mitigate flakiness of inout_non_nat test

### DIFF
--- a/lte/gateway/python/magma/pipelined/gw_mac_address.py
+++ b/lte/gateway/python/magma/pipelined/gw_mac_address.py
@@ -180,7 +180,7 @@ def _send_packet_and_receive_response(pkt: dpkt.arp.ARP, vlan: str, non_nat_arp_
     packet_aux_data = 8
     with socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(0x0003)) as s:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, buffsize)
-        s.settimeout(2)
+        s.settimeout(10)
         if vlan.isdigit():
             s.setsockopt(sol_packet, packet_aux_data, 1)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, 1)


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #14790

## Test Plan

- Ran test many times
  - The error mentioned in the issue does not occur anymore.
  - 80-90% successful, other errors can occur. 

Some test runs:
- https://github.com/LKreutzer/magma/actions/runs/3874994928
- https://github.com/LKreutzer/magma/actions/runs/3874996897
- https://github.com/LKreutzer/magma/actions/runs/3874997640
- https://github.com/LKreutzer/magma/actions/runs/3874999425


## Additional Information

Follow up: https://github.com/magma/magma/issues/14818

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
