### PR TITLE
chore(agw): Remove unused dynamic libraries from MME build

### DIFF
--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -39,7 +39,6 @@ RUN echo "Install general purpose packages" && \
         libczmq-dev \
         libgcrypt-dev \
         libgmp3-dev \
-        libidn11-dev \
         libsctp1 \
         libsqlite3-dev \
         libsctp-dev `# dependency of sctpd` \
@@ -84,7 +83,6 @@ RUN add-apt-repository 'deb https://linuxfoundation.jfrog.io/artifactory/magma-p
         libfolly-dev \
         liblfds710 \
         oai-asn1c \
-        oai-gnutls \
         oai-nettle \
         oai-freediameter
 

--- a/bazel/external/system_libraries.BUILD
+++ b/bazel/external/system_libraries.BUILD
@@ -56,18 +56,6 @@ cc_library(
 )
 
 cc_library(
-    name = "libfd",
-    srcs = [
-        "usr/local/lib/libfdcore.so",
-        "usr/local/lib/libfdproto.so",
-    ],
-    linkopts = [
-        "-lfdcore",
-        "-lfdproto",
-    ],
-)
-
-cc_library(
     name = "libnettle",
     srcs = ["usr/lib/libnettle.so"],
     linkopts = ["-lnettle"],
@@ -81,11 +69,6 @@ cc_library(
     ),
 )
 
-cc_library(
-    name = "libgnutls",
-    srcs = ["usr/lib/libgnutls.so"],
-    linkopts = ["-lgnutls"],
-)
 
 # TODO(GH9710): Generate asn1c with Bazel
 native_binary(

--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1068,8 +1068,6 @@ MME_DEPS = [
     "@liblfds//:lfds710",
     "@system_libraries//:czmq",
     "@system_libraries//:libconfig",
-    "@system_libraries//:libfd",
-    "@system_libraries//:libgnutls",
     "@system_libraries//:libnettle",
     "@system_libraries//:libsqlite3-dev",
     "@system_libraries//:libsystemd",

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -102,7 +102,6 @@ RUN apt-get update && apt-get install -y \
   magma-libfluid \
   oai-asn1c \
   oai-freediameter \
-  oai-gnutls \
   oai-nettle \
   prometheus-cpp-dev \
   && rm -rf /var/lib/apt/lists/* \
@@ -234,7 +233,6 @@ COPY --from=builder /usr/local/lib/libgrpc.so /usr/local/lib/
 COPY --from=builder /usr/local/lib/libgpr.so /usr/local/lib/
 COPY --from=builder /usr/lib/libnettle.so  /usr/local/lib/
 COPY --from=builder /usr/lib/libfluid* /usr/local/lib/
-COPY --from=builder /usr/lib/libgnutls.so.* /usr/local/lib/
 COPY --from=builder /usr/lib/libhogweed.so.2 /usr/local/lib/
 
 COPY --from=builder /usr/local/lib/libfdproto.so.6 /usr/local/lib/

--- a/lte/gateway/release/deb_dependencies.bzl
+++ b/lte/gateway/release/deb_dependencies.bzl
@@ -60,7 +60,6 @@ MAGMA_DEPS = [
 OAI_DEPS = [
     "libconfig9",
     "oai-asn1c",
-    "oai-gnutls (>= 3.1.23)",
     "oai-nettle (>= 1.0.1)",
     "prometheus-cpp-dev (>= 1.0.2)",
     "liblfds710",


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- There are currently unused dynamic libraries in the MME build with Bazel
  - This leads to failures when the services are running in environments where these dependencies are not installed.
  - Unused library targets are removed and not built into the Docker images anymore. 

## Test Plan

- Run `ldd -u` on the MME artifact with and without the changes to see unused direct dependencies.
- Unit testing and integ testing TBD
- [Sudo tests](https://github.com/magma/magma/actions/runs/3987788459/jobs/6838072113)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
