### PR TITLE
chore: federated integ test running vs magma_deb

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -632,7 +632,7 @@ jobs:
             --target-props="${DEBIAN_META_INFO}" \
             "packages/(*).deb" magma-packages-test/pool/focal-ci/{1}.deb
 
-      - name: Trigger debian integ test workflow
+      - name: Trigger debian integ test workflows
         uses: peter-evans/repository-dispatch@f2696244ec00ed5c659a5cc77f7138ad0302dffb # pin@v2.1.0
         if: |
           github.event_name == 'push' &&

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -154,7 +154,7 @@ jobs:
       - uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # pin@v2.0.0
         with:
           name: |
-            docker-build-orc8r-images |
+            docker-build-orc8r-images
             docker-build-feg-images
       - name: Load Docker images from tar files
         run: |

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -105,11 +105,11 @@ jobs:
           sudo touch /etc/vbox/networks.conf
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
           sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
-      - name: Cache magma-dev-box
+      - name: Cache magma-deb-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.3.20221230
+          path: ~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-focal64
+          key: vagrant-box-magma-deb-focal64-20220804.0.0
       - name: Cache magma-test-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
@@ -132,12 +132,12 @@ jobs:
       - uses: ./.github/workflows/composite/bazel-gh-cache
         with:
           cache-key-prefix: magma_test
-      - name: build_agw
+      - name: Install AGW
         run: |
           cd lte/gateway/python/integ_tests/federated_tests
           export MAGMA_DEV_CPUS=3
           export MAGMA_DEV_MEMORY_MB=9216
-          fab build-agw
+          fab install-agw
       # Download to local and delete artifacts from remote
       - uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
         with:
@@ -160,7 +160,7 @@ jobs:
           do
             echo Image being loaded $IMAGE
             gzip -cd $IMAGE > image.tar
-            vagrant ssh magma -c 'cat magma/lte/gateway/image.tar | docker load'
+            vagrant ssh magma_deb -c 'cat magma/lte/gateway/image.tar | docker load'
             rm image.tar
           done
       - name: Run the federated integ test
@@ -185,7 +185,7 @@ jobs:
         if: always()
         run: |
           cd lte/gateway
-          fab get-test-logs --dst-path=./logs.tar.gz
+          fab get-test-logs --gateway-host-name=magma_deb --dst-path=./logs.tar.gz
       - name: Upload test logs
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -132,10 +132,6 @@ jobs:
       - uses: ./.github/workflows/composite/bazel-gh-cache
         with:
           cache-key-prefix: magma_test
-      - name: Build test vms
-        run: |
-          cd ${{ env.AGW_ROOT }} && fab build-test-vms
-          cd ${{ env.AGW_ROOT }} && vagrant halt magma_test && vagrant halt magma_trfserver
       - name: build_agw
         run: |
           cd lte/gateway/python/integ_tests/federated_tests

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -17,10 +17,8 @@ name: Magma Build, Publish & Test Federated Integration
 
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch: null
-  push:
-    branches:
-      - master
-      - 'v1.*'
+  repository_dispatch:
+    types: [magma-debian-artifact]
 
 jobs:
   # Build images on ubuntu which is faster than MacOs.
@@ -133,10 +131,16 @@ jobs:
         with:
           cache-key-prefix: magma_test
       - name: Install AGW
+        env:
+          MAGMA_DEV_CPUS: 3
+          MAGMA_DEV_MEMORY_MB: 9216
+        working-directory: 'lte/gateway/python/integ_tests/federated_tests/'
         run: |
-          cd lte/gateway/python/integ_tests/federated_tests
-          export MAGMA_DEV_CPUS=3
-          export MAGMA_DEV_MEMORY_MB=9216
+          if [[ -z "${{ github.event.client_payload.magma_version }}" ]]; then
+            export MAGMA_PACKAGE=magma
+          else
+            export MAGMA_PACKAGE=magma=${{ github.event.client_payload.magma_version }}
+          fi
           fab install-agw
       # Download to local and delete artifacts from remote
       - uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1

--- a/lte/gateway/deploy/magma_deb.yml
+++ b/lte/gateway/deploy/magma_deb.yml
@@ -16,7 +16,24 @@
   hosts: deb
   become: yes
 
+  vars:
+    user: "{{ ansible_user }}"
+    magma_root: /home/{{ ansible_user }}/magma
+    # The install task for docker is guared by preburn.
+    # Docker is installed by e.g., 'INSTALL_DOCKER=true vagrant up magma_deb'
+    preburn: "{{ lookup('env', 'INSTALL_DOCKER', default=false) }}"
+    # The setup role for the test certs is guarded by full_provision.
+    # The test certs are setup by e.g., 'SETUP_TEST_CERTS=true vagrant up magma_deb'
+    full_provision: "{{ lookup('env', 'SETUP_TEST_CERTS', default=false) }}"
+
   roles:
     - role: gai_config
     - role: magma_deb
     - role: service_aliases
+    - role: test_certs
+
+  tasks:
+    # Only run installation for docker
+    - include_role:
+        name: docker
+        tasks_from: install

--- a/lte/gateway/dev_tools.py
+++ b/lte/gateway/dev_tools.py
@@ -134,7 +134,7 @@ def register_federated_vm(c):
     )
     _register_network(FEG_LTE_NETWORK_TYPE, network_payload)
     # registering gateway with LTE type. FEG_LTE doesn't have gateway endpoint
-    _register_agw(c, FEG_LTE_NETWORK_TYPE)
+    _register_agw(c, FEG_LTE_NETWORK_TYPE, vm_name='magma_deb')
 
 
 @task
@@ -183,8 +183,8 @@ def check_agw_cloud_connectivity(c, timeout=10):
         c: fabric connection
         timeout: amount of time the command will retry
     """
-    with vagrant_connection(c, "magma") as c_gw:
-        with c_gw.cd("/home/vagrant/build/python/bin/"):
+    with vagrant_connection(c, "magma_deb") as c_gw:
+        with c_gw.cd("/usr/local/bin/"):
             dev_utils.run_remote_command_with_repetition(c_gw, "./checkin_cli.py", timeout)
 
 
@@ -196,8 +196,8 @@ def check_agw_feg_connectivity(c, timeout=10):
         c: fabric connection
         timeout: amount of time the command will retry
     """
-    with vagrant_connection(c, "magma") as c_gw:
-        with c_gw.cd("/home/vagrant/build/python/bin/"):
+    with vagrant_connection(c, "magma_deb") as c_gw:
+        with c_gw.cd("/usr/local/bin/"):
             dev_utils.run_remote_command_with_repetition(c_gw, "./feg_hello_cli.py m 0", timeout)
 
 
@@ -214,6 +214,7 @@ def _register_agw(
         url: Optional[str] = None,
         admin_cert: Optional[types.ClientCert] = None,
         network_id: Optional[str] = None,
+        vm_name: str = 'magma',
 ):
     network_id = network_id or NIDS_BY_TYPE[network_type]
 
@@ -224,7 +225,7 @@ def _register_agw(
         admin_cert=admin_cert,
     )
 
-    hw_id = dev_utils.get_gateway_hardware_id_from_vagrant(c, vm_name='magma')
+    hw_id = dev_utils.get_gateway_hardware_id_from_vagrant(c, vm_name=vm_name)
     already_registered, registered_as = dev_utils.is_hw_id_registered(
         network_id,
         hw_id,

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -616,9 +616,7 @@ def build_and_start_magma(c, destroy_vm=False, provision_vm=False):
     with vagrant_connection(
         c, 'magma', destroy_vm=destroy_vm, force_provision=provision_vm,
     ) as c_gw:
-        c_gw.run('sudo service magma@* stop')
         _build_magma(c_gw)
-        c_gw.run('sudo service magma@magmad start')
 
 
 @task
@@ -636,17 +634,6 @@ def start_magma(c, destroy_vm=False, provision_vm=False):
         c, 'magma', destroy_vm=destroy_vm, force_provision=provision_vm,
     ) as c_gw:
         c_gw.run('sudo service magma@magmad start')
-
-
-@task
-def build_test_vms(c, provision_vm=False, destroy_vm=False):
-    vagrant_connection(
-        c, 'magma_trfserver', destroy_vm=destroy_vm, force_provision=provision_vm,
-    )
-
-    c_test = vagrant_connection(
-        c, 'magma_test', destroy_vm=destroy_vm, force_provision=provision_vm,
-    )
 
 
 def _copy_out_c_execs_in_magma_vm(c_gw):

--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -143,7 +143,6 @@ def build_agw(c, provision_vm=False):
        provision_vm: forces the reprovision of the magma VM
     """
     print('#### Building AGW ####')
-    subprocess.check_call('vagrant up magma', shell=True, cwd=agw_path)
     cmd = 'fab build-and-start-magma'
     if provision_vm:
         cmd += ' --provision-vm'


### PR DESCRIPTION
## Summary

The federated integration test are currently setting up a magma VM where the AGW is built with make. On the VM then the orc8r and fed gateway Docker images are deployed. Apart from using a make build workflow that will be deprecated with the Bazel switchover, this takes a lot of building time for a component that is not the main focus of the tests.

Here, we use a Magma instance that installs the AGW based on a Debian artifact. This reduces the workflow runtime by roughly one hour and removes another make dependency.

The federated integ tests are now triggered by the Bazel workflow when the AGW Debian artifact is published - this is, the integ tests are using the Debian artifact that was created for the respective merge on master. If the workflow is started manually, then the latest AGW Debian artifact is installed.

Also this change includes a couple of cleanups for the lte/gateway and federated integ tests fabric files.

This change is best reviewed commit by commit.

## Test Plan

Run on fork: https://github.com/nstng/magma/actions/runs/4176993704

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
