### PR TITLE
chore: envoy service is started for containerized integ tests

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -457,6 +457,8 @@ def _start_gateway_containerized():
     with cd(AGW_ROOT):
         run('for component in redis nghttpx td-agent-bit; do cp "${MAGMA_ROOT}"/{orc8r,lte}/gateway/configs/templates/${component}.conf.template; done')
 
+    run('sudo systemctl start magma_dp@envoy')
+
     with cd(AGW_ROOT + "/docker"):
         # The `docker compose up` times are machine dependent, such that a retry is needed here for resilience.
         run_with_retry('DOCKER_REGISTRY=%s docker compose -f docker-compose.yaml up -d --quiet-pull' % (env.DOCKER_REGISTRY))


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Approach to fix extended tests added in #14808. We see failing he tests while getting the envoy config - e.g., https://github.com/magma/magma/runs/10576007895.

In the documentation for a local setup `magma_dp@envoy` is started - this is not happening in CI. (see [here](https://github.com/magma/magma/blob/f06d1225e39b00e409d61079579d1650b1381774/lte/gateway/docker/README.md#running-the-containerized-agw-locally-on-the-magma-vm))

Approach here: start `magma_dp@envoy` for CI runs

## Test Plan

run extended tests on fork - three consecutive green runs:
* https://github.com/nstng/magma/actions/runs/3893572071
* https://github.com/nstng/magma/actions/runs/3900680015
* https://github.com/nstng/magma/actions/runs/3900678995

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
