### PR TITLE
docs: bump the magma version in example checkout to latests 1.8 release

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.8.0/basics/prerequisites.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/basics/prerequisites.md
@@ -166,8 +166,8 @@ To download Magma current version, or a specific release do the following
 git clone https://github.com/magma/magma.git
 cd magma
 
-# in case you want to use a specific version of Magma (for example v1.6)
-git checkout v1.6
+# in case you want to use a specific version of Magma (for example v1.8)
+git checkout v1.8
 
 # to list all available releases
 git tag -l

--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -165,8 +165,8 @@ To download Magma current version, or a specific release do the following
 git clone https://github.com/magma/magma.git
 cd magma
 
-# in case you want to use a specific version of Magma (for example v1.6)
-git checkout v1.6
+# in case you want to use a specific version of Magma (for example v1.8)
+git checkout v1.8
 
 # to list all available releases
 git tag -l


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

In the `prerequisite` pages of both 1.8 and master, there is an example to checkout magma v1.6. This changes it to 1.8 for consistency.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
