### PR TITLE
chore: simplify codeowner structure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,65 +1,45 @@
-# approvers-ci
-/ci-scripts/ @magma/approvers-ci
-/.github/workflows/ @magma/approvers-ci
-/third_party/build/ @magma/approvers-ci
-/orc8r/tools/packer/ @magma/approvers-ci
-/orc8r/cloud/deploy/bare-metal/ @magma/approvers-ci
-/orc8r/cloud/deploy/bare-metal-ansible/ @magma/approvers-ci
-/lte/gateway/release @magma/approvers-ci
-/lte/gateway/Vagrantfile @magma/approvers-ci
-/cwf/gateway/Vagrantfile @magma/approvers-ci
+# approvers-infra
+/.github/workflows/ @magma/approvers-infra
+/ci-scripts/ @magma/approvers-infra
+/cwf/gateway/Vagrantfile @magma/approvers-infra
+/lte/gateway/release @magma/approvers-infra
+/lte/gateway/Vagrantfile @magma/approvers-infra
+/lte/gateway/docker @magma/approvers-infra
+/lte/gateway/python/integ_tests @magma/approvers-infra
+/orc8r/tools/packer/ @magma/approvers-infra
+/orc8r/cloud/deploy/bare-metal/ @magma/approvers-infra
+/orc8r/cloud/deploy/bare-metal-ansible/ @magma/approvers-infra
+/third_party/build/ @magma/approvers-infra
+#  docs
+/docs/ @magma/approvers-infra
+#  bazel related
+/.bazel-cache/ @magma/approvers-infra
+/.bazel-cache-repo/ @magma/approvers-infra
+/.github/workflows/bazel.yml @magma/approvers-infra
+/bazel/ @magma/approvers-infra
+/.bazelignore @magma/approvers-infra
+/.bazelrc @magma/approvers-infra
+*.bazel @magma/approvers-infra
 
-# approvers-orc8r
-*/cloud/ @magma/approvers-orc8r
-/.golangci.yml @magma/approvers-orc8r
-/orc8r/ @magma/approvers-orc8r
+# approvers-cloud
+*/cloud/ @magma/approvers-cloud
+/.golangci.yml @magma/approvers-cloud
+/dp/ @magma/approvers-cloud
+/nms/ @magma/approvers-cloud
+/orc8r/ @magma/approvers-cloud
 
-# approvers-nms
-/nms/ @magma/approvers-nms
-
-# approvers-feg
-/feg/ @magma/approvers-feg
-
-# approvers-cwf
-/cwf/ @magma/approvers-cwf
-/openwrt/ @magma/approvers-cwf
-/feg/radius @magma/approvers-cwf
-
-# approvers-agw
-/lte/gateway @magma/approvers-agw
-/lte/protos @magma/approvers-agw
-/lte/gateway/python @magma/approvers-agw
-/lte/gateway/c @magma/approvers-agw
-/show-tech/ @magma/approvers-agw
+# approvers-gw
+/cwf/ @magma/approvers-gw
+/feg/ @magma/approvers-gw
+/lte/gateway @magma/approvers-gw
+/lte/protos @magma/approvers-gw
+/openwrt/ @magma/approvers-gw
+/orc8r/gateway/c/ @magma/approvers-gw
+/show-tech/ @magma/approvers-gw
+/third_party/gtp_ovs @magma/approvers-gw
 
 # agw code related to orc8r
-/orc8r/gateway/c/ @magma/approvers-agw
-/orc8r/gateway/python @magma/approvers-agw @magma/approvers-orc8r
-
-# approvers-agw-<subsection>
-/lte/gateway/c/core/oai @magma/approvers-agw-mme
-/lte/gateway/c/sctpd @magma/approvers-agw-mme
-/lte/gateway/python/integ_tests @magma/approvers-agw-integtests
-/lte/gateway/docker @magma/approvers-agw-containers @magma/approvers-ci
-
-# approvers-agw-pipelined
-/lte/gateway/python/magma/pipelined @magma/approvers-agw-pipelined
-/third_party/gtp_ovs @magma/approvers-agw-pipelined
-
-# approvers-docs
-/docs/ @magma/approvers-docs
-
-# approvers-domain-proxy
-/dp/ @magma/approvers-domain-proxy
-
-# approvers-bazel
-/.bazel-cache/ @magma/approvers-bazel
-/.bazel-cache-repo/ @magma/approvers-bazel
-/.github/workflows/bazel.yml @magma/approvers-bazel
-/bazel/ @magma/approvers-bazel
-/.bazelignore @magma/approvers-bazel
-/.bazelrc @magma/approvers-bazel
-*.bazel @magma/approvers-bazel
+/orc8r/gateway/python @magma/approvers-gw @magma/approvers-cloud
 
 # approvers-tsc
 /CODEOWNERS @magma/approvers-tsc

--- a/docs/readmes/contributing/contribute_codeowners.md
+++ b/docs/readmes/contributing/contribute_codeowners.md
@@ -74,4 +74,4 @@ This is still high-risk and should be used with extreme care. One potential exam
 
 For high-priority work: if the PR author is a codeowner for the code they changed, and all other codeowners for that part of the codebase are OOO ("out of office") for an extended period, the codeowner can request a force-merge once all CI checks have passed.
 
-This guideline circumvents the quirk that a PR author can't approve their own PR, even if they are a codeowner for part of the PR's changes. The author *must* be a codeowner, and *must* share permissions with the OOO codeowner (e.g. they're both on the `orc8r-approvers` codeowner team).
+This guideline circumvents the quirk that a PR author can't approve their own PR, even if they are a codeowner for part of the PR's changes. The author *must* be a codeowner, and *must* share permissions with the OOO codeowner (e.g. they're both on the `approvers-gw` codeowner team).


### PR DESCRIPTION

## Summary

This change implements the code changes needed for #14822.

The diff in the CODEOWNERS file might be hard to read - what I did?
1. exchange the legacy groups by the groups specified in #14822
2. sort entries by new codeowner groups
3. sort cluster alphabetically
4. remove obsolete entries, e.g., before we had `/lte/gateway @magma/approvers-agw` and `/lte/gateway/c/core/oai @magma/approvers-agw-mme` which are now both handled by `@magma/approvers-gw` -> `/lte/gateway/c/core/oai @magma/approvers-gw` is already covered by `/lte/gateway @magma/approvers-gw`.

Closes #14822

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
