### PR TITLE
fix(agw): Address mypy errors in lte/gateway/python/

### DIFF
--- a/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py
+++ b/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py
@@ -83,7 +83,7 @@ class DhcpHelperCli:
         self, mac: MacAddress, vlan: int, iface: str, ip: Optional[str] = None,
             server_ip: Optional[str] = None, router_ip: Optional[str] = None,
     ) -> None:
-        self._lease_expiration_time = None
+        self._lease_expiration_time: Optional[str] = None
         self._iface = iface
         self._mac = mac
         self._vlan = vlan

--- a/lte/gateway/python/integ_tests/gateway/rpc.py
+++ b/lte/gateway/python/integ_tests/gateway/rpc.py
@@ -17,7 +17,9 @@ from magma.common.service_registry import create_grpc_channel
 from magma.configuration.mconfigs import unpack_mconfig_any
 from orc8r.protos.common_pb2 import Void
 from orc8r.protos.magmad_pb2_grpc import MagmadStub
-from orc8r.protos.mconfig import mconfigs_pb2
+from orc8r.protos.mconfig import (
+    mconfigs_pb2,  # type: ignore[attr-defined] # mypy error when file not generated due to folder with same name
+)
 
 
 def get_rpc_channel(service):

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -205,7 +205,7 @@ class S1ApUtil(object):
 
     def get_response(
         self,
-        timeout: int = None,
+        timeout: Optional[int] = None,
     ) -> Msg:
         """Return the response message invoked by S1APTester TFW callback
 
@@ -1512,8 +1512,8 @@ class MagmadUtil(object):
                     "/etc/magma/mme.yml"
                 )
 
-        ret_code = self.exec_command("sudo " + ha_config_cmd)
-        if ret_code == 0:
+        ret_code = str(self.exec_command("sudo " + ha_config_cmd))
+        if ret_code == "0":
             print("Ha service configured successfully")
             return 1
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_dl_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_dl_tcp.py
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestIpv4v6NonNatDedBearerDlTcp(unittest.TestCase):
     """Integration Test: TestIpv4v6NonNatDedBearerDlTcp"""
 
-    def __init__(self, method_name: str = ...) -> None:
+    def __init__(self, method_name: str) -> None:
         """Initialize unittest class"""
         super().__init__(methodName=method_name)
         self.magma_utils = MagmadUtil(None)

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ded_bearer_ul_tcp.py
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestIpv4v6NonNatDedBearerUlTcp(unittest.TestCase):
     """Integration Test: TestIpv4v6NonNatDedBearerUlTcp"""
 
-    def __init__(self, method_name: str = ...) -> None:
+    def __init__(self, method_name: str) -> None:
         """Initialize unittest class"""
         super().__init__(methodName=method_name)
         self.magma_utils = MagmadUtil(None)

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_non_nat_ul_tcp.py
@@ -21,7 +21,7 @@ from s1ap_utils import MagmadUtil
 class TestIpv4v6NonNatUlTcp(unittest.TestCase):
     """Integration Test: TestIpv4v6NonNatUlTcp"""
 
-    def __init__(self, method_name: str = ...) -> None:
+    def __init__(self, method_name: str) -> None:
         """Initialize unittest class"""
         super().__init__(methodName=method_name)
         self.magma_utils = MagmadUtil(None)

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_dl_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_dl_tcp.py
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestIpv6NonNatDedBearerDlTcp(unittest.TestCase):
     """Integration Test: TestIpv6NonNatDedBearerDlTcp"""
 
-    def __init__(self, method_name: str = ...) -> None:
+    def __init__(self, method_name: str) -> None:
         """Initialize unittest class"""
         super().__init__(methodName=method_name)
         self.magma_utils = MagmadUtil(None)

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_ded_bearer_ul_tcp.py
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestIpv6NonNatDedBearerUlTcp(unittest.TestCase):
     """Integration Test: TestIpv6NonNatDedBearerUlTcp"""
 
-    def __init__(self, method_name: str = ...) -> None:
+    def __init__(self, method_name: str) -> None:
         """Initialize unittest class"""
         super().__init__(methodName=method_name)
         self.magma_utils = MagmadUtil(None)

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_tcp.py
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestIpv6NonNatDpDlTcp(unittest.TestCase):
     """Integration Test: TestIpv6NonNatDpDlTcp"""
 
-    def __init__(self, method_name: str = ...) -> None:
+    def __init__(self, method_name: str) -> None:
         """Initialize unittest class"""
         super().__init__(methodName=method_name)
         self.magma_utils = MagmadUtil(None)

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_udp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_dl_udp.py
@@ -22,7 +22,7 @@ from s1ap_utils import MagmadUtil
 class TestIpv6NonNatDpDlUdp(unittest.TestCase):
     """Integration Test: TestIpv6NonNatDpDlUdp"""
 
-    def __init__(self, method_name: str = ...) -> None:
+    def __init__(self, method_name: str) -> None:
         """Initialize unittest class"""
         super().__init__(methodName=method_name)
         self.magma_utils = MagmadUtil(None)

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_ul_tcp.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_non_nat_dp_ul_tcp.py
@@ -23,7 +23,7 @@ from s1ap_utils import MagmadUtil
 class TestIpv6NonNatDpUlTcp(unittest.TestCase):
     """Integration Test: TestAttachDetachNonNatDpUlTcp"""
 
-    def __init__(self, method_name: str = ...) -> None:
+    def __init__(self, method_name: str) -> None:
         """Initialize unittest class"""
         super().__init__(methodName=method_name)
         self.magma_utils = MagmadUtil(None)

--- a/lte/gateway/python/load_tests/loadtest_sessiond.py
+++ b/lte/gateway/python/load_tests/loadtest_sessiond.py
@@ -12,7 +12,7 @@ limitations under the License.
 """
 import argparse
 import json
-from typing import List
+from typing import List, Optional
 
 from google.protobuf import json_format
 from load_tests.common import (
@@ -40,7 +40,7 @@ PROTO_PATH = PROTO_DIR + '/session_manager.proto'
 SERVICE_NAME = 'magma.lte.LocalSessionManager'
 
 
-def _handle_create_session_benchmarking(subs: List[SubscriberID], import_path: str = None):
+def _handle_create_session_benchmarking(subs: List[SubscriberID], import_path: Optional[str] = None):
     _build_create_session_data(subs)
     request_type = 'CreateSession'
     benchmark_grpc_request(
@@ -77,7 +77,7 @@ def _build_create_session_data(subs: List[SubscriberID]):
         json.dump(reqs, file, separators=(',', ':'))
 
 
-def _handle_end_session_benchmarking(subs: List[SubscriberID], import_path: str = None):
+def _handle_end_session_benchmarking(subs: List[SubscriberID], import_path: Optional[str] = None):
     _build_end_session_data(subs)
     request_type = 'EndSession'
     benchmark_grpc_request(

--- a/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
@@ -52,7 +52,7 @@ SingleEnodebConfig = namedtuple(
 )
 
 
-def config_assert(condition: bool, message: str = None) -> None:
+def config_assert(condition: bool, message: Optional[str] = None) -> None:
     """ To be used in place of 'assert' so that ConfigurationError is raised
         for all config-related exceptions. """
     if not condition:

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
@@ -12,7 +12,7 @@ limitations under the License.
 """
 
 import asyncio
-from typing import Dict
+from typing import Dict, Optional
 from unittest import mock
 
 from lte.protos.mconfig import mconfigs_pb2
@@ -55,7 +55,7 @@ class EnodebAcsStateMachineBuilder:
     def build_acs_state_machine(
         cls,
         device: EnodebDeviceName = EnodebDeviceName.BAICELLS,
-        service_config: Dict = None,
+        service_config: Optional[Dict] = None,
     ) -> EnodebAcsStateMachine:
         # Build the state_machine
         service = cls.build_magma_service(device, service_config)
@@ -68,7 +68,7 @@ class EnodebAcsStateMachineBuilder:
         cls,
         device: EnodebDeviceName = EnodebDeviceName.BAICELLS,
             mconfig: mconfigs_pb2.EnodebD = None,
-            service_config: Dict = None,
+            service_config: Optional[Dict] = None,
     ) -> MagmaService:
         event_loop = asyncio.get_event_loop()
         if not mconfig:

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -354,9 +354,9 @@ class IPAllocatorDHCP(IPAllocator):
             raise NoAvailableIPError(msg)
 
     def _parse_dhcp_helper_cli_response_to_store(
-            self, dhcp_desc: DHCPDescriptor, dhcp_response: Dict[str, Any],
+            self, dhcp_desc: Optional[DHCPDescriptor], dhcp_response: Dict[str, Any],
             mac: MacAddress, vlan: int,
-    ) -> DHCPDescriptor:
+    ) -> Optional[DHCPDescriptor]:
         if dhcp_response:
             dhcp_desc = DHCPDescriptor(
                 mac=mac,

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor.py
@@ -49,11 +49,11 @@ class IPDesc:
     """
 
     def __init__(
-        self, ip: IPAddress = None, state: IPState = None,
-        sid: str = None, ip_block: IPNetwork = None,
-        ip_type: IPType = None, vlan_id: int = 0,
+        self, ip: Optional[IPAddress] = None, state: Optional[IPState] = None,
+        sid: Optional[str] = None, ip_block: Optional[IPNetwork] = None,
+        ip_type: Optional[IPType] = None, vlan_id: int = 0,
     ):
-        self.ip: Optional[IPAddress] = ip
+        self.ip = ip
         self.ip_block = ip_block
         self.state = state
         self.sid = sid

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp.py
@@ -242,7 +242,7 @@ def _run_allocator_and_assert(
 
 def _assert_calls_and_deadlines(
         advance_time: int, call_args: List[str], ip_allocator: IPAllocatorDHCP,
-        reference_time: datetime.date, subprocess_mock: MagicMock,
+        reference_time: datetime, subprocess_mock: MagicMock,
 ) -> None:
     subprocess_mock.assert_called_once()
     subprocess_mock.assert_called_with(

--- a/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp_with_vlan.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_ip_allocator_dhcp_with_vlan.py
@@ -27,11 +27,10 @@ import fakeredis
 from freezegun import freeze_time
 from magma.mobilityd.dhcp_desc import DHCPDescriptor, DHCPState
 from magma.mobilityd.ip_allocator_dhcp import IPAllocatorDHCP
-from magma.mobilityd.ip_descriptor import IPDesc, IPState
+from magma.mobilityd.ip_descriptor import IPState
 from magma.mobilityd.mac import MacAddress, create_mac_from_sid
 from magma.mobilityd.mobility_store import MobilityStore
 from magma.pipelined.bridge_util import BridgeTools
-from scapy.layers.dhcp import DHCP
 
 LOG = logging.getLogger('mobilityd.dhcp.test')
 LOG.isEnabledFor(logging.DEBUG)
@@ -60,7 +59,6 @@ class IpAllocatorDhcp(unittest.TestCase):
 
         self.dhcp_wait = threading.Condition()
         self.pkt_list_lock = threading.Condition()
-        self._ip_allocator = None
 
     def tearDown(self) -> None:
         BridgeTools.destroy_bridge(self._br)

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -47,7 +47,7 @@ class MockedSubscriberDBStub:
 
     @classmethod
     def add_sub(
-        cls, sid: str, apn: str, ip: str, vlan: str = None,
+        cls, sid: str, apn: str, ip: str, vlan: Optional[str] = None,
         gw_ip=None, gw_mac=None,
     ):
         sub_db_sid = SIDUtils.to_pb(sid)
@@ -76,7 +76,7 @@ class MockedSubscriberDBStub:
 
     @classmethod
     def add_sub_ip(
-        cls, sid: str, apn: str, ip: str, vlan: str = None,
+        cls, sid: str, apn: str, ip: str, vlan: Optional[str] = None,
         gw_ip=None, gw_mac=None,
     ):
         sub_db_sid = SIDUtils.to_pb(sid)

--- a/lte/gateway/python/magma/pipelined/app/classifier.py
+++ b/lte/gateway/python/magma/pipelined/app/classifier.py
@@ -465,7 +465,7 @@ class Classifier(MagmaController):
     def _add_tunnel_ip_flow_dl(
         self, i_teid: int, ip_flow_dl: IPFlowDL,
         gtp_port: int, o_teid: int, enodeb_ip_addr: str,
-        sid: int = None,
+        sid: Optional[int] = None,
     ):
 
         priority = Utils.get_of_priority(ip_flow_dl.precedence)
@@ -792,10 +792,10 @@ class Classifier(MagmaController):
 
     def gtp_handler(
         self, session_state, precedence: int, local_f_teid: int,
-        o_teid: int, gnb_ip_addr: str, ue_ip_addr: str = None,
-        sid: int = None, ng_flag: bool = True,
-        ue_ipv6_address: str = None, apn: str = None,
-        vlan: int = 0, ip_flow_dl: IPFlowDL = None,
+        o_teid: int, gnb_ip_addr: str, ue_ip_addr: Optional[str] = None,
+        sid: Optional[int] = None, ng_flag: bool = True,
+        ue_ipv6_address: Optional[str] = None, apn: Optional[str] = None,
+        vlan: int = 0, ip_flow_dl: Optional[IPFlowDL] = None,
         session_qfi: QCI = 0,
     ):
         ue_ip_adr = None
@@ -946,8 +946,8 @@ class Classifier(MagmaController):
 
     def delete_s8_tunnel_flows(
         self, i_teid: int, ue_ip_adr: IPAddress,
-        enodeb_ip_addr: str = None, pgw_gtp_port: int = 0,
-        ip_flow_dl: IPFlowDL = None,
+        enodeb_ip_addr: Optional[str] = None, pgw_gtp_port: int = 0,
+        ip_flow_dl: Optional[IPFlowDL] = None,
     ) -> bool:
 
         # Delete flow for gtp port

--- a/lte/gateway/python/magma/pipelined/app/policy_mixin.py
+++ b/lte/gateway/python/magma/pipelined/app/policy_mixin.py
@@ -12,7 +12,7 @@ limitations under the License.
 """
 from abc import ABCMeta, abstractmethod
 from logging import Logger
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 from lte.protos.mobilityd_pb2 import IPAddress
 from lte.protos.pipelined_pb2 import (
@@ -160,7 +160,7 @@ class PolicyMixin(metaclass=ABCMeta):
         self, imsi, msisdn: bytes, uplink_tunnel: int, ip_addr, apn_ambr, flow, rule_num,
         priority, qos, hard_timeout, rule_id, app_name,
         app_service_type, next_table, version, qos_mgr,
-        copy_table, _, urls: List[str] = None, local_f_teid_ng: int = 0,
+        copy_table, _, urls: Optional[List[str]] = None, local_f_teid_ng: int = 0,
     ):
         """
         Install a flow from a rule. If the flow action is DENY, then the flow

--- a/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager_util.py
+++ b/lte/gateway/python/magma/pipelined/ng_manager/session_state_manager_util.py
@@ -20,7 +20,7 @@ from lte.protos.pipelined_pb2 import (
 
 class FARRuleEntry(NamedTuple):
     apply_action: int
-    gnb_ip_addr: str
+    gnb_ip_addr: Optional[str]
 
 
 class PDRRuleEntry(NamedTuple):

--- a/lte/gateway/python/magma/pipelined/ng_set_session_msg.py
+++ b/lte/gateway/python/magma/pipelined/ng_set_session_msg.py
@@ -190,7 +190,7 @@ class CreateSessionUtil:
     def CreateSession(
         self, imsi_val: str, pdr_state: str = "ADD", in_teid: int = 0,
         out_teid: int = 0, ue_ip_addr: str = "", gnb_ip_addr: str = "",
-        del_rule_id: str = '', add_rule_id: str = '', ipv4_dst: str = None, allow: str = "YES",
+        del_rule_id: str = '', add_rule_id: str = '', ipv4_dst: str = '', allow: str = "YES",
         priority: int = 10, hard_timeout: int = 0, apn_ambr: AggregatedMaximumBitrate = None,
     ):
 

--- a/lte/gateway/python/magma/pipelined/openflow/magma_match.py
+++ b/lte/gateway/python/magma/pipelined/openflow/magma_match.py
@@ -35,11 +35,11 @@ class MagmaMatch(object):
     """
 
     def __init__(
-        self, imsi: int = None, direction: Optional[Direction] = None,
-        rule_num: int = None, rule_version: int = None,
-        passthrough: int = None, vlan_tag: int = None,
-        app_id: int = None, proxy_tag: int = None,
-        local_f_teid_ng: int = None, **kwargs
+        self, imsi: Optional[int] = None, direction: Optional[Direction] = None,
+        rule_num: Optional[int] = None, rule_version: Optional[int] = None,
+        passthrough: Optional[int] = None, vlan_tag: Optional[int] = None,
+        app_id: Optional[int] = None, proxy_tag: Optional[int] = None,
+        local_f_teid_ng: Optional[int] = None, **kwargs
     ):
         self.imsi = imsi
         self.direction = direction

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops.py
@@ -20,6 +20,7 @@ from __future__ import (
 )
 
 from abc import ABC, abstractmethod
+from typing import Optional
 
 
 class TcOpsBase(ABC):
@@ -32,7 +33,7 @@ class TcOpsBase(ABC):
     @abstractmethod
     def create_htb(
         self, iface: str, qid: str, max_bw: int, rate: str,
-        parent_qid: str = None,
+        parent_qid: Optional[str] = None,
     ) -> int:
         """
         Create HTB scheduler

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops_cmd.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops_cmd.py
@@ -16,7 +16,7 @@ import logging
 import os
 import shlex
 import subprocess
-from typing import List  # noqa
+from typing import List, Optional  # noqa
 
 from .tc_ops import TcOpsBase
 
@@ -53,7 +53,7 @@ class TcOpsCmd(TcOpsBase):
 
     def create_htb(
         self, iface: str, qid: str, max_bw: int, rate: str,
-        parent_qid: str = None,
+        parent_qid: Optional[str] = None,
     ) -> int:
         tc_cmd = "tc class add dev {intf} parent {parent_qid} "
         tc_cmd += "classid 1:{qid} htb rate {rate} ceil {maxbw} prio 2"

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
@@ -14,7 +14,7 @@ limitations under the License.
 
 import logging
 import pprint
-from typing import Union
+from typing import Optional, Union
 
 from pyroute2 import IPRoute, NetlinkError  # pylint: disable=no-name-in-module
 
@@ -39,7 +39,7 @@ class TcOpsPyRoute2(TcOpsBase):
 
     def create_htb(
         self, iface: str, qid: str, max_bw: int, rate: str,
-        parent_qid: str = None,
+        parent_qid: Optional[str] = None,
     ) -> int:
         """
         Create HTB class for a UE session.
@@ -141,7 +141,7 @@ class TcOpsPyRoute2(TcOpsBase):
 
     def create(
         self, iface: str, qid: str, max_bw: int, rate=None,
-        parent_qid: str = None, proto=PROTOCOL,
+        parent_qid: Optional[str] = None, proto=PROTOCOL,
     ) -> int:
         err = self.create_htb(iface, qid, max_bw, rate, parent_qid)
         if err:

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -17,9 +17,10 @@ import re
 import subprocess
 from collections import namedtuple
 from concurrent.futures import Future
+from dataclasses import dataclass
 from datetime import datetime
 from difflib import unified_diff
-from typing import List, NamedTuple, Optional, Tuple
+from typing import List, Optional, Tuple
 from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
@@ -67,7 +68,8 @@ class FlowTest(namedtuple('FlowTest', ['query', 'match_num', 'flow_count'])):
         return super(FlowTest, cls).__new__(cls, query, match_num, flow_count)
 
 
-class SubTest(NamedTuple):
+@dataclass
+class SubTest:
     __test__ = False
     context: RyuDirectSubscriberContext
     isolator: RyuDirectTableIsolator
@@ -407,7 +409,7 @@ def get_enforcement_stats(enforcement_stats):
 
 def create_service_manager(
     services: List[int],
-    static_services: List[str] = None,
+    static_services: Optional[List[str]] = None,
 ):
     """
     Creates a service manager from the given list of services.

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -144,7 +144,7 @@ class InOutNonNatTest(unittest.TestCase):
 
     def setUpNetworkAndController(
         self, vlan: str = "",
-        non_nat_arp_egress_port: str = None,
+        non_nat_arp_egress_port: Optional[str] = None,
         gw_mac_addr="ff:ff:ff:ff:ff:ff",
     ):
         """


### PR DESCRIPTION
## Summary

Fixes all 60 mypy errors in lte/gateway/python. The errors can be looked at locally by running `cd $MAGMA_ROOT && mypy lte/gateway/python/`. For this, I have been using mypy version 0.991, which is the same as is running [in the CI](https://github.com/magma/magma/actions/runs/4003466751/jobs/6871604351#step:3:45).

Note that in `pipelined_test_util.py`, I converted `SubTest` from a named tuple into a dataclass, following the discussion [here](https://github.com/python/mypy/issues/3959).  

## Test Plan

- [x] Unit tests are green locally: `bazel test //lte/gateway/python/...`
- [x] Sudo tests are green locally: `bazel/scripts/run_sudo_tests.sh`
- [x] CI