### PR TITLE
fix: old digest is compared with new digest of helm dependencies

### DIFF
--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -42,7 +42,7 @@ jobs:
           echo "DIGEST=$(cat $MAGMA_ROOT/orc8r/cloud/helm/orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
           helm dependency update "$MAGMA_ROOT/orc8r/cloud/helm/orc8r/"
           echo "NEW_DIGEST=$(cat $MAGMA_ROOT/orc8r/cloud/helm/orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
-          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+          if [ "$DIGEST" != "$NEW_DIGEST" ]; then
             exit 1
           fi
       - name: Check cwf-orc8r
@@ -51,7 +51,7 @@ jobs:
           echo "DIGEST=$(cat $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r//Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
           helm dependency update "$MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r/"
           echo "NEW_DIGEST=$(cat $MAGMA_ROOT/cwf/cloud/helm/cwf-orc8r//Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
-          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+          if [ "$DIGEST" != "$NEW_DIGEST" ]; then
             exit 1
           fi
       - name: Check lte-orc8r
@@ -60,7 +60,7 @@ jobs:
           echo "DIGEST=$(cat $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
           helm dependency update "$MAGMA_ROOT/lte/cloud/helm/lte-orc8r/"
           echo "NEW_DIGEST=$(cat $MAGMA_ROOT/lte/cloud/helm/lte-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
-          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+          if [ "$DIGEST" != "$NEW_DIGEST" ]; then
             exit 1
           fi
       - name: Check feg-orc8r
@@ -69,7 +69,7 @@ jobs:
           echo "DIGEST=$(cat $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
           helm dependency update "$MAGMA_ROOT/feg/cloud/helm/feg-orc8r/"
           echo "NEW_DIGEST=$(cat $MAGMA_ROOT/feg/cloud/helm/feg-orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV
-          if [ "$NEW_DIGEST" != "$NEW_DIGEST" ]; then
+          if [ "$DIGEST" != "$NEW_DIGEST" ]; then
             exit 1
           fi
       - name: Notify failure to slack


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

This change fixes the check whether helm dependencies need to be updated.

## Test Plan

CI https://github.com/magma/magma/actions/runs/3966546157

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
