### PR TITLE
chore(ci): Remove Make MME build from build-containers workflow

### DIFF
--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -114,6 +114,7 @@ WORKDIR /magma
 # Copy Bazel files at root and third_party
 COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion ${MAGMA_ROOT}/
 COPY bazel/ ${MAGMA_ROOT}/bazel
+COPY third_party/build/patches/libfluid/ ${MAGMA_ROOT}/third_party/build/patches/libfluid/
 
 # Build external dependencies first. This will help not rebuilt all dependencies triggered by Magma changes.
 RUN bazel build \
@@ -132,7 +133,6 @@ COPY orc8r/protos ${MAGMA_ROOT}/orc8r/protos
 COPY protos ${MAGMA_ROOT}/protos
 
 # Build session_manager c code
-COPY lte/gateway/Makefile ${MAGMA_ROOT}/lte/gateway/Makefile
 COPY orc8r/gateway/c/common ${MAGMA_ROOT}/orc8r/gateway/c/common
 COPY lte/gateway/c ${MAGMA_ROOT}/lte/gateway/c
 
@@ -140,15 +140,13 @@ COPY lte/gateway/python/scripts ${MAGMA_ROOT}/lte/gateway/python/scripts
 COPY lte/gateway/docker ${MAGMA_ROOT}/lte/gateway/docker
 COPY lte/gateway/docker/mme/configs/ ${MAGMA_ROOT}/lte/gateway/docker/configs/
 
-ARG BUILD_TYPE=RelWithDebInfo
-ENV BUILD_TYPE=$BUILD_TYPE
 RUN bazel build  \
+  --config=production \
   //lte/gateway/c/sctpd/src:sctpd \
   //lte/gateway/c/connection_tracker/src:connectiond \
   //lte/gateway/c/li_agent/src:liagentd \
-  //lte/gateway/c/session_manager:sessiond
-
-RUN make -C ${MAGMA_ROOT}/lte/gateway/ build_oai BUILD_TYPE="${BUILD_TYPE}"
+  //lte/gateway/c/session_manager:sessiond \
+  //lte/gateway/c/core:agw_of
 
 # Prepare config file
 COPY lte/gateway/configs ${MAGMA_ROOT}/lte/gateway/configs
@@ -166,9 +164,11 @@ ARG MAGMA_VERSION=master
 ENV MAGMA_ROOT /magma
 ENV C_BUILD /build/c
 ENV TZ=Europe/Paris
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Install runtime dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   apt-transport-https \
   apt-utils \
   ca-certificates \
@@ -176,6 +176,7 @@ RUN apt-get update && apt-get install -y \
   iproute2 \
   iptables \
   libgoogle-glog-dev \
+  libidn11-dev \
   libmnl-dev \
   libprotoc-dev \
   libsctp-dev \
@@ -246,7 +247,7 @@ COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/session_manager/sessio
 COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/sctpd/src/sctpd /usr/local/bin/sctpd
 COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/connection_tracker/src/connectiond /usr/local/bin/connectiond
 COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/li_agent/src/liagentd /usr/local/bin/liagentd
-COPY --from=builder $C_BUILD/core/oai/oai_mme/mme /usr/local/bin/oai_mme
+COPY --from=builder ${MAGMA_ROOT}/bazel-bin/lte/gateway/c/core/agw_of /usr/local/bin/oai_mme
 
 RUN ldconfig 2> /dev/null
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #14858
- Remove Make MME build from build-containers workflow

## Test Plan
- [Link to all workflow runs on this branch](https://github.com/magma/magma/actions/workflows/agw-build-publish-container.yml?query=branch%3Abazel_build_containers).
- [Successful precommit tests](https://github.com/magma/magma/actions/runs/4013059314)
- [Successful precommit, ext and ext-long tests](https://github.com/magma/magma/actions/runs/4013391214)
- [Successful precommit, ext and ext-long tests](https://github.com/magma/magma/actions/runs/4013392041)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
