### PR TITLE
fix(agw): Address selection of mypy errors in orc8r/gateway/python/

### DIFF
--- a/orc8r/gateway/python/magma/common/health/service_state_wrapper.py
+++ b/orc8r/gateway/python/magma/common/health/service_state_wrapper.py
@@ -11,6 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from typing import Dict
+
 from magma.common.redis.client import get_default_client
 from magma.common.redis.containers import RedisFlatDict
 from magma.common.redis.serializers import (
@@ -70,7 +72,7 @@ class ServiceStateWrapper:
         """
         return self._flat_dict[service_name]
 
-    def get_all_services_status(self) -> [str, ServiceExitStatus]:
+    def get_all_services_status(self) -> Dict[str, ServiceExitStatus]:
         """
         Get a dict of service name to service status
         @return dict of service_name to service map

--- a/orc8r/gateway/python/magma/common/service_registry.py
+++ b/orc8r/gateway/python/magma/common/service_registry.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 import logging
 import os
+from typing import Any, Dict
 
 import grpc
 from magma.configuration.exceptions import LoadConfigError
@@ -30,9 +31,9 @@ class ServiceRegistry:
     params like ip/port, TLS, certs, etc based on service level configuration.
     """
 
-    _REGISTRY = {}
-    _PROXY_CONFIG = {}
-    _CHANNELS_CACHE = {}
+    _REGISTRY: Dict[str, Dict] = {}
+    _PROXY_CONFIG: Dict[str, Any] = {}
+    _CHANNELS_CACHE: Dict[str, Any] = {}
 
     LOCAL = 'local'
     CLOUD = 'cloud'

--- a/orc8r/gateway/python/magma/ctraced/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/ctraced/rpc_servicer.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from magma.ctraced.trace_manager import TraceManager
+from magma.ctraced.trace_manager import EndTraceResult, TraceManager
 from orc8r.protos.ctraced_pb2 import (
     EndTraceRequest,
     EndTraceResponse,

--- a/orc8r/gateway/python/magma/eventd/event_validator.py
+++ b/orc8r/gateway/python/magma/eventd/event_validator.py
@@ -73,7 +73,7 @@ class EventValidator(object):
         Loads all swagger definitions from the files specified in the
         event registry.
         """
-        specs_by_filename = {}
+        specs_by_filename: Dict[Any, Dict] = {}
         for event_type, info in self.event_registry.items():
             filename = info[FILENAME]
             if filename in specs_by_filename:

--- a/orc8r/gateway/python/magma/magmad/gateway_status.py
+++ b/orc8r/gateway/python/magma/magmad/gateway_status.py
@@ -340,7 +340,7 @@ class GatewayStatusFactory:
         )
         return network_info
 
-    def _meta_has_required_services(self, meta_services: List[str]) -> bool:
+    def _meta_has_required_services(self, meta_services: KeysView) -> bool:
         """
         Verifies based on status meta pulled from service_poller.
         service_statusmeta contains map of service_name -> statusmeta

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -43,7 +43,7 @@ class MetricsCollector(object):
     """
     Polls magma services periodicaly for metrics and posts them to cloud
     """
-    _services = []
+    _services: List[str] = []
 
     def __init__(
         self, services: List[str],
@@ -53,7 +53,7 @@ class MetricsCollector(object):
         grpc_max_msg_size_mb: Union[int, float],
         loop: Optional[asyncio.AbstractEventLoop] = None,
         post_processing_fn: Optional[Callable] = None,
-        scrape_targets: [ScrapeTarget] = None,
+        scrape_targets: Optional[List[ScrapeTarget]] = None,
     ):
         self.sync_interval = sync_interval
         self.collect_interval = collect_interval
@@ -61,7 +61,7 @@ class MetricsCollector(object):
         self.grpc_max_msg_size_bytes = grpc_max_msg_size_mb * 1024 * 1024
         self._services = services
         self._loop = loop if loop else asyncio.get_event_loop()
-        self._samples_for_service = {}
+        self._samples_for_service: Dict[str, List] = {}
         for s in self._services:
             self._samples_for_service[s] = []
         self._grpc_options = _get_metrics_chan_grpc_options(
@@ -258,7 +258,7 @@ class MetricsCollector(object):
             )
 
     def _package_and_send_metrics(
-            self, metrics: [metrics_pb2.MetricFamily],
+            self, metrics: List[metrics_pb2.MetricFamily],
             target: ScrapeTarget,
     ) -> None:
         """
@@ -311,7 +311,7 @@ class MetricsCollector(object):
             )
 
 
-def _parse_metrics_response(response_text: str) -> [metrics_pb2.MetricFamily]:
+def _parse_metrics_response(response_text: str) -> List[metrics_pb2.MetricFamily]:
     parsed_families = list(text_string_to_metric_families(response_text))
     metrics_to_send = list(map(core_metric_to_proto, parsed_families))
     # Flatten list
@@ -319,7 +319,7 @@ def _parse_metrics_response(response_text: str) -> [metrics_pb2.MetricFamily]:
 
 
 def _add_scrape_label_to_metrics(
-        metrics: [metrics_pb2.MetricFamily],
+        metrics: List[metrics_pb2.MetricFamily],
         scrape_label: str,
 ) -> None:
     for family in metrics:
@@ -425,7 +425,7 @@ _METRIC_TYPES = ('counter', 'gauge', 'summary', 'histogram', 'untyped')
 
 def core_metric_to_proto(
         metric: prometheus_client.core.Metric,
-) -> [metrics_pb2.MetricFamily]:
+) -> List[metrics_pb2.MetricFamily]:
     """
     Converts metrics from the prometheus client parser format to protobuf for
     sending to cloud
@@ -471,7 +471,7 @@ def _gauge_to_proto(
 
 def _summary_to_proto(
         metric: prometheus_client.core.Metric,
-) -> [metrics_pb2.MetricFamily]:
+) -> List[metrics_pb2.MetricFamily]:
     """
     1. Get metrics by unique labelset ignoring quantile
     2. convert to proto separately for each one
@@ -519,7 +519,7 @@ def _summary_to_proto(
 
 def _histogram_to_proto(
         metric: prometheus_client.core.Metric,
-) -> [metrics_pb2.MetricFamily]:
+) -> List[metrics_pb2.MetricFamily]:
     """
     1. Get metrics by unique labelset ignoring quantile
     2. convert to proto separately for each one

--- a/orc8r/gateway/python/magma/magmad/service_manager.py
+++ b/orc8r/gateway/python/magma/magmad/service_manager.py
@@ -16,7 +16,7 @@ import json
 import logging
 import subprocess
 from enum import Enum
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import magma.magmad.events as magmad_events
 from magma.magmad.service_poller import ServicePoller
@@ -48,17 +48,17 @@ class ServiceManager(object):
     Manages a set of systemd services, performing bulk operations across all
     of them.
     """
-    _service_control = {}
-    _services = []
-    _registered_dynamic_services = []
+    _service_control: Dict[str, 'ServiceControl'] = {}
+    _services: List[str] = []
+    _registered_dynamic_services: List[str] = []
 
     def __init__(
             self,
             services: List[str],
             init_system,
             service_poller: ServicePoller,
-            registered_dynamic_services: List[str] = None,
-            dynamic_services: List[str] = None,
+            registered_dynamic_services: Optional[List[str]] = None,
+            dynamic_services: Optional[List[str]] = None,
     ):
         if registered_dynamic_services is None:
             registered_dynamic_services = []
@@ -242,7 +242,7 @@ class ServiceManager(object):
 
     class InitSystemSpec(object):
         # Command to interact with the init system (i.e. 'systemctl', 'sv')
-        _init_cmd = None
+        _init_cmd: Optional[str] = None
 
         # Commands used by the init system to control processes.
         # start/stop/restart seem to be consistent among most init systems so
@@ -250,10 +250,10 @@ class ServiceManager(object):
         _start_cmd = 'start'
         _stop_cmd = 'stop'
         _restart_cmd = 'reload-or-restart'
-        _status_cmd = None
+        _status_cmd: Optional[str] = None
 
         # Dictionary mapping the status response to a ServiceState
-        _statuses = None
+        _statuses: Optional[Dict[str, ServiceState]] = None
 
         def __init__(self, name):
             assert isinstance(name, str), "Process name is not a string"

--- a/orc8r/gateway/python/magma/magmad/service_poller.py
+++ b/orc8r/gateway/python/magma/magmad/service_poller.py
@@ -13,7 +13,7 @@ limitations under the License.
 
 import logging
 import time
-from typing import List
+from typing import List, Optional
 
 import grpc
 from magma.common.job import Job
@@ -88,7 +88,7 @@ class ServicePoller(Job):
     # Timeout when getting status from other local services, in seconds
     GET_STATUS_TIMEOUT = 8
 
-    def __init__(self, loop, config, dynamic_services: List[str] = None):
+    def __init__(self, loop, config, dynamic_services: Optional[List[str]] = None):
         """
         Initialize the ServicePooler
 

--- a/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
+++ b/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
@@ -16,7 +16,7 @@ import queue
 import random
 import threading
 import time
-from typing import List
+from typing import Dict, Iterator
 
 import grpc
 import magma.magmad.events as magmad_events
@@ -43,7 +43,7 @@ class SyncRPCClient(threading.Thread):
     ):
         threading.Thread.__init__(self)
         # a synchronized queue
-        self._response_queue = queue.Queue()
+        self._response_queue: queue.Queue = queue.Queue()
         self._loop = loop
         asyncio.set_event_loop(self._loop)
         # seconds to wait for an actual SyncRPCResponse to become available
@@ -52,8 +52,8 @@ class SyncRPCClient(threading.Thread):
         self._proxy_client = ControlProxyHttpClient()
         self.daemon = True
         self._current_delay = 0
-        self._last_conn_time = 0
-        self._conn_closed_table = {}  # mapping of req id -> conn closed
+        self._last_conn_time = 0.0
+        self._conn_closed_table: Dict[int, bool] = {}  # mapping of req id -> conn closed
         self._print_grpc_payload = print_grpc_payload
 
     def run(self):
@@ -143,7 +143,7 @@ class SyncRPCClient(threading.Thread):
 
     def forward_requests(
         self,
-        sync_rpc_requests: List[SyncRPCRequest],
+        sync_rpc_requests: Iterator[SyncRPCRequest],
     ) -> None:
         """
         Send requests in the sync_rpc_requests iterator.

--- a/orc8r/gateway/python/magma/magmad/tests/state_reporter_test.py
+++ b/orc8r/gateway/python/magma/magmad/tests/state_reporter_test.py
@@ -35,7 +35,6 @@ MS = 'magma.common.service'
 SReg = 'magma.common.service_registry'
 
 
-@staticmethod
 def make_awaitable(func, return_value):
     future = asyncio.Future()
     future.set_result(return_value)
@@ -144,7 +143,7 @@ class StateReporterTests(TestCase):
     def _construct_operational_state_mock(device_id: str) \
             -> unittest.mock.Mock:
         mock = unittest.mock.Mock()
-        future = asyncio.Future()
+        future: asyncio.Future = asyncio.Future()
         future.set_result(
             GetOperationalStatesResponse(
                 states=[

--- a/orc8r/gateway/python/magma/magmad/upgrade/upgrader2.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/upgrader2.py
@@ -32,7 +32,7 @@ import pathlib
 import ssl
 import time
 import urllib.request  # TODO: Figure out how to get aiohttp
-from typing import NamedTuple, NewType, Set
+from typing import NamedTuple, NewType, Optional, Set
 
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
@@ -55,7 +55,7 @@ class UpgraderGauges(NamedTuple):
     idle: Gauge
 
 
-_GAUGES = None  # type: typing.Optional[UpgraderGauges]
+_GAUGES = None  # type: Optional[UpgraderGauges]
 
 
 def get_gauges() -> UpgraderGauges:
@@ -168,7 +168,7 @@ class Upgrader2(Upgrader, metaclass=abc.ABCMeta):
 
     def __init__(self, service: MagmaService) -> None:
         self.service = service
-        self.upgrade_task = None  # type: typing.Optional[asyncio.Task]
+        self.upgrade_task = None  # type: Optional[asyncio.Task]
 
     @property
     def loop(self) -> asyncio.AbstractEventLoop:

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -14,6 +14,7 @@ limitations under the License.
 
 import json
 import logging
+from typing import Any, Dict, Set
 
 import grpc
 import jsonpickle
@@ -95,10 +96,10 @@ class StateReplicator(SDWatchdogTask):
         # Garbage collector to propagate deletions back to Orchestrator
         self._garbage_collector = garbage_collector
         # In memory mapping of states to version
-        self._state_versions = {}
+        self._state_versions: Dict[str, Any] = {}
         # Set of keys from current replication iteration - used to track
         # keys to delete from _state_versions dict
-        self._state_keys_from_current_iteration = set()
+        self._state_keys_from_current_iteration: Set[str] = set()
         # Redis clients for each type of state to replicate
         self._redis_dicts = []
         self._redis_dicts.extend(get_proto_redis_dicts(service.config))

--- a/orc8r/gateway/python/scripts/register.py
+++ b/orc8r/gateway/python/scripts/register.py
@@ -36,7 +36,7 @@ CONFIG_OVERRIDE_DIR = '/var/opt/magma/configs'
 CONTROL_PROXY = 'control_proxy.yml'
 
 
-def register_handler(client: RegistrationStub, args: List[str]) -> RegisterResponse:
+def register_handler(client: RegistrationStub, args: argparse.Namespace) -> RegisterResponse:
     """
     Register a device and retrieves its control proxy
     Args:


### PR DESCRIPTION
## Summary

Takes the number of mypy errors in orc8r/gateway/python/ down from 79 to 37. The errors can be looked at locally by running `cd $MAGMA_ROOT && mypy orc8r/gateway/python/`. More mypy fixes are to follow in subsequent PRs.

## Test Plan

- [x] Unit tests: `bazel test //orc8r/gateway/python/...` runs succesfully -> `Executed 29 out of 29 tests: 29 tests pass.`
- [x] CI
