### PR TITLE
test(agw): Add scaling tests for DHCP ip allocation mode

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -178,6 +178,8 @@ s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_rar_tcp_he.py \
 s1aptests/test_attach_detach_with_he_policy.py \
 s1aptests/test_paging_after_mme_restart.py \
+s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py \
+s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py \
 s1aptests/test_restore_mme_config_after_sanity.py
 
 EXTENDED_TESTS_LONG = s1aptests/test_modify_mme_config_for_sanity.py \

--- a/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
+++ b/lte/gateway/python/integ_tests/s1aptests/BUILD.bazel
@@ -1190,6 +1190,15 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_attach_detach_with_non_nat_dhcp",
+    size = "large",
+    srcs = ["test_attach_detach_with_non_nat_dhcp.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_PRECOMMIT_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
     name = "test_modify_mme_config_for_sanity",
     size = "medium",
     srcs = ["test_modify_mme_config_for_sanity.py"],
@@ -1664,6 +1673,24 @@ pytest_test(
         ":gpp_types",
         ":s1ap_wrapper",
     ],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_non_nat_dhcp_multi_ue",
+    size = "large",
+    srcs = ["test_attach_detach_with_non_nat_dhcp_multi_ue.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
+)
+
+pytest_test(
+    name = "test_attach_detach_with_non_nat_dhcp_multi_ue_looped",
+    size = "large",
+    srcs = ["test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py"],
+    imports = [LTE_ROOT],
+    tags = TAG_EXTENDED_TEST + TAG_TRAFFIC_SERVER_TEST,
+    deps = [":s1ap_wrapper"],
 )
 
 pytest_test(
@@ -2207,15 +2234,6 @@ pytest_test(
     name = "test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue",
     size = "large",
     srcs = ["test_attach_and_mme_restart_loop_detach_and_mme_restart_loop_multi_ue.py"],
-    imports = [LTE_ROOT],
-    tags = TAG_NON_SANITY_TEST,
-    deps = [":s1ap_wrapper"],
-)
-
-pytest_test(
-    name = "test_attach_detach_with_non_nat_dhcp",
-    size = "large",
-    srcs = ["test_attach_detach_with_non_nat_dhcp.py"],
     imports = [LTE_ROOT],
     tags = TAG_NON_SANITY_TEST,
     deps = [":s1ap_wrapper"],

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp.py
@@ -25,6 +25,7 @@ class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
     def setUp(self):
         """Initialize before test case execution"""
         self.magma_utils = MagmadUtil(None)
+
         self.magma_utils.enable_dhcp_config()
         self.trf_util = TrafficUtil()
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
@@ -59,8 +60,7 @@ class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
                 s1ap_types.ueAttachAccept_t,
             )
-            n_leases = len(self.trf_util.dump_leases().decode("utf-8").split("\n")) - 2
-            assert n_leases == i + 1, "IP not assigned to UE"
+            self.trf_util.check_attached_leases(expected_leases=i + 1)
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -86,14 +86,7 @@ class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
             if i == max_iterations - 1:
                 assert False, f"IPs not released after {max_iterations * wait_interval} seconds"
 
-        dump_lease_timeout = 5
-        for i in range(dump_lease_timeout):
-            time.sleep(1)
-            res = self.trf_util.dump_leases()
-            if num_ues == res.decode("utf-8").count("expired"):
-                break
-            if i == dump_lease_timeout - 1:
-                assert False, "Not all IPs released"
+        self.trf_util.check_detached_leases(expected_leases=num_ues)
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
@@ -38,7 +38,7 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
         self.trf_util.clear_leases()
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach_with_non_nat_dhcp(self):
+    def test_attach_detach_with_non_nat_dhcp_multi_ue(self):
         """ Basic attach/detach test with 32 UEs and DHCP"""
         num_ues = 32
         ue_ids = []

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
@@ -25,6 +25,7 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
     def setUp(self):
         """Initialize before test case execution"""
         self.magma_utils = MagmadUtil(None)
+
         self.magma_utils.enable_dhcp_config()
         self.trf_util = TrafficUtil()
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
@@ -59,8 +60,7 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
                 s1ap_types.ueAttachAccept_t,
             )
-            n_leases = len(self.trf_util.dump_leases().decode("utf-8").split("\n")) - 2
-            assert n_leases == i + 1, "IP not assigned to UE"
+            self.trf_util.check_attached_leases(expected_leases=i + 1)
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -87,14 +87,7 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
             if i == max_iterations - 1:
                 assert False, f"IPs not released after {max_iterations * wait_interval} seconds"
 
-        dump_lease_timeout = 5
-        for i in range(dump_lease_timeout):
-            time.sleep(1)
-            res = self.trf_util.dump_leases()
-            if num_ues == res.decode("utf-8").count("expired"):
-                break
-            if i == dump_lease_timeout - 1:
-                assert False, "Not all IPs released"
+        self.trf_util.check_detached_leases(expected_leases=num_ues)
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
@@ -17,6 +17,7 @@ import unittest
 import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
+from util.traffic_util import TrafficUtil
 
 
 class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
@@ -25,6 +26,7 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
         """Initialize before test case execution"""
         self.magma_utils = MagmadUtil(None)
         self.magma_utils.enable_dhcp_config()
+        self.trf_util = TrafficUtil()
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
         self.magma_utils.disable_nat()
 
@@ -32,6 +34,7 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
         """Cleanup after test case execution"""
         self.magma_utils.disable_dhcp_config()
         self.magma_utils.enable_nat()
+        self.trf_util.clear_leases()
         self._s1ap_wrapper.cleanup()
 
     def test_attach_detach_with_non_nat_dhcp(self):
@@ -44,7 +47,7 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
         ]
         self._s1ap_wrapper.configUEDevice(num_ues)
 
-        for _ in range(num_ues):
+        for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             print(
                 "************************* Running End to End attach for ",
@@ -56,6 +59,8 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
                 s1ap_types.ueAttachAccept_t,
             )
+            n_leases = len(self.trf_util.dump_leases().decode("utf-8").split("\n")) - 2
+            assert n_leases == i + 1, "IP not assigned to UE"
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -81,6 +86,15 @@ class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
             time.sleep(wait_interval)
             if i == max_iterations - 1:
                 assert False, f"IPs not released after {max_iterations * wait_interval} seconds"
+
+        dump_lease_timeout = 5
+        for i in range(dump_lease_timeout):
+            time.sleep(1)
+            res = self.trf_util.dump_leases()
+            if num_ues == res.decode("utf-8").count("expired"):
+                break
+            if i == dump_lease_timeout - 1:
+                assert False, "Not all IPs released"
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue.py
@@ -19,7 +19,7 @@ from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
 
-class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
+class TestAttachDetachWithNonNatDhcpMultiUe(unittest.TestCase):
 
     def setUp(self):
         """Initialize before test case execution"""
@@ -35,16 +35,16 @@ class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
 
     def test_attach_detach_with_non_nat_dhcp(self):
-        """ Basic attach/detach test with two UEs and DHCP"""
-        num_ues = 2
+        """ Basic attach/detach test with 32 UEs and DHCP"""
+        num_ues = 32
+        ue_ids = []
         detach_type = [
             s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
         ]
-        wait_for_s1 = [True, False]
         self._s1ap_wrapper.configUEDevice(num_ues)
 
-        for i in range(num_ues):
+        for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req
             print(
                 "************************* Running End to End attach for ",
@@ -59,13 +59,14 @@ class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
-            print(
-                "************************* Running UE detach for UE id ",
-                req.ue_id,
-            )
+            ue_ids.append(req.ue_id)
+
+        for i, ue in enumerate(ue_ids):
             # Now detach the UE
+            print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i],
+                ue,
+                detach_type[i % 2], True,
             )
 
         wait_interval = 5

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
@@ -25,6 +25,7 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
     def setUp(self):
         """Initialize before test case execution"""
         self.magma_utils = MagmadUtil(None)
+
         self.magma_utils.enable_dhcp_config()
         self.trf_util = TrafficUtil()
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
@@ -58,8 +59,7 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
                 s1ap_types.ueAttachAccept_t,
             )
-            n_leases = len(self.trf_util.dump_leases().decode("utf-8").split("\n")) - 2
-            assert n_leases == i + 1, "IP not assigned to UE"
+            self.trf_util.check_attached_leases(expected_leases=i + 1)
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -86,14 +86,7 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
             if i == max_iterations - 1:
                 assert False, f"IPs not released after {max_iterations * wait_interval} seconds"
 
-        dump_lease_timeout = 5
-        for i in range(dump_lease_timeout):
-            time.sleep(1)
-            res = self.trf_util.dump_leases()
-            if num_ues == res.decode("utf-8").count("expired"):
-                break
-            if i == dump_lease_timeout - 1:
-                assert False, "Not all IPs released"
+        self.trf_util.check_detached_leases(expected_leases=num_ues)
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
@@ -17,6 +17,7 @@ import unittest
 import s1ap_types
 from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
+from util.traffic_util import TrafficUtil
 
 
 class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
@@ -25,6 +26,7 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
         """Initialize before test case execution"""
         self.magma_utils = MagmadUtil(None)
         self.magma_utils.enable_dhcp_config()
+        self.trf_util = TrafficUtil()
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
         self.magma_utils.disable_nat()
 
@@ -32,6 +34,7 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
         """Cleanup after test case execution"""
         self.magma_utils.disable_dhcp_config()
         self.magma_utils.enable_nat()
+        self.trf_util.clear_leases()
         self._s1ap_wrapper.cleanup()
 
     def test_attach_detach_with_non_nat_dhcp(self):
@@ -55,6 +58,8 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
                 s1ap_types.ueAttachAccept_t,
             )
+            n_leases = len(self.trf_util.dump_leases().decode("utf-8").split("\n")) - 2
+            assert n_leases == i + 1, "IP not assigned to UE"
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -80,6 +85,15 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
             time.sleep(wait_interval)
             if i == max_iterations - 1:
                 assert False, f"IPs not released after {max_iterations * wait_interval} seconds"
+
+        dump_lease_timeout = 5
+        for i in range(dump_lease_timeout):
+            time.sleep(1)
+            res = self.trf_util.dump_leases()
+            if num_ues == res.decode("utf-8").count("expired"):
+                break
+            if i == dump_lease_timeout - 1:
+                assert False, "Not all IPs released"
 
 
 if __name__ == "__main__":

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
@@ -38,7 +38,7 @@ class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
         self.trf_util.clear_leases()
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach_with_non_nat_dhcp(self):
+    def test_attach_detach_with_non_nat_dhcp_multi_ue_looped(self):
         """ looped attach/detach test with 32 UEs and DHCP"""
         num_ues = 32
         detach_type = [

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_non_nat_dhcp_multi_ue_looped.py
@@ -19,7 +19,7 @@ from integ_tests.s1aptests import s1ap_wrapper
 from s1ap_utils import MagmadUtil
 
 
-class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
+class TestAttachDetachWithNonNatDhcpMultiUeLooped(unittest.TestCase):
 
     def setUp(self):
         """Initialize before test case execution"""
@@ -35,13 +35,12 @@ class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
 
     def test_attach_detach_with_non_nat_dhcp(self):
-        """ Basic attach/detach test with two UEs and DHCP"""
-        num_ues = 2
+        """ looped attach/detach test with 32 UEs and DHCP"""
+        num_ues = 32
         detach_type = [
             s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
             s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
         ]
-        wait_for_s1 = [True, False]
         self._s1ap_wrapper.configUEDevice(num_ues)
 
         for i in range(num_ues):
@@ -59,13 +58,14 @@ class TestAttachDetachWithNonNatDhcp(unittest.TestCase):
 
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
+
+            # Now detach the UE
             print(
                 "************************* Running UE detach for UE id ",
                 req.ue_id,
             )
-            # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, detach_type[i], wait_for_s1[i],
+                req.ue_id, detach_type[i % 2], True,
             )
 
         wait_interval = 5

--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -142,7 +142,7 @@ class TrafficUtil(object):
         cmd = 'systemctl stop udhcpd.service && ' \
               'rm -f /var/lib/misc/udhcpd.leases && ' \
               'systemctl start udhcpd.service'
-        return self.exec_command(f"sudo bash -c '{cmd}'").returncode
+        self.exec_command(f"sudo bash -c '{cmd}'")
 
     def _count_leases(self):
         """Count the total number of leases in TRF server VM"""

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -435,29 +435,17 @@ class IPAllocatorDHCP(IPAllocator):
         dhcp_desc = self.get_dhcp_desc_from_store(mac, vlan)
         logging.info("Releasing dhcp desc: %s", dhcp_desc)
         if dhcp_desc:
-            call_args = [
-                DHCP_HELPER_CLI,
-                "--mac", str(mac),
-                "--vlan", str(vlan),
-                "--interface", self._iface,
-                "--json",
-                "release",
-                "--ip", str(ip_desc.ip),
-                "--server-ip", str(dhcp_desc.server_ip),
-            ]
-            ret = subprocess.run(
-                call_args,
-                capture_output=True,
-                check=False,
+            subprocess.Popen(
+                [
+                    DHCP_HELPER_CLI,
+                    "--mac", str(mac),
+                    "--vlan", str(vlan),
+                    "--interface", self._iface,
+                    "release",
+                    "--ip", str(ip_desc.ip),
+                    "--server-ip", str(dhcp_desc.server_ip),
+                ],
             )
-
-            if ret.returncode != 0:
-                call_str = " ".join(call_args)
-                logging.error(
-                    "CLI call '%s' failed with return code %s and error %s",
-                    call_str, ret.returncode, ret.stderr,
-                )
-                raise NoAvailableIPError('Failed to call dhcp_helper_cli.')
 
             key = mac.as_redis_key(vlan)
             with self.dhcp_wait:


### PR DESCRIPTION
We had to revert #14724 in #14881 because of out of memory failures on the `magma_deb` VM. This issue was not apparent on the magma dev VM because mobilityd was able to write into the swap. Each `dhcp_helper_cli` thread spawned when we release one IP uses about 50 MB, so running six or more in parallel will cause an out of memory error (The default memory limit of mobilityd is 300 MB).

## Summary

- Revert #14881
- Add a mechanism to limit the number of concurrent dhcp helper cli threads to 3 by implementing a queue.
- Add a test utility to check that the correct number of leases are allocated and all leases are released at the end.
- Add a test utility to clear the lease file at the end of the test.
- Some minor refactoring to improve the traffic server utilities.

## Test Plan

We manually observed the memory usage and number of dhcp_helper_cli threads during test execution manually with `watch -n 0.1 "systemctl status magma@mobilityd"` and found that the 300MB limit was no longer exceeded.
