### PR TITLE
feat(ci): change default registry for containerized integ tests

### DIFF
--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -20,7 +20,7 @@ on:
         required: true
       registry:
         type: string
-        default: 'linuxfoundation.jfrog.io/magma-docker-agw-test'
+        default: 'linuxfoundation.jfrog.io/magma-docker-test'
         required: true
       test_targets:
         type: choice


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This change in the default directory for this job is mostly relevant for manual execution. The `gateway_go`'s 1.8 release image is not located in the current default folder, which leads tests with these images to fail. The new directory includes these images.

## Test Plan

- [ ] [Failing test on current master with `1.8` image tag](https://github.com/mpfirrmann/magma/actions/runs/3986875135/jobs/6835960772#step:13:1153)
- [ ] Passing tests on feature branch with [`1.8`](https://github.com/mpfirrmann/magma/actions/runs/3987110963/jobs/6836500620) and [`latest`](https://github.com/mpfirrmann/magma/actions/runs/3987108511/jobs/6836495910) image tags

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
