### PR TITLE
fix(agw): Updating priority of default rule in AGW

### DIFF
--- a/lte/gateway/python/magma/policydb/default_rules.py
+++ b/lte/gateway/python/magma/policydb/default_rules.py
@@ -29,8 +29,9 @@ def get_allow_all_policy_rule(
         # Don't set the rating group
         # Don't set the monitoring key
         # Don't set the hard timeout
+        # Setting priority to a low value
         id=policy_id,
-        priority=2,
+        priority=65530,
         flow_list=_get_allow_all_flows(),
         tracking_type=PolicyRule.TrackingType.Value("NO_TRACKING"),
     )

--- a/lte/gateway/python/magma/policydb/tests/test_streamer_callback.py
+++ b/lte/gateway/python/magma/policydb/tests/test_streamer_callback.py
@@ -91,7 +91,7 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
                                 DynamicRuleInstall(
                                     policy_rule=PolicyRule(
                                         id="allowlist_sid-imsi_1-apn1",
-                                        priority=2,
+                                        priority=65530,
                                         flow_list=allow_all_flow_list,
                                         tracking_type=no_tracking_type,
                                     ),
@@ -113,7 +113,7 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
                                 DynamicRuleInstall(
                                     policy_rule=PolicyRule(
                                         id="allowlist_sid-imsi_2-apn1",
-                                        priority=2,
+                                        priority=65530,
                                         flow_list=allow_all_flow_list,
                                         tracking_type=no_tracking_type,
                                     ),
@@ -234,7 +234,7 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
                                 DynamicRuleInstall(
                                     policy_rule=PolicyRule(
                                         id="allowlist_sid-imsi_1-apn2",
-                                        priority=2,
+                                        priority=65530,
                                         flow_list=allow_all_flow_list,
                                         tracking_type=no_tracking_type,
                                     ),
@@ -256,7 +256,7 @@ class ApnRuleMappingsStreamerCallbackTest(unittest.TestCase):
                                 DynamicRuleInstall(
                                     policy_rule=PolicyRule(
                                         id="allowlist_sid-imsi_2-apn1",
-                                        priority=2,
+                                        priority=65530,
                                         flow_list=allow_all_flow_list,
                                         tracking_type=no_tracking_type,
                                     ),


### PR DESCRIPTION
Signed-off-by: Bhuvanesh N E <bhuvaneshne@highway9networks.com>

## Summary

Default rule was previously installed with priority 2.
This is inverted before flows are pushed to OVS - Which resulted in very high priority for "this" rule.
This caused side effects when multiple policies are tested with differing priorities.
Fix involves changing priority to a very high value (Lowering priority).

## Test Plan

Bring up end to end setup. Attach UE with atleast two policies. Dump flows in OVS and inspect.

pipelined_cli.py debug display_flows | grep "table=enforcement(main_table)"

Check if the default rules are installed with low priority in OVS
(See screenshot above): Default rules are installed with PRIORITY=5 (very low)
The other rules (defaultBearerPolicy, dedicatedBearerTCP) are installed with higher priorities

## Additional Information

Issuing a new pull request ( OLD request: https://github.com/magma/magma/pull/11377)
