### PR TITLE
chore(ci): Add logging for yarn failure in generateAPIFromSwagger.sh

### DIFF
--- a/nms/scripts/generateAPIFromSwagger.sh
+++ b/nms/scripts/generateAPIFromSwagger.sh
@@ -56,7 +56,15 @@ if [ "$FORCE" = false ] && [ -d "${OUTPUT}"  ] ; then
     fi
 fi
 
-(set -x; yarn --silent openapi-generator-cli version-manager set 6.0.0)
+if ! (set -x && yarn --silent openapi-generator-cli version-manager set 6.0.0) ;
+then
+  echo "Info: If this yarn command fails due to 'Request failed with status code 504'"
+  echo "the availability of search.maven.org may be responsible, see https://status.maven.org/#month"
+  echo "For more information see https://github.com/OpenAPITools/openapi-generator-cli/issues/680"
+  echo "or the issue https://github.com/magma/magma/issues/14860"
+  exit 1
+fi
+
 (set -x;
 yarn --silent openapi-generator-cli generate -i "${INPUT}" --output "${OUTPUT}" --skip-validate-spec --additional-properties=useSingleRequestParameter=true -g typescript-axios)
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Resolves #14860
- The flakiness of the insync check is likely due to outages of `search.maven.org`
  - See https://github.com/OpenAPITools/openapi-generator-cli/issues/680.
  - Added logging to the failing Yarn step if the step is failing.
  - Currently the failure is not reproducible, see https://status.maven.org/#month.
    - The error may appear intermittently.

## Test Plan
- Tested the bash logic for [failing case](https://github.com/LKreutzer/GH-actions-testing/actions/runs/3957288333/jobs/6777469741) in dummy workflow.
- [Insync workflow run on this PR](https://github.com/magma/magma/actions/runs/3957297084/jobs/6777490652)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
