### PR TITLE
chore: Do not use MAGMA_ROOT in Starlark format script

### DIFF
--- a/.devcontainer/bazel-base/README.md
+++ b/.devcontainer/bazel-base/README.md
@@ -46,5 +46,6 @@ bazel test ...
 To format all bazel related files run the following
 
 ```bash
-$MAGMA_ROOT/bazel/scripts/run_buildifier.sh format
+cd $MAGMA_ROOT
+./bazel/scripts/run_buildifier.sh format
 ```

--- a/bazel/scripts/run_buildifier.sh
+++ b/bazel/scripts/run_buildifier.sh
@@ -54,14 +54,8 @@ else
     echo "Download successful."
 fi
 
-if [[ -z "${MAGMA_ROOT:-}" ]];
-then
-  echo "Warning: 'MAGMA_ROOT' is not set, defaulting to current directory."
-  echo "This script should be run from the base of the magma repository."
-  WORKING_DIR="./"
-else
-  WORKING_DIR="$MAGMA_ROOT"
-fi
+WORKING_DIR="./"
+echo "Info: Only the subfolders of the current directory are checked or formatted."
 
 echo "Running bazel buildifier with the following command:"
 set -x

--- a/docs/readmes/lte/dev_unit_testing.md
+++ b/docs/readmes/lte/dev_unit_testing.md
@@ -140,5 +140,6 @@ To use the script, run
 To format all Bazel related files, run
 
 ```bash
-$MAGMA_ROOT/bazel/scripts/run_buildifier.sh format
+cd $MAGMA_ROOT
+./bazel/scripts/run_buildifier.sh format
 ```


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #14793
- Do not use  `MAGMA_ROOT` in Starlark format script
  - Format check is always run in current directory.
  - Can still be run on host system.
  - Avoids issues with Git worktrees.

## Test Plan

- Run locally with 
  - `./bazel/scripts/run_buildifier.sh check`
  - `./bazel/scripts/run_buildifier.sh format`
- CI job: Skipped since the path filter is not triggered. But current runs already do not use `MAGMA_ROOT` in CI, because no Docker container is used for this job. [Manual workflow run](https://github.com/LKreutzer/magma/actions/runs/3875448858/jobs/6608005754).

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
