### PR TITLE
test(cwg): Make radius test sequential

### DIFF
--- a/feg/radius/src/modules/coadynamic/coa_dynamic_test.go
+++ b/feg/radius/src/modules/coadynamic/coa_dynamic_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestCoaDynamic(t *testing.T) {
-	t.Skip("Skipped due to flakiness") // TODO GH14659
-
 	// Arrange
 	secret := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
 	port := 4799

--- a/feg/radius/src/run.sh
+++ b/feg/radius/src/run.sh
@@ -51,7 +51,8 @@ function pretty {
 }
 
 function test {
-    gotestsum ./...
+    go clean -testcache
+    gotestsum -- -p 1 ./...
 }
 
 function e2e {

--- a/feg/radius/src/run.sh
+++ b/feg/radius/src/run.sh
@@ -51,7 +51,7 @@ function pretty {
 }
 
 function test {
-    go clean -testcache
+    # Run tests sequentially to avoid radius server cross-talk between tests.
     gotestsum -- -p 1 ./...
 }
 


### PR DESCRIPTION
In pairing with @wolfseb 
## Summary

This change ensures that radius src tests are run sequentially. `go test` can run tests in parallel if they are defined in different packages, which is effectively the case in `radius/src`. By adding the `-p 1` flag, we ensure that no tests run in parallel. This change fixes the flakiness we observed in `TestCoaDynamic`. 


## Test Plan

We ran the test manually with other tests in `radius/src` many times with and without the `-p 1` flag. The flakiness in `TestCoaDynamic` only occurs without the `-p 1` flag.
