### PR TITLE
chore: unnecessary ref and repository attributes are removed

### DIFF
--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -77,8 +77,6 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
       - name: jsonlint-mconfig
         run: find . -name gateway.mconfig -print0 | xargs --max-args=1 --null --replace='%' sh -c ">/dev/null jq . % || { echo % is not a valid json file; exit 1; } "
@@ -91,8 +89,6 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
       - name: Setup Bazel Cache Image
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # pin@v3

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -429,11 +429,11 @@ class IPAllocatorDHCP(IPAllocator):
         )
 
     def _release_dhcp_ip(self, ip_desc: IPDesc) -> None:
-        logging.info(f"Releasing: {ip_desc}")
+        logging.info("Releasing: %s", ip_desc)
         mac = create_mac_from_sid(ip_desc.sid)
         vlan = ip_desc.vlan_id
         dhcp_desc = self.get_dhcp_desc_from_store(mac, vlan)
-        logging.info(f"Releasing dhcp desc: {dhcp_desc}")
+        logging.info("Releasing dhcp desc: %s", dhcp_desc)
         if dhcp_desc:
             subprocess.Popen(
                 [


### PR DESCRIPTION
## Summary

This change removes unnecessary attributes ref and repository from the checkout action - as the checkout is used on the magma repository, this information should not be needed.

Closes #14741

## Test Plan

CI agw-workflow https://github.com/magma/magma/actions/runs/3983918289/jobs/6829647477

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
