### PR TITLE
chore: vagrant up magma* VMs failures in CI are mitigated by retry

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -273,10 +273,10 @@ def provision_magma_dev_vm(
         ansible_setup(gateway_host, "dev", "magma_dev.yml")
 
 
-def _setup_vm(c, host, name, ansible_role, ansible_file, destroy_vm, provision_vm):
+def _setup_vm(c, host, name, ansible_role, ansible_file, destroy_vm, provision_vm, max_retries=1):
     if not host:
         connection, host_data = vagrant_setup(
-            c, name, destroy_vm, force_provision=provision_vm,
+            c, name, destroy_vm, force_provision=provision_vm, max_retries=max_retries,
         )
     else:
         ansible_setup(host, ansible_role, ansible_file)
@@ -289,11 +289,11 @@ def _setup_vm(c, host, name, ansible_role, ansible_file, destroy_vm, provision_v
 
 def _setup_gateway(
         c, gateway_host, name, ansible_role, ansible_file, destroy_vm,
-        provision_vm,
+        provision_vm, max_retries=1,
 ):
     gateway_connection, _ = _setup_vm(
         c, gateway_host, name, ansible_role, ansible_file, destroy_vm,
-        provision_vm,
+        provision_vm, max_retries=max_retries,
     )
     if gateway_host is None:
         gateway_ip = GATEWAY_IP_ADDRESS
@@ -387,7 +387,7 @@ def integ_test_deb_installation(
     # vagrant machine
     c_gw, gateway_ip = _setup_gateway(
         c, gateway_host, "magma_deb", "deb", "magma_deb.yml", destroy_vm,
-        provision_vm,
+        provision_vm, max_retries=3,
     )
     with c_gw:
         _start_gateway(c_gw)
@@ -405,7 +405,7 @@ def integ_test_deb_installation(
     # the vagrant machine
     c_test, test_host_data = _setup_vm(
         c, test_host, "magma_test", "test", "magma_test.yml", destroy_vm,
-        provision_vm,
+        provision_vm, max_retries=3,
     )
 
     # run this on the host, not on the vm, as it will connect to the vm via ssh
@@ -437,7 +437,7 @@ def integ_test_containerized(
     # vagrant machine
     c_trf, _ = _setup_vm(
         c, trf_host, "magma_trfserver", "trfserver", "magma_trfserver.yml",
-        destroy_vm, provision_vm,
+        destroy_vm, provision_vm, max_retries=3,
     )
     with c_trf:
         _start_trfserver(c_trf)

--- a/orc8r/tools/fab/hosts.py
+++ b/orc8r/tools/fab/hosts.py
@@ -18,11 +18,16 @@ from tools.fab import vagrant
 
 def split_hoststring(hoststring: str) -> Tuple[str, str, str]:
     """
-    Splits a host string into its user, hostname, and port components
-
+    Split a host string into its user, hostname, and port components
     e.g. 'vagrant@localhost:22' -> ('vagrant', 'localhost', '22')
+
+    Parameters:
+        hoststring: The host string of the target host
+
+    Returns:
+        user, ip, port derived from the hoststring
     """
-    user = hoststring[0:hoststring.find('@')]
+    user = hoststring[:hoststring.find('@')]
     ip = hoststring[hoststring.find('@') + 1:hoststring.find(':')]
     port = hoststring[hoststring.find(':') + 1:]
     return user, ip, port
@@ -32,6 +37,18 @@ def vagrant_connection(
     c: Connection, host: str, destroy_vm: bool = False,
     force_provision: bool = False,
 ) -> Connection:
+    """
+    Set up a VM and return the connection context.
+
+    Parameters:
+        c: The connection context for execution
+        host: The Vagrant box to setup, e.g. "magma"
+        destroy_vm : Whether the VM should be destroyed if already running
+        force_provision: Whether provisioning should be forced
+
+    Returns:
+        Connection: Connection context of the configured VM
+    """
     conn, _ = vagrant_setup(c, host, destroy_vm, force_provision)
     return conn
 
@@ -41,9 +58,17 @@ def vagrant_setup(
         force_provision: bool = False, max_retries: int = 1,
 ) -> Tuple[Connection, Dict[str, str]]:
     """
-    Setup the specified vagrant box
+    Set up the specified vagrant box
 
-    host: the Vagrant box to setup, e.g. "magma"
+    Parameters:
+        c: The connection context for execution
+        host: The Vagrant box to setup, e.g. "magma"
+        destroy_vm: Whether the VM should be destroyed if already running
+        force_provision: Whether provisioning should be forced
+        max_retries: Max attempts to setup machine
+
+    Returns:
+        Connection to the set up vm and meta information
     """
     if destroy_vm:
         vagrant.teardown_vagrant(c, host)
@@ -55,19 +80,18 @@ def ansible_setup(
     preburn='false', full_provision='true',
 ):
     """
-    Setup the specified ansible machine
+    Set up the specified ansible machine
 
-    hoststr: the host string of the target host
-             e.g. vagrant@192.168.60.10:22
-
-    ansible_group: The group the deploy targets
-             e.g. "dev"
-
-    preburn: 'true' to run preburn tasks, 'false' to skip them.
-             Defaults to 'false'
-
-    full_provision: 'true' to run post-preburn tasks, 'false' to skip them.
-                    Defaults to 'true'
+    Parameters:
+        hoststr: The host string of the target host
+            e.g. vagrant@192.168.60.10:22
+        playbook: The Ansible playbook to be used for provisioning
+        ansible_group: The group the deploy targets
+            e.g. "dev"
+        preburn: 'true' to run preburn tasks, 'false' to skip them.
+            Defaults to 'false'
+        full_provision: 'true' to run post-preburn tasks, 'false' to skip them.
+            Defaults to 'true'
     """
     # Provision the gateway host
     (user, ip, port) = split_hoststring(hoststr)

--- a/orc8r/tools/fab/hosts.py
+++ b/orc8r/tools/fab/hosts.py
@@ -38,7 +38,7 @@ def vagrant_connection(
 
 def vagrant_setup(
         c: Connection, host: str, destroy_vm: bool = False,
-        force_provision: bool = False,
+        force_provision: bool = False, max_retries: int = 1,
 ) -> Tuple[Connection, Dict[str, str]]:
     """
     Setup the specified vagrant box
@@ -47,7 +47,7 @@ def vagrant_setup(
     """
     if destroy_vm:
         vagrant.teardown_vagrant(c, host)
-    return vagrant.setup_env_vagrant(c, host, force_provision=force_provision)
+    return vagrant.setup_env_vagrant(c, host, force_provision=force_provision, max_retries=max_retries)
 
 
 def ansible_setup(

--- a/orc8r/tools/fab/vagrant.py
+++ b/orc8r/tools/fab/vagrant.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import os
-import os.path
 from typing import Dict, Tuple
 
 from fabric import Connection
@@ -28,7 +27,6 @@ def _ensure_in_vagrant_dir(c: Connection) -> None:
         if ret_code != 0:
             print("Error: Vagrantfile not found or not valid")
             exit(ret_code)
-    return
 
 
 def setup_env_vagrant(
@@ -39,6 +37,15 @@ def setup_env_vagrant(
 
     Sets the environment to point at the local vagrant machine. Used
     whenever we need to run commands on the vagrant machine.
+
+    Parameters:
+        c: The connection context for execution
+        machine: The machine that should be setup
+        force_provision: Whether provisioning should be done
+        max_retries: Max attempts to setup machine
+
+    Returns:
+        Connection to the set up vm and meta information
     """
     _ensure_in_vagrant_dir(c)
 
@@ -54,9 +61,10 @@ def setup_env_vagrant(
     ssh_config = c.run(f'vagrant ssh-config {machine}', hide=True).stdout.strip()
 
     ssh_lines = [line.strip() for line in ssh_config.split("\n")]
+    ssh_key_val = [line.split(" ", 1) for line in ssh_lines]
     ssh_params = {
-        key: val for key, val
-        in [line.split(" ", 1) for line in ssh_lines]
+        key: val
+        for key, val in ssh_key_val
     }
 
     host = ssh_params.get("HostName", "").strip()
@@ -80,11 +88,12 @@ def _is_vm_running(c: Connection, machine: str):
 def _vagrant_up_with_retry(c: Connection, machine: str, max_retries: int):
     print(f'VM {machine} is not running - attempting to bring it up ...')
     for attempt in range(max_retries):
-        print(f'... attempt {attempt + 1}/{max_retries} to bring up VM {machine}')
+        inc_attempt = attempt + 1
+        print(f'... attempt {inc_attempt}/{max_retries} to bring up VM {machine}')
 
         try:
             c.run(f'vagrant up {machine}')
-        except:
+        except Exception:
             print(f'... VM {machine} failed during "vagrant up" - VM will be destroyed')
             teardown_vagrant(c, machine)
 
@@ -98,8 +107,12 @@ def _vagrant_up_with_retry(c: Connection, machine: str, max_retries: int):
 
 
 def teardown_vagrant(c: Connection, machine: str) -> None:
-    """ Destroy a vagrant machine so that we get a clean environment to work
-        in
+    """
+    Destroy a vagrant machine so that we get a clean environment to work in.
+
+    Parameters:
+        c: The connection context for execution
+        machine: The machine to be destroyed
     """
     _ensure_in_vagrant_dir(c)
 


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

Closes #14829

Approach here: try a configurable number of times to provision a VM via fabric. For now, use this only for the debian artifact integration tests with three re-tries.

Note: this approach does **not** distinguish between the failure described in #14829 or lets say, a failed provisioning. This is, the re-try can also happen in other cases. Imo this is ok, and might be even helpful for now.

Note: fixed wemake styleguide failures in touched files - but not in `lte/gateway/fabfile.py` as this file is currently refactored in a different PR.

## Test Plan

Reproduced locally - we see that magma_test encountered the failure from #14829 and was successful in the second try (provisioning was disabled).
```
~/magma/lte/gateway$ fab my_test
[localhost] local: pwd
[localhost] local: vagrant status magma_test
[localhost] local: pwd
[localhost] local: touch ~/.ssh/config
[localhost] local: vagrant status magma_test
VM magma_test is not running... Attempting to bring it up (attempt 1/3).
[localhost] local: vagrant up magma_test
Bringing machine 'magma_test' up with 'virtualbox' provider...
==> magma_test: Cloning VM...
==> magma_test: Matching MAC address for NAT networking...
==> magma_test: Checking if box 'magmacore/magma_test' version '1.2.20221012' is up to date...
==> magma_test: Setting the name of the VM: magma_test
==> magma_test: Clearing any previously set network interfaces...
==> magma_test: Preparing network interfaces based on configuration...
    magma_test: Adapter 1: nat
    magma_test: Adapter 2: hostonly
    magma_test: Adapter 3: intnet
    magma_test: Adapter 4: intnet
==> magma_test: Forwarding ports...
    magma_test: 22 (guest) => 2222 (host) (adapter 1)
==> magma_test: Running 'pre-boot' VM customizations...
==> magma_test: Booting VM...
==> magma_test: Waiting for machine to boot. This may take a few minutes...
    magma_test: SSH address: 127.0.0.1:2222
    magma_test: SSH username: vagrant
    magma_test: SSH auth method: private key
Timed out while waiting for the machine to boot. This means that
Vagrant was unable to communicate with the guest machine within
the configured ("config.vm.boot_timeout" value) time period.

If you look above, you should be able to see the error(s) that
Vagrant had when attempting to connect to the machine. These errors
are usually good hints as to what may be wrong.

If you're using a custom box, make sure that networking is properly
working and you're able to connect to the machine. It is a common
problem that networking isn't setup properly in these boxes.
Verify that authentication configurations are also setup properly,
as well.

If the box appears to be booting properly, you may want to increase
the timeout ("config.vm.boot_timeout") value.

Fatal error: local() encountered an error (return code 1) while executing 'vagrant up magma_test'

Aborting.
VM magma_test failed during 'vagrant up'
[localhost] local: pwd
[localhost] local: vagrant status magma_test
[localhost] local: vagrant destroy -f magma_test
==> magma_test: Forcing shutdown of VM...
==> magma_test: Destroying VM and associated drives...
[localhost] local: vagrant status magma_test
VM magma_test is not running... Attempting to bring it up (attempt 2/3).
[localhost] local: vagrant up magma_test
Bringing machine 'magma_test' up with 'virtualbox' provider...
==> magma_test: Cloning VM...
==> magma_test: Matching MAC address for NAT networking...
==> magma_test: Checking if box 'magmacore/magma_test' version '1.2.20221012' is up to date...
==> magma_test: Setting the name of the VM: magma_test
==> magma_test: Clearing any previously set network interfaces...
==> magma_test: Preparing network interfaces based on configuration...
    magma_test: Adapter 1: nat
    magma_test: Adapter 2: hostonly
    magma_test: Adapter 3: intnet
    magma_test: Adapter 4: intnet
==> magma_test: Forwarding ports...
    magma_test: 22 (guest) => 2222 (host) (adapter 1)
==> magma_test: Running 'pre-boot' VM customizations...
==> magma_test: Booting VM...
==> magma_test: Waiting for machine to boot. This may take a few minutes...
    magma_test: SSH address: 127.0.0.1:2222
    magma_test: SSH username: vagrant
    magma_test: SSH auth method: private key
==> magma_test: Machine booted and ready!
==> magma_test: Checking for guest additions in VM...
==> magma_test: Configuring and enabling network interfaces...
==> magma_test: Mounting shared folders...
    magma_test: /vagrant => /home/nils/magma/lte/gateway
    magma_test: /home/vagrant/magma => /home/nils/magma
[localhost] local: vagrant status magma_test
[localhost] local: vagrant ssh-config magma_test

Done.
```

##### Runs on fork:

The following runs are based on a test workflow on my fork, where
* magma_trfserver is created via vagrant up - ansible provisioning is disabled
* vagrant up/destroy is looped 20 times
  * for each iteration it is tried up to three times to do vagrant up successfully
  * (-> 20 to 60 times vagrant up/destroy)
* For a successful vagrant up, we can see here that booting the vm takes less than a minute.

* https://github.com/nstng/magma/actions/runs/4075156447/jobs/7021181931
  * two times "Timed out while waiting for the machine to boot."
* https://github.com/nstng/magma/actions/runs/4075156905/jobs/7021182447
  * four times "Timed out while waiting for the machine to boot."
* https://github.com/nstng/magma/actions/runs/4075157396/jobs/7021183529
  * three times "Timed out while waiting for the machine to boot."

Conclusion: it looks like the re-try logic can help to mitigate the time out behavior.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
