### PR TITLE
docs: switch artifactory location in 1.8 docs

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.8.0/basics/prerequisites.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/basics/prerequisites.md
@@ -67,7 +67,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    1. Download the tar file.
 
       ```bash
-      wget https://artifactory.magmacore.org/artifactory/generic/go1.18.3.linux-amd64.tar.gz
+      wget https://linuxfoundation.jfrog.io/artifactory/magma-blob/go1.18.3.linux-amd64.tar.gz
       ```
 
    2. Extract the archive you downloaded into `/usr/local`, creating a Go tree in `/usr/local/go`.

--- a/docs/docusaurus/versioned_docs/version-1.8.0/orc8r/deploy_intro.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/orc8r/deploy_intro.md
@@ -9,7 +9,7 @@ original_id: deploy_intro
 
 This section walks through installing a production Orchestrator deployment.
 
-We assume you will use the versioned artifacts provided by the project's official artifactory at [artifactory.magmacore.org](https://artifactory.magmacore.org/). If you would like to build and host your own artifacts, see the [Build Orchestrator](./dev_build.md) page.
+We assume you will use the versioned artifacts provided by the project's official artifactory at [linuxfoundation.jfrog.io](https://linuxfoundation.jfrog.io/). If you would like to build and host your own artifacts, see the [Build Orchestrator](./dev_build.md) page.
 
 To deploy orc8r, see the [Manual installation](./deploy_install.md) page.
 

--- a/docs/docusaurus/versioned_docs/version-1.8.0/orc8r/dev_minikube.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/orc8r/dev_minikube.md
@@ -49,7 +49,7 @@ helm upgrade --install \
 
 ### Build and publish images
 
-> NOTE: skip this step if you want to use the official container images at [artifactory.magmacore.org](https://artifactory.magmacore.org/).
+> NOTE: skip this step if you want to use the official container images at [linuxfoundation.jfrog.io](https://linuxfoundation.jfrog.io/).
 
 There are 2 ways you can publish your own images: to a private registry, or to a localhost registry. Choose an option, then complete the relevant prerequisites:
 
@@ -80,7 +80,7 @@ cd ${MAGMA_ROOT}/orc8r/cloud/docker && ./build.py && ./run.py && sleep 30 && doc
 Create the K8s secrets
 
 ```bash
-export IMAGE_REGISTRY_URL=docker.artifactory.magmacore.org  # or replace with your registry
+export IMAGE_REGISTRY_URL=linuxfoundation.jfrog.io/magma-docker  # or replace with your registry
 export IMAGE_REGISTRY_USERNAME=''
 export IMAGE_REGISTRY_PASSWORD=''
 
@@ -140,8 +140,8 @@ A minimal values file is at `${MAGMA_ROOT}/orc8r/cloud/helm/orc8r/examples/minik
 
 This section describes how to install based on local charts. However, you can also install charts from the official chart repositories
 
-- Stable: <https://artifactory.magmacore.org/artifactory/helm/>
-- Test: <https://artifactory.magmacore.org/artifactory/helm-test/>
+- Stable: <https://linuxfoundation.jfrog.io/artifactory/magma-helm-prod/>
+- Test: <https://linuxfoundation.jfrog.io/artifactory/magma-helm-test/>
 
 Install base `orc8r` chart
 


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The old magmacore artifactory is still present in some 1.8 docs. Switched to the LF artifactory links from current master docs.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
