### PR TITLE
chore: cwag c images are build based on cached bazel image

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -244,18 +244,6 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/orc8r/cloud/docker
           python3 build.py --all --nocache
-      - name: Export docker images to deploy them
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir images
-          cd images
-          docker save orc8r_nginx | gzip > nginx.tar.gz
-          docker save orc8r_controller  | gzip > controller.tar.gz
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: github.event_name == 'pull_request'
-        with:
-          name: docker-images-orc8r
-          path: images
       - name: Create release Tag
         if: github.event_name == 'push'
         run: |
@@ -378,22 +366,6 @@ jobs:
              echo "Docker compose failed"
              exit 1
           fi
-      - name: Export docker images to deploy them on pull_request
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir images
-          cd images
-          docker save cwf_cwag_go | gzip > cwag_go.tar.gz
-          docker save cwf_gateway_go | gzip > gateway_go.tar.gz
-          docker save cwf_gateway_sessiond | gzip > gateway_sessiond.tar.gz
-          docker save cwf_gateway_python | gzip > gateway_python.tar.gz
-          docker save cwf_gateway_pipelined | gzip > gateway_pipelined.tar.gz
-      - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: github.event_name == 'pull_request'
-        with:
-          name: docker-images-cwag
-          path: images
       # Need to save PR number as Github action does not propagate it with workflow_run event
       # Used as version for PR builds
       - name: Save PR number
@@ -465,18 +437,6 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/cwf/k8s/cwf_operator/docker
           DOCKER_REGISTRY=cwf_ docker compose --compatibility build
-      - name: Export docker images to deploy them on pull_request
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir images
-          cd images
-          docker save cwf_operator | gzip > operator.tar.gz
-      - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: github.event_name == 'pull_request'
-        with:
-          name: docker-images-cwf
-          path: images
       # Need to save PR number as Github action does not propagate it with workflow_run event
       # Used as version for PR builds
       - name: Save PR number
@@ -568,19 +528,6 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/feg/gateway/docker
           python3 build.py -e
-      - name: Export docker images to deploy them on pull_request
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir images
-          cd images
-          docker save feg_gateway_go | gzip > feg_gateway_go.tar.gz
-          docker save feg_gateway_python | gzip > feg_gateway_python.tar.gz
-      - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: github.event_name == 'pull_request'
-        with:
-          name: docker-images-feg
-          path: images
       - name: Create release Tag
         run: |
           if [ "$GITHUB_REF" = "refs/heads/master" ]; then
@@ -644,18 +591,6 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/nms
           COMPOSE_PROJECT_NAME=magmalte docker compose --compatibility build magmalte
-      - name: Export docker images to deploy them on pull_request
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir images
-          cd images
-          docker save magmalte_magmalte | gzip > magmalte.tar.gz
-      - name: Upload docker images as artifacts
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: github.event_name == 'pull_request'
-        with:
-          name: docker-images-nms
-          path: images
       - name: Create release Tag
         if: github.event_name == 'push'
         run: |

--- a/bazel/bazelrcs/cwag.bazelrc
+++ b/bazel/bazelrcs/cwag.bazelrc
@@ -1,1 +1,0 @@
-build --define=disable_sentry_native=1

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -17,46 +17,7 @@
 
 ARG OS_DIST=ubuntu OS_RELEASE=focal EXTRA_REPO=https://linuxfoundation.jfrog.io/artifactory/magma-packages-test
 
-FROM $OS_DIST:$OS_RELEASE AS builder
-ARG OS_DIST OS_RELEASE EXTRA_REPO
-
-RUN apt-get update && \
-  # Setup necessary tools for adding the Magma repository
-  apt-get install -y apt-utils software-properties-common apt-transport-https gnupg wget && \
-  # Download Bazel
-  wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-amd64 && \
-  chmod +x /usr/sbin/bazelisk-linux-amd64 && \
-  ln -s /usr/sbin/bazelisk-linux-amd64 /usr/sbin/bazel
-
-# Add the magma apt repo
-COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-RUN add-apt-repository "deb ${EXTRA_REPO} focal-ci main"
-
-# Install dependencies required for building
-RUN apt-get -y update && apt-get -y install \
-  sudo \
-  curl \
-  unzip \
-  cmake \
-  git \
-  gcc \
-  g++ \
-  build-essential \
-  # folly deps
-  libfolly-dev \
-  libgoogle-glog-dev \
-  libgflags-dev \
-  libevent-dev \
-  libdouble-conversion-dev \
-  libiberty-dev \
-  libdouble-conversion-dev \
-  libboost-chrono-dev \
-  libboost-context-dev \
-  libboost-program-options-dev \
-  libboost-filesystem-dev \
-  libboost-regex-dev \
-  libsystemd-dev \
-  python3-distutils
+FROM ghcr.io/magma/magma/bazel-cache-plain:latest as builder
 
 ENV MAGMA_ROOT /magma
 WORKDIR /magma
@@ -64,14 +25,6 @@ WORKDIR /magma
 # Copy Bazel files at root and third_party
 COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion ${MAGMA_ROOT}/
 COPY bazel/ ${MAGMA_ROOT}/bazel
-
-# Build external dependencies first. This will help not rebuilt all dependencies triggered by Magma changes.
-RUN bazel build \
-  @com_github_grpc_grpc//:grpc++ \
-  @com_google_protobuf//:protobuf \
-  @prometheus_cpp//:prometheus-cpp \
-  @yaml-cpp//:yaml-cpp \
-  @github_nlohmann_json//:json
 
 # Copy proto files
 COPY feg/protos ${MAGMA_ROOT}/feg/protos
@@ -84,7 +37,7 @@ COPY protos ${MAGMA_ROOT}/protos
 COPY orc8r/gateway/c/common ${MAGMA_ROOT}/orc8r/gateway/c/common
 COPY lte/gateway/c/session_manager ${MAGMA_ROOT}/lte/gateway/c/session_manager
 
-RUN bazel --bazelrc=${MAGMA_ROOT}/bazel/bazelrcs/cwag.bazelrc build //lte/gateway/c/session_manager:sessiond
+RUN bazel build //lte/gateway/c/session_manager:sessiond --define=disable_sentry_native=1
 
 # -----------------------------------------------------------------------------
 # Dev/Production image


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This change optimizes the cwag CI build (and other docker builds) by
* using a bazel cache image as a base for the c image cwag build - this drastically improves the build time and should lead to the same build result as before (will be verified on master via cwag integration tests).
  * The downside here is that on local/manual builds the latest cache image has to be downloaded. This still results in faster builds, but prevents the former usage of a locally cached focal base image - please comment if in your opinion this downside is a blocker
  * thanks to @LKreutzer for the initial idea to try this
* Removing unused tar.gz-ing and uploading of images to the workflow - these images are not downloaded in CI again (name of steps suggest that something was planned here, but it was either removed or never implemented)
  * If someone actually downloads these images manually for local deployments, then these steps can be re-added.

### Step runtime before and after (sample size of one, but should represent a direction)

| Job  | Before | After |
| ---| ---|--- |
| **orc8r build job**  | ~20Min | ~8Min |
| **cwag deploy job**  | ~56Min | ~13Min |
| **feg-build**  | ~18Min | ~8Min |
| **nms-build job**  | ~6Min | ~3Min |
| **cwf operator build job**  | ~7Min | ~3Min |

Before: https://github.com/magma/magma/actions/runs/3986153893
After: https://github.com/magma/magma/actions/runs/3987590153

## Test Plan

CI build_all workflow https://github.com/magma/magma/actions/runs/3987590153

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
