### PR TITLE
chore: meta info (owner, purpose, remediation) is added to magma workflows

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -27,8 +27,8 @@
 #   them with a combined pass/fail verdict to Firebase.
 
 # owner: @magma/approvers-gw
-# purpose: Building AGW docker container and run integration tests
-# remediation: -
+# purpose: Building the AGW Docker containers and run the integration tests
+# remediation: see lte/gateway/docker/README.md
 
 name: AGW Build, Publish & Test Container
 

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -26,6 +26,9 @@
 # - The 'publish-container-test-results' job collects the results and uploads
 #   them with a combined pass/fail verdict to Firebase.
 
+# owner: @magma/approvers-gw
+# purpose: Building AGW docker container and run integration tests
+# remediation: -
 
 name: AGW Build, Publish & Test Container
 

--- a/.github/workflows/agw-coverage.yml
+++ b/.github/workflows/agw-coverage.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-gw
-# purpose: Generate code coverage for AGW componentes
+# purpose: Generate code coverage for AGW components
 # remediation: -
 
 name: AGW Generate Coverage

--- a/.github/workflows/agw-coverage.yml
+++ b/.github/workflows/agw-coverage.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Generate code coverage for AGW componentes
+# remediation: -
+
 name: AGW Generate Coverage
 
 on:

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Linting various components in AGW
+# remediation: https://magma.github.io/magma/docs/next/lte/dev_unit_testing#format-agw
+
 name: AGW Lint
 
 on:

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Add labels to a PR based on changed code
+# remediation: -
+
 name: PR Generate Labels
 on:
   # Use pull_request_target to gain write permissions.

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -11,6 +11,10 @@
 
 # Based on https://github.com/sqren/backport-github-action/blob/main/README.md under MIT license.
 
+# owner: @magma/approvers-infra
+# purpose: Apply backports based on PR labels
+# remediation: -
+
 name: PR Backport
 on:
   pull_request_target:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-gw, @magma/approvers-infra
-# purpose: Running unit tests and packaging the AGW with bazel
+# purpose: Unit testing and packaging the AGW with Bazel. Starlark format checking.
 # remediation: https://magma.github.io/magma/docs/next/bazel/agw_with_bazel
 
 name: AGW Build, Format & Test Bazel

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw, @magma/approvers-infra
+# purpose: Running unit tests and packaging the AGW with bazel
+# remediation: https://magma.github.io/magma/docs/next/bazel/agw_with_bazel
+
 name: AGW Build, Format & Test Bazel
 on:
   # yamllint disable-line rule:truthy

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw (agw-build, cwf-operator-build, feg-build), @magma/approvers-cloud (nms-build, orc8r-build)
+# purpose: Building and publishing cloud and gateway components
+# remediation: https://magma.github.io/magma/docs/next/basics/quick_start_guide#terminal-tab-2-build-orchestrator (orc8r), https://magma.github.io/magma/docs/next/basics/quick_start_guide#using-the-nms-ui (nms-build), https://magma.github.io/magma/docs/next/feg/deploy_build (feg-build)
+
 name: Magma Build & Publish
 
 on:

--- a/.github/workflows/check-rebase.yml
+++ b/.github/workflows/check-rebase.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Check if your PR needs a rebase on the current master
+# remediation: Rebase your PR on the current master branch
+
 name: PR Check Rebase
 
 on:

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-cloud
+# purpose: Orc8r linting and testing
+# remediation: https://magma.github.io/magma/docs/next/orc8r/dev_testing
+
 name: Orc8r Lint & Test
 
 on:

--- a/.github/workflows/codeowners-syntax.yml
+++ b/.github/workflows/codeowners-syntax.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Validate changes to the CODEOWNERS file
+# remediation: -
+
 name: PR Check Codeowners
 
 on:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,10 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 
+# owner: any
+# purpose: CodeQL security analysis
+# remediation: -
+
 name: Magma Analyze With CodeQL
 
 on:

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Centralized workflow to add a comment on a PR based on results of other workflows
+# remediation: -
+
 name: PR Generate Comment On Workflow Failure
 on:
   workflow_run:

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: CWAG formatting and testing
+# remediation: https://magma.github.io/magma/docs/next/cwf/dev_testing
+
 name: CWAG Format & Test
 
 on:

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: CWAG building and integration testing
+# remediation: https://magma.github.io/magma/docs/cwf/dev_testing
+
 name: CWAG Build & Test Integration
 
 on:

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Run CWF deployer unit tests
+# remediation: -
+
 name: CWAG Lint & Test Operator
 
 on:

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: any
+# purpose: Check PR is signed off
+# remediation: https://github.com/magma/magma/wiki/Contributing-Code#commit-and-pull-request-guidelines
+
 name: PR Check DCO
 on:
   pull_request:

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Building Bazel Base and DevContainer images
+# remediation: -
+
 name: Magma Build Docker Image Bazel Base & DevContainer
 on:
   push:

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-infra
-# purpose: Building Bazel Base and DevContainer images
+# purpose: Building the bazel-base and devcontainer Docker images
 # remediation: -
 
 name: Magma Build Docker Image Bazel Base & DevContainer

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Check if the python precommit image can be build
+# remediation: -
+
 name: AGW Build Docker Image Python Precommit
 on:
   push:

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-gw
-# purpose: Check if the python precommit image can be build
+# purpose: Check if the Python precommit image can be built
 # remediation: -
 
 name: AGW Build Docker Image Python Precommit

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-infra
-# purpose: Manual workflow to promote docker images for releases
+# purpose: Manual workflow to promote Docker images for releases
 # remediation: -
 
 name: Magma Promote Docker Images

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Manual workflow to promote docker images for releases
+# remediation: -
+
 name: Magma Promote Docker Images
 
 on:

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Ensure documentation changes are formatted and in sync
+# remediation: https://magma.github.io/magma/docs/docs/docs_overview#precommit
+
 name: Docs Lint & Check Generated Files In Sync
 
 on:

--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Building and deploying the docusaurus documentation
+# remediation: -
+
 name: Docs Build & Deploy
 
 on:

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-cloud
+# purpose: Domain Proxy (DP) linting and testing
+# remediation: Check alembic migrations
+
 name: DP Lint & Test
 
 on:

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-gw
-# purpose: FED building and integration testing
+# purpose: FeG building and integration testing
 # remediation: https://magma.github.io/magma/docs/feg/s1ap_federated_tests
 
 name: Magma Build, Publish & Test Federated Integration

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: FED building and integration testing
+# remediation: https://magma.github.io/magma/docs/feg/s1ap_federated_tests
+
 name: Magma Build, Publish & Test Federated Integration
 
 on:  # yamllint disable-line rule:truthy

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: FeG linting and testing
+# remediation: https://magma.github.io/magma/docs/next/feg/dev_testing
+
 name: FeG Lint & Test
 
 on:

--- a/.github/workflows/fossa-workflow.yml
+++ b/.github/workflows/fossa-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-cloud
+# purpose: Orc8r fossa analysis
+# remediation: -
+
 name: Orc8r Analyze With Fossa
 
 on:

--- a/.github/workflows/golang-check-version.yml
+++ b/.github/workflows/golang-check-version.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw, @magma/approvers-cloud
+# purpose: Make sure all places in Magma use the same Go version
+# remediation: -
+
 name: Magma Check Go Version
 on:
   push:

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-cloud
+# purpose: Check if helm dependencies are up to date
+# remediation: -
+
 name: Magma Check Helm Dependencies
 
 on:

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-cloud
-# purpose: Check if helm dependencies are up to date
+# purpose: Check if Helm dependencies are up to date
 # remediation: -
 
 name: Magma Check Helm Dependencies

--- a/.github/workflows/helm-deploy-on-demand.yml
+++ b/.github/workflows/helm-deploy-on-demand.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Manual workflow for publishing helm charts
+# remediation: -
+
 name: Magma Build & Publish Helm Charts
 
 # Temporary on demand Job until we refactor helm build job in build-all

--- a/.github/workflows/helm-deploy-on-demand.yml
+++ b/.github/workflows/helm-deploy-on-demand.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-infra
-# purpose: Manual workflow for publishing helm charts
+# purpose: Manual workflow for publishing Helm charts
 # remediation: -
 
 name: Magma Build & Publish Helm Charts

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Manual workflow to promote helm charts for releases
+# remediation: -
+
 name: Magma Promote Helm Charts
 
 on:

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-infra
-# purpose: Manual workflow to promote helm charts for releases
+# purpose: Manual workflow to promote Helm charts for releases
 # remediation: -
 
 name: Magma Promote Helm Charts

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-cloud
+# purpose: Ensure generated files are committed
+# remediation: https://magma.github.io/magma/docs/next/orc8r/dev_testing
+
 name: Orc8r Check Generated Files In Sync
 
 on:

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-gw
-# purpose: Run integration tests vs an environment based on a debian AGW artifact build with Bazel
+# purpose: Run LTE integration tests against the AGW services from the Bazel-built Debian package
 # remediation: -
 
 name: AGW Test LTE Integration With Bazel Debian Build

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Run integration tests vs an environment based on a debian AGW artifact build with Bazel
+# remediation: -
+
 name: AGW Test LTE Integration With Bazel Debian Build
 
 on:

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Run integration tests (utilized by agw-build-publish-container.yml)
+# remediation: -
+
 name: AGW Test LTE Integration With Make Containerized Build
 
 on:

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-gw
-# purpose: Run integration tests vs an environment based on a debian AGW artifact build with Make
+# purpose: Run LTE integration tests against the AGW services from the Make-built Debian package
 # remediation: -
 
 name: AGW Test LTE Integration With Make Debian Build

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Run integration tests vs an environment based on a debian AGW artifact build with Make
+# remediation: -
+
 name: AGW Test LTE Integration With Make Debian Build
 
 on:

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-gw
-# purpose: Run integration tests vs an environment based a AGW build with Make
+# purpose: Run LTE integration tests against the Make-built AGW services
 # remediation: -
 
 name: AGW Build & Test LTE Integration With Make Dev Build

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Run integration tests vs an environment based a AGW build with Make
+# remediation: -
+
 name: AGW Build & Test LTE Integration With Make Dev Build
 
 on:

--- a/.github/workflows/magma-build-3rd-party.yml
+++ b/.github/workflows/magma-build-3rd-party.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Test if 3rd party dependencies can be build - publish if manually triggered
+# remediation: -
+
 name: Magma Build & Publish 3rd Party Dependencies
 on:
   push:

--- a/.github/workflows/magma-build-3rd-party.yml
+++ b/.github/workflows/magma-build-3rd-party.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-infra
-# purpose: Test if 3rd party dependencies can be build - publish if manually triggered
+# purpose: Test if 3rd party dependencies can be built - publish if manually triggered
 # remediation: -
 
 name: Magma Build & Publish 3rd Party Dependencies

--- a/.github/workflows/magma-build-openvswitch.yml
+++ b/.github/workflows/magma-build-openvswitch.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-infra
-# purpose: Test if patched OVS can be build - publish if manually triggered
+# purpose: Test if patched OVS can be built - publish if manually triggered
 # remediation: -
 
 name: Magma Build & Publish Open vSwitch Artifacts

--- a/.github/workflows/magma-build-openvswitch.yml
+++ b/.github/workflows/magma-build-openvswitch.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Test if patched OVS can be build - publish if manually triggered
+# remediation: -
+
 name: Magma Build & Publish Open vSwitch Artifacts
 on:
   push:

--- a/.github/workflows/magma-publish-go.yml
+++ b/.github/workflows/magma-publish-go.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-infra
-# purpose: Manual workflow to publish a new go version to the artifactory blob storage (for caching)
+# purpose: Manual workflow to publish a new Go version to the artifactory blob storage (for caching)
 # remediation: -
 
 name: Magma Publish Go Package

--- a/.github/workflows/magma-publish-go.yml
+++ b/.github/workflows/magma-publish-go.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Manual workflow to publish a new go version to the artifactory blob storage (for caching)
+# remediation: -
+
 name: Magma Publish Go Package
 
 on:

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-cloud
+# purpose: NMS linting and testing
+# remediation: https://magma.github.io/magma/docs/next/nms/dev_testing
+
 name: NMS Lint & Test
 
 on:

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-infra
-# purpose: Generate message with general information for a new PR
+# purpose: Generate comment with general information for a new PR
 # remediation: -
 
 name: PR Generate Hello

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-infra
+# purpose: Generate message with general information for a new PR
+# remediation: -
+
 name: PR Generate Hello
 on:
   # Use pull_request_target to gain write permissions.

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Ensure Python changes are formatted correctly
+# remediation: https://magma.github.io/magma/docs/next/lte/dev_unit_testing#format-agw
+
 name: AGW Build & Format Python
 on:
   push:

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: any
+# purpose: Linting various components
+# remediation: -
+
 name: PR Lint Reviewdog
 on:
   pull_request_target:

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: any
+# purpose: PR format checker
+# remediation: https://github.com/magma/magma/wiki/Contributing-Code#commit-and-pull-request-guidelines
+
 name: PR Check Title Or Commit Message
 
 on:

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw
+# purpose: Run sudo python tests (pipelined tests that need OVS, mobilityd tests that need a certain network setup)
+# remediation: -
+
 name: AGW Test Sudo Python
 
 on:

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # owner: @magma/approvers-gw
-# purpose: Run sudo python tests (pipelined tests that need OVS, mobilityd tests that need a certain network setup)
+# purpose: Run sudo Python tests (pipelined tests that need OVS, mobilityd tests that need a certain network setup)
 # remediation: -
 
 name: AGW Test Sudo Python

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -9,6 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# owner: @magma/approvers-gw, @magma/approvers-cloud
+# purpose: Centralized workflow to publish test results for other workflows
+# remediation: -
+
 name: PR Generate Unit Test Results
 on:
   workflow_run:


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This change adds meta info to the magma workflows. Goal is to get rid of the detailed list [Blocking checks](https://github.com/magma/magma/wiki/Contributing-Code#blocking-checks) and [Non-blocking checks](https://github.com/magma/magma/wiki/Contributing-Code#non-blocking-checks) and to replace them with commands to get this information from the workflow definitions.

The majority of workflows did not have this meta info in the GH wiki - i.e., a lot of additional info were added. Also some URLs in the remediation column were outdated and are changed here.

This PR comes together with changes in the Wiki - see below. Changes will be applied after the review.

Closes #14324

## Test Plan

Check added meta info.

# Changes to Wiki
https://github.com/magma/magma/wiki/Contributing-Code#code-review-process

-----------------------------------------------

## Continuous Integration (CI) / Continuous Deployment (CD)

When a PR is submitted to the Magma repository, a suite of CI tests and analysis is executed. Checks marked as _required_ (blocking checks) must pass for a PR to be merged.

Most of the checks are implemented as [GitHub Actions](https://github.com/magma/magma/actions), which need to run successfully. Before adding or updating an action, familiarize yourself with the [Secure Use of Github Actions](https://github.com/magma/magma/wiki/Secure-Use-of-Github-Actions).

See [[this page|Magma CI]] for a technical overview of magma CI workflows.

### Overview of checks applied to a pull request

You can find a summary of the check results on the overview page of a pull request. All workflow runs can be found via the [GitHub actions](https://github.com/magma/magma/actions) page, which can be filtered by branch name and user. Alternatively, you can use the [GitHub CLI](https://cli.github.com/) to get the same information (and more) from the command line. Some useful commands for the GitHub CLI are listed below.

Change the default repository:
```
gh repo set-default user/repository
```

List the last couple of pull requests:
```
gh pr list
```

List the executed checks on a pull request with results:
```
gh pr checks some_remote:branch_name
```

Same as above filtered by required checks:
```
gh pr checks --required some_remote:branch_name
```

List all workflows (including disabled workflows):
```
gh workflow list -a
```

See the yaml definition of a workflow:
```
gh workflow view "DP Lint & Test" --yaml
```

If you get stuck by a failing check it usually suffices to write a respective comment on the pull request. If necessary the approver group that owns the check can be mentioned. You can find the needed group in the workflow definition. This can be found, e.g., via:
```
gh workflow view "DP Lint & Test" --yaml | grep "^# owner:"
```

Get the purpose of a check:
```
gh workflow view "DP Lint & Test" --yaml | grep "^# purpose:"
```

Get additional information for the check:
```
gh workflow view "DP Lint & Test" --yaml | grep "^# remediation:"
```

There are a couple of checks that are not modeled by github workflows. 

| Check Name             | Purpose                                       | Owner                         | Remediation Steps |
| ---------------------- | --------------------------------------------- | ----------------------------- | ----------------- |
| mergefreeze            | Stop merges during a code freeze (required)             | @magma/approvers-infra                  | N/A
| Magma-OAI-Jenkins      | OAI's MME integration test run on OAI Jenkins (required) | @rdefosse                     | N/A
| Codecov.io | Evaluate code coverage data (not required)  | @magma/approvers-infra  | N/A

### How to add a new CI check to Magma

Please add meta data to the workflow definition that can be parsed by the commands above, e.g.,
```
# owner: @magma/approvers-gw
# purpose: Linting various components in AGW
# remediation: https://magma.github.io/magma/docs/next/lte/dev_unit_testing#format-agw
```

To add a blocking check,

1. File a proposal to outline the motivation and any relevant timelines and assign to a relevant codeowner or TSC ([example proposal](https://github.com/magma/magma/issues/7774))
2. Once the proposal is accepted, announce the plan in [#dev](https://magmacore.slack.com/archives/C018J8UMGMR) and coordinate with one of the [repo admins](https://github.com/orgs/magma/teams/repo-magma-admin/members) to make the switch.

### Naming conventions

The convention for naming new workflows is as follows:

__{component} {verbs} {additions}__

with

- {component} in AGW, CWAG, Docs, DP, FeG, Magma, NMS, Orc8r, PR
- {verbs} in Analyse, Backport, Build, Check, Deploy, Format, Generate, Lint, Promote, Publish, Test
- {addition} being a short descriptive addition 

Rules and notes:
- All words in the name should be capitalized.
- {component}:
  - Exactly one component should be chosen for every workflow.
  - "Magma" is intended for workflows relating to multiple Magma components.
  - "PR" is intended for workflows that interact with pull requests.
- {verbs}:
  - In the case that multiple verbs are applicable, the last separator should be an ampersand with one space each side, while any other separator should be a comma followed by one space, e.g. `Build & Test`, `Lint, Build & Test`

# Action on blocked CI

While the `master` branch is protected by (required) CI checks, merging PRs still bears the possibility of breaking the CI workflow, e.g. by not rebasing, failing post-merge workflows or changes in workflows with `pull_request_target` triggers. Reverting a merged PR accompanied by a discussion on Magma's slack may prove a viable option to unblock the CI workflow if the amount of time for a proper fix is significant.

