### PR TITLE
fix(cwg): wait for radius server in TestProxy

### DIFF
--- a/feg/radius/src/modules/module_test_utils.go
+++ b/feg/radius/src/modules/module_test_utils.go
@@ -29,7 +29,7 @@ func WaitForRadiusServerToBeReady(secret []byte, addr string) (err error) {
 	defer func() {
 		os.Stdout = temp
 	}()
-	MaxRetries := 10
+	MaxRetries := 20
 	for r := 0; r < MaxRetries; r++ {
 		_, err = radius.Exchange(
 			context.Background(),

--- a/feg/radius/src/modules/proxy/proxy_test.go
+++ b/feg/radius/src/modules/proxy/proxy_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestProxy(t *testing.T) {
-	t.Skip("Skipped due to flakiness") // TODO GH14659
 
 	// Arrange
 	var sessionID = "sessionID"
@@ -59,6 +58,9 @@ func TestProxy(t *testing.T) {
 		_ = radiusServer.ListenAndServe()
 	}()
 	defer radiusServer.Shutdown(context.Background())
+	addr := fmt.Sprintf(":%d", randomPort)
+	err = modules.WaitForRadiusServerToBeReady(secret, addr)
+	require.Nil(t, err)
 	fmt.Println("Server listening")
 
 	// Act

--- a/feg/radius/src/monitoring/scuba/scuba_test.go
+++ b/feg/radius/src/monitoring/scuba/scuba_test.go
@@ -14,11 +14,12 @@ limitations under the License.
 package scuba
 
 import (
-	"fbc/cwf/radius/config"
 	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
+
+	"fbc/cwf/radius/config"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -26,7 +27,6 @@ import (
 
 // TestAnalyticsModulesAuthenticate tests the Analytics module handling of the Authenticate RADIUS packet
 func TestSendOdsCounters(t *testing.T) {
-	t.Skip("Skipped due to flakiness") // TODO GH14659
 
 	// Arrange
 	logger, _ := zap.NewDevelopment()
@@ -59,6 +59,8 @@ func TestSendOdsCounters(t *testing.T) {
 			panic(err)
 		}
 	}()
+	// wait for server to start
+	time.Sleep(1 * time.Millisecond)
 
 	// Act
 	logger, err := NewLogger("some_table")

--- a/feg/radius/src/monitoring/scuba/scuba_test.go
+++ b/feg/radius/src/monitoring/scuba/scuba_test.go
@@ -59,7 +59,7 @@ func TestSendOdsCounters(t *testing.T) {
 			panic(err)
 		}
 	}()
-	// wait for server to start
+	// Wait for server to start
 	time.Sleep(1 * time.Millisecond)
 
 	// Act


### PR DESCRIPTION
Part of #14659 

## Summary

* Wait for the radius server to be ready in `TestProxy`
* Increase the wait time of `WaitForRadiusServerToBeReady` from 10 to 20 loops (the test `TestCoaFixed` was observed to fail sometimes due to reaching the limit here)
* Wait for the server to start in `TestSendOdsCounters` (probably better to query the server somehow instead of a flat sleep)

## Test Plan

Run the unit tests

## Additional Information

- [ ] This change is backwards-breaking
