### PR TITLE
docs: improve hyperlinks in magma docs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,6 +1,6 @@
 # VS Code DevContainer Environment
 
-Documentation on the usage of DevContainer can also be found in the [contributor documentation](https://docs.magmacore.org/docs/next/contributing/contribute_vscode#using-devcontainer-for-development).
+Documentation on the usage of DevContainer can also be found in the [contributor documentation](https://github.com/magma/magma/wiki/Contributing-Code-with-VSCode#using-devcontainer-for-development).
 
 
 For a comprehensive developer environment supporting AGW c / c++ workflows see the [instructions below](#using-clang-tidy-in-vs-code).
@@ -12,7 +12,7 @@ DevContainer is a technology developed by Microsoft. Thus, it is only available 
 In order to use the Github codespaces, you must be member of the Magma Github organization.
 In any case you will need a working Docker installation, as DevContainer is a docker based technology.
 
-For detailed instructions see the [contributor documentation](https://docs.magmacore.org/docs/next/contributing/contribute_vscode#using-devcontainer-for-development).
+For detailed instructions see the [contributor documentation](https://github.com/magma/magma/wiki/Contributing-Code-with-VSCode#using-devcontainer-for-development).
 
 ## Developing DevContainer
 

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: needs.skip_check.outputs.should_skip == 'false'
     env:
-      CHECK_GUIDELINE: "[Guide to the different CI checks and resolution guidelines](https://docs.magmacore.org/docs/next/contributing/contribute_ci_checks)"
+      CHECK_GUIDELINE: "[Guide to the different CI checks and resolution guidelines](https://github.com/magma/magma/wiki/Contributing-Code#continuous-integration-ci--continuous-deployment-cd)"
       WORKFLOW_NAME: "${{ github.event.workflow.name }}"
       WORKFLOW_STATUS: "${{ github.event.workflow_run.conclusion }}"
     steps:
@@ -109,7 +109,7 @@ jobs:
         run: |
           echo "Oops! Looks like you failed the \`PR Check DCO\`. Be sure to sign all your commits.
           ### Howto
-          - [Magma guidelines on signing commits](https://magma.github.io/magma/docs/next/contributing/contribute_workflow#guidelines)
+          - [Magma guidelines on signing commits](https://github.com/magma/magma/wiki/Contributing-Code#signed-off-commits)
           - [About the \`signoff\` feature](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)
           - [Howto: sign-off most-recent commit](https://stackoverflow.com/questions/13043357#answer-15667644)
           - [Howto: sign-off multiple past commits](https://gist.github.com/kwk/d70f20d17b18c4f3296d)
@@ -119,14 +119,14 @@ jobs:
         run: |
           echo "Oops! Looks like you failed the \`AGW Build & Format Python\`.
           ### Howto
-          - Instructions on running the formatter and linter locally are provided in the [format AGW doc](https://docs.magmacore.org/docs/next/lte/dev_unit_testing#format-agw)
+          - Instructions on running the formatter and linter locally are provided in the [format AGW doc](https://magma.github.io/magma/docs/lte/dev_unit_testing#format-python)
           - $CHECK_GUIDELINE" >> $GITHUB_WORKSPACE/msg
       - name: Semantic PR comment message
         if: ${{ github.event.workflow.name == 'Semantic PR' }}
         run: |
           echo "Oops! Looks like you failed the \`Semantic PR check\`.
           ### Howto
-          - [Instructions on formatting your PR title](https://magma.github.io/magma/docs/next/contributing/contribute_workflow#guidelines)
+          - [Instructions on formatting your PR title](https://github.com/magma/magma/wiki/Contributing-Code#pull-request-and-commit-message-title-are-following-conventional-commits-format)
           - For PRs with only one commit, the commit message must also be semantic. See [Changing a commit message](https://docs.github.com/en/github/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message) for a howto
           - $CHECK_GUIDELINE" >> $GITHUB_WORKSPACE/msg
       - name: Markdown lint comment message

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -46,7 +46,7 @@ jobs:
             - [Contributing Conventions](https://github.com/magma/magma/wiki/Contributing-Code-Conventions) for norms around contributed code
 
             If this is your first Magma PR, also consider reading
-            - [Developer Onboarding](https://docs.magmacore.org/docs/next/contributing/contribute_onboarding) for onboarding as a new Magma developer
+            - [Developer Onboarding](https://github.com/magma/magma/wiki/Contributor-Guide) for onboarding as a new Magma developer
             - [Development Workflow](https://github.com/magma/magma/wiki/Contributing-Code#developing-workflow) for guidance on your first pull request
             - [CI Checks](https://github.com/magma/magma/wiki/Contributing-Code#continuous-integration-ci--continuous-deployment-cd) for points of contact for failing or flaky CI checks
             - [GitHub-to-Slack mappings for Magma maintainers](https://github.com/magma/magma/wiki/Overview-of-the-Community-Structure-and-Governance) for guidance on how to contact maintainers on Slack`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
     <a href="https://github.com/magma/magma/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-BSD3clause-blue.svg" alt="License"></a>
     <a href="https://github.com/magma/magma/releases"><img src="https://img.shields.io/github/release/magma/magma" alt="GitHub Release"></a>
-    <a href="https://docs.magmacore.org/docs/next/contributing/contribute_workflow"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PR's Welcome"></a>
+    <a href="https://github.com/magma/magma/wiki/Contributing-Code"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PR's Welcome"></a>
     <a href="https://github.com/magma/magma/graphs/contributors"><img src="https://img.shields.io/github/contributors/magma/magma" alt="GitHub contributors"></a>
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/last-commit/magma/magma" alt="GitHub last commit"></a>
     <a href="https://github.com/magma/magma/commits/master"><img src="https://img.shields.io/github/commit-activity/y/magma/magma" alt="GitHub commit activity the past week"></a>
@@ -38,7 +38,7 @@ Magma has three major components
 ## Documentation
 
 - [Magma Website](https://magmacore.org/): Project landing page
-- [Docs](https://docs.magmacore.org/): Deployment, configuration and usage information
+- [Docs](https://magma.github.io/magma/docs/basics/introduction.html): Deployment, configuration and usage information
 - [Code](https://github.com/magma): Source code
 - [Contributing](https://github.com/magma/magma/wiki/Contributor-Guide): Contributor Guide
 - [Wiki](https://wiki.magmacore.org/): Meeting notes and project team resources

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5g_sa.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5g_sa.md
@@ -27,9 +27,9 @@ Following diagram gives an overview of the 5G SA components.
 
 Before starting to configure 5G SA setup, first you need to bring up a setup to handle your own/local subscribers. So before configuring Inbound Roaming you need:
 
-- Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
-- Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
+- Install [Or8cr](https:///magma.github.io/magma/docs/orc8r/architecture_overview),
+- Install [Federation Gateway](https:///magma.github.io/magma/docs/feg/deploy_intro) and,
+- Install [Access Gateway](https://magma.github.io/magma/docs/lte/setup_deb).
 - Make sure your setup is able to serve calls with your local subscribers
 
 Once you are done you need to enable the 5G feature set from the orchestrator. Also need to ensure that this AGW serves the mapped PLMN.Once done we can connect Magma AGW with GNB and the 5G supported UE.

--- a/docs/docusaurus/versioned_docs/version-1.8.0/lte/extended_5g_sa_features.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/lte/extended_5g_sa_features.md
@@ -7,7 +7,7 @@ original_id: extended_5g_sa_features
 
 # Extended Features of 5G SA FWA
 
-This document gives an overview of the Extended features added on top of the [integrated 5G SA FWA](https://docs.magmacore.org/docs/lte/integrated_5g_sa) (5G Standalone Architecture Fixed Wireless Access) such as
+This document gives an overview of the Extended features added on top of the [integrated 5G SA FWA](https://magma.github.io/magma/docs/next/lte/integrated_5g_sa) (5G Standalone Architecture Fixed Wireless Access) such as
 
 - [5G QoS](/docs/next/lte/extended_5g_sa_features#5g-qos)
 - [IPv6 & Dual IPv4v6 support](/docs/next/lte/extended_5g_sa_features#ipv6--dual-ipv4v6-support)
@@ -80,7 +80,7 @@ Here, Rule 1 is the default QoS policy and Rule 2 is the QoS policy configured a
 
 In compliance with 5G standards and to provide enhanced security, SUCI based registration has been introduced in the current release supporting both Profile-A and Profile-B configuration using ECIES-based protection scheme. With this feature end devices (UE/CPE) can encrypt the identifiers (IMSI) during the registration request using the pre-shared keys which will be then decrypted and processed by AMF.
 
-In this release AGW supports two different profiles of [SUCI Extensions](https://docs.magmacore.org/docs/next/lte/suci_extensions).
+In this release AGW supports two different profiles of [SUCI Extensions](https://magma.github.io/magma/docs/next/lte/suci_extensions).
 
 ## Stateless feature
 

--- a/docs/readmes/cwf/deploy_install.md
+++ b/docs/readmes/cwf/deploy_install.md
@@ -82,7 +82,7 @@ DOCKER_PASSWORD=<password>
 IMAGE_VERSION=latest
 GIT_HASH=master
 
-BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master
+BUILD_CONTEXT=https://github.com/magma/magma.git#master
 
 ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem
 CONTROL_PROXY_PATH=/etc/magma/control_proxy.yml

--- a/docs/readmes/feg/architecture_overview.md
+++ b/docs/readmes/feg/architecture_overview.md
@@ -15,7 +15,7 @@ simple, extensible, multi-language interfaces based on GRPC which allow develope
 complexities of 3GPP protocols. Implementing these RPC interfaces allows networks running on Magma to integrate
 with traditional 3GPP core components.
 
-![Federated Gateway architecture diagram](https://github.com/facebookincubator/magma/blob/master/docs/readmes/assets/federated_gateway_diagram.png?raw=true "FeG Architecture")
+![Federated Gateway architecture diagram](https://github.com/magma/magma/blob/master/docs/readmes/assets/federated_gateway_diagram.png?raw=true "FeG Architecture")
 
 The Federated Gateway supports the following features and functionalities:
 

--- a/docs/readmes/feg/debug_cli.md
+++ b/docs/readmes/feg/debug_cli.md
@@ -7,8 +7,7 @@ hide_title: true
 # FeG CLI
 
 Some Go services on FeG include a cli to run commands against the
-3GPP core. The different clients source code can be seen at
-[here](https://github.com/magma/magma/tree/master/feg/gateway/tools)
+3GPP core. The different clients source code can be seen in the [`feg/gateway/tools`](https://github.com/magma/magma/tree/master/feg/gateway/tools) folder.
 
 ## CLI binaries
 

--- a/docs/readmes/howtos/inbound_roaming.md
+++ b/docs/readmes/howtos/inbound_roaming.md
@@ -18,7 +18,7 @@ At the bottom of this document you have
 [configuration example](#configuration-example)
 
 TEID allocation is described on
-[Technical Reference](https://docs.magmacore.org/docs/lte/dev_teid_allocation)
+[Technical Reference](https://magma.github.io/magma/docs/lte/dev_teid_allocation)
 section.
 
 ## Architecture
@@ -96,9 +96,9 @@ Before starting to configure roaming setup, first you need to bring up a
 setup to handle your own/local subscribers. So before configuring Inbound
 Roaming you need:
 
-- Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
-- Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
+- Install [Or8cr](https://magma.github.io/magma/docs/orc8r/architecture_overview),
+- Install [Federation Gateway](https://magma.github.io/magma/docs/feg/deploy_intro) and,
+- Install [Access Gateway](https://magma.github.io/magma/docs/lte/setup_deb).
 - Create a Federate Deployment (see [below](#Create a Federated Deployment)).
 - Make sure your setup is able to serve calls with your local subscribers
 
@@ -115,7 +115,7 @@ from the `roaming` Networks and Gateways we will create in the next step.
 
 As mentioned, Inbound Roaming requires of a FeG gateway to reach the roaming
 network. That is why Federated Deployment is required. Please, configure it
-using this guide for [Federated Deployment](https://docs.magmacore.org/docs/feg/federated_FWA_setup_guide).
+using this guide for [Federated Deployment](https://magma.github.io/magma/docs/feg/federated_FWA_setup_guide).
 
 All architectures requiere a Local FeG Network to exist. However depending on
 your architecture, you may not need to create a local FeG Gateway inside that

--- a/docs/readmes/howtos/troubleshooting/user_unable_to_attach.md
+++ b/docs/readmes/howtos/troubleshooting/user_unable_to_attach.md
@@ -50,7 +50,7 @@ PROTOCOL_ERROR 111
 
 Suggested Solution:
 
-1. Identify which parameter the UE is sending in the Attach Request and compare with the ones Magma support. You can find which parameters magma is currently supported from the code. <https://github.com/magma/magma/blob/master/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c>
+1. Identify which parameter the UE is sending in the Attach Request and compare with the ones Magma support. You can find which parameters magma is currently supported from the code. <https://github.com/magma/magma/tree/master/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.cpp>
 
     Note: Make sure to select the branch you are currently have in your network(v1.1, v1.2, v1.3 , etc)
 

--- a/docs/readmes/lte/build_install_magma_pkg_in_agw.md
+++ b/docs/readmes/lte/build_install_magma_pkg_in_agw.md
@@ -25,7 +25,7 @@ Note that the following is supported starting with magma v1.9. For older version
     ```
 
 2. **Install prerequisites**.
-    Make sure you have installed all the tools specified in the prerequisites <https://magma.github.io/magma/docs/basics/prerequisites#prerequisites>
+    Make sure you have installed all the tools specified in the [prerequisites](https://magma.github.io/magma/docs/basics/prerequisites#prerequisites)
 
 3. **Build and create deb package**.
     To build an AGW package spin up a vagrant machine and then build and create a deb package.

--- a/docs/readmes/lte/datapath.md
+++ b/docs/readmes/lte/datapath.md
@@ -9,7 +9,7 @@ hide_title: true
 
 Magma gateway is a software appliance. Magma Gateway uses linux networking stack and OVS to program packet pipeline on the gateway. OVS gives us tremendous programmability to classify and process packets on the gateway
 
-![datapath components](https://github.com/facebookincubator/magma/blob/master/docs/readmes/assets/AGW-OVS.png?raw=true)
+![datapath components](https://github.com/magma/magma/blob/master/docs/readmes/assets/AGW-OVS.png?raw=true)
 
 OVS configuration has two major component.
 

--- a/docs/readmes/lte/ha_setup.md
+++ b/docs/readmes/lte/ha_setup.md
@@ -124,7 +124,7 @@ service magma@* status
 
 ### Access Gateway Configuration
 
-1. Follow the [configuration steps](https://docs.magmacore.org/docs/lte/deploy_config_agw) to register the new gateway.
+1. Follow the [configuration steps](https://magma.github.io/magma/docs/lte/deploy_config_agw) to register the new gateway.
 2. To configure the gateway to serve as a secondary use the Orc8r API (NMS does
 not currently support this functionality).
     1. Use the POST request endpoint `/lte/{network_id}/gateway_pools` to

--- a/docs/readmes/lte/pipelined.md
+++ b/docs/readmes/lte/pipelined.md
@@ -18,7 +18,7 @@ The OpenFlow pipeline of OVS contains 255 flow tables. Pipelined splits the tabl
 - Main table (Table 1 - 20)
 - Scratch table (Table 21 - 254)
 
-![OpenFlow Pipeline](https://github.com/facebookincubator/magma/blob/master/docs/readmes/assets/openflow-pipeline.png?raw=true)
+![OpenFlow Pipeline](https://github.com/magma/magma/blob/master/docs/readmes/assets/openflow-pipeline.png?raw=true)
 
 [*Source: OpenFlow Specification*](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-spec-v1.4.0.pdf)
 

--- a/docs/readmes/lte/readme_agw.md
+++ b/docs/readmes/lte/readme_agw.md
@@ -74,7 +74,7 @@ Sessiond implements the control plane for the PCEF functionality in Magma. Sessi
 
 ## Pipelined
 
-Pipelined is the control application that programs the OVS openflow rules. In implementation pipelined is a set of services that are chained together. These services can be chained and enabled/disabled through the REST API.  The README (<https://github.com/facebookincubator/magma/blob/master/README.md>) describes the contract in greater detail.
+Pipelined is the control application that programs the OVS openflow rules. In implementation pipelined is a set of services that are chained together. These services can be chained and enabled/disabled through the REST API.  The README (<https://github.com/magma/magma/blob/master/README.md>) describes the contract in greater detail.
 
 ## PolicyDB
 

--- a/docs/readmes/lte/setup_baremetal.md
+++ b/docs/readmes/lte/setup_baremetal.md
@@ -125,7 +125,7 @@ installation process to get an IP using DHCP.
 
   ``` bash
   #Clone magma repository on Ansible host
-  git clone https://github.com/facebookincubator/magma.git ~/
+  git clone https://github.com/magma/magma.git ~/
   ```
 
 - Prepare for deployment

--- a/docs/readmes/lte/tr069.md
+++ b/docs/readmes/lte/tr069.md
@@ -60,7 +60,7 @@ differences between devices. Some devices require rebooting for parameter
 changes to take effect, for example. You can add/remove behavior through this
 map, and also add custom states.
 
-[An example pull request for adding an eNB](https://github.com/facebookincubator/magma/commit/e1d4564f7daa7a4c1be135e8dbffe7a10bfa4e34)
+[An example pull request for adding an eNB](https://github.com/magma/magma/commit/e1d4564f7daa7a4c1be135e8dbffe7a10bfa4e34)
 
 ## Testing
 

--- a/docs/readmes/nms/alerts_troubleshooting.md
+++ b/docs/readmes/nms/alerts_troubleshooting.md
@@ -28,12 +28,12 @@ It is one of the key KPI and may impact network deployment/expansion/operations 
 ### Troubleshooting steps
 
 1. If any Orchestrator pods has some issue, please try to resolve that first.
-2. Make sure that Gateways are successfully checking in. If they are not checked-in, means that their metrics won’t be reported. Please follow [these steps](https://docs.magmacore.org/docs/howtos/troubleshooting/agw_unable_to_checkin) to troubleshoot.
+2. Make sure that Gateways are successfully checking in. If they are not checked-in, means that their metrics won’t be reported. Please follow [these steps](https://magma.github.io/magma/docs/howtos/troubleshooting/agw_unable_to_checkin) to troubleshoot.
 3. Perform relevant sync/changes if any update has been performed on NMS -> Network.
-4. Make sure that configuration for [Gateway](https://docs.magmacore.org/docs/lte/deploy_config_agw), [eNodeB](https://docs.magmacore.org/docs/lte/deploy_config_enodebd) and [APN](https://docs.magmacore.org/docs/lte/deploy_config_apn)has been followed.
+4. Make sure that configuration for [Gateway](https://magma.github.io/magma/docs/lte/deploy_config_agw), [eNodeB](https://magma.github.io/magma/docs/lte/deploy_config_enodebd) and [APN](https://magma.github.io/magma/docs/lte/deploy_config_apn) has been followed.
 5. If any faulty Gateway has been identified, please consider rebooting _enodebd_ service. Please consider rebooting the device (this should be done in minimal traffic duration) if need be.
 6. If still not resolved, then capture trace on eth1 interface on issue Gateway(s) to identify the case. Try to analyze and identify the cause. This will give an indication of any parameter inserted by eNodeB causing the issue.
-7. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
+7. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
 
 ### Causes / Effects/ Solutions
 
@@ -75,13 +75,13 @@ Subscribers will not be able to access the services.
 ### Troubleshooting steps
 
 1. Perform relevant sync/changes if any update has been performed on NMS -> Network.
-2. Make sure that configuration for [Gateway](https://docs.magmacore.org/docs/lte/deploy_config_agw), [eNodeB](https://docs.magmacore.org/docs/lte/deploy_config_enodebd) and [APN](https://docs.magmacore.org/docs/lte/deploy_config_apn)has been followed.
-3. Please follow troubleshooting steps from [here](https://docs.magmacore.org/docs/howtos/troubleshooting/user_unable_to_attach) for issue Gateway. Please note the error code.
+2. Make sure that configuration for [Gateway](https://magma.github.io/magma/docs/lte/deploy_config_agw), [eNodeB](https://magma.github.io/magma/docs/lte/deploy_config_enodebd) and [APN](https://magma.github.io/magma/docs/lte/deploy_config_apn) has been followed.
+3. Please follow troubleshooting steps from [here](https://magma.github.io/magma/docs/howtos/troubleshooting/user_unable_to_attach) for issue Gateway. Please note the error code.
 4. Please check mme logs, verify if the service request failures are coming from a specific user/device/model/firmware.
 5. You may use PromQL _ue_attach{networkID=&lt;NetworkID>,result="failure"}_ to isolate further.
 6. If required, please consider rebooting the problematic device (this should be done in minimal traffic duration).
 7. If still not resolved, then capture trace on eth1 interface on issue Gateway(s) to identify the case.
-8. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
+8. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
 
 ### Causes / Effects/ Solutions
 
@@ -106,7 +106,7 @@ Network, eNodeB, Gateway, Subscribers.
 
 ### Description
 
-It was observed that AGW is not able to check-in to Orchestrator as described [here](https://docs.magmacore.org/docs/lte/deploy_config_agw).
+It was observed that AGW is not able to check-in to Orchestrator as described in the [Configure Access Gateway](https://magma.github.io/magma/docs/lte/deploy_config_agw) docs.
 
 ### Why is this important?
 
@@ -121,8 +121,8 @@ Visibility of AGW will be lost. That means admins cannot perform AGW related con
 
 ### Troubleshooting steps
 
-1. Please follow [this section](https://docs.magmacore.org/docs/howtos/troubleshooting/agw_unable_to_checkin) for troubleshooting steps.
-2. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech).
+1. Please follow [this section](https://magma.github.io/magma/docs/howtos/troubleshooting/agw_unable_to_checkin) for troubleshooting steps.
+2. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech).
 
 ### Causes / Effects/ Solutions
 
@@ -164,8 +164,8 @@ Impacts the new radio deployment.
 ### Troubleshooting steps
 
 1. Please make sure that IP reachability is ok between eNodeB and AGW.
-2. Please make sure to that all the steps mentioned [here](https://docs.magmacore.org/docs/lte/deploy_config_enodebd) are followed properly.
-3. If issue still persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech).
+2. Please make sure to that all the steps mentioned [here](https://magma.github.io/magma/docs/lte/deploy_config_enodebd) are followed properly.
+3. If issue still persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech).
 
 ### Causes / Effects/ Solutions
 

--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -71,4 +71,4 @@ docker compose --compatibility up
 ```
 
 The test VM can then be set up and the tests executed by following
-[these instructions](https://docs.magmacore.org/docs/next/lte/s1ap_tests#test-vm-setup).
+[these instructions](https://magma.github.io/magma/docs/next/lte/s1ap_tests#test-vm-setup).

--- a/lte/gateway/python/load_tests/README.md
+++ b/lte/gateway/python/load_tests/README.md
@@ -18,7 +18,7 @@ failure, and so on. The options for configuration and such can be looked
 
 Spin up and provision the gateway VM. From `magma/lte/gateway` on the host machine run `vagrant up magma && vagrant ssh magma`.
 
-Next build and start the magma services. See the [integ test documentation](https://docs.magmacore.org/docs/next/lte/s1ap_tests#s1ap-integration-tests) for details.
+Next build and start the magma services. See the [integ test documentation](https://magma.github.io/magma/docs/next/lte/s1ap_tests#s1ap-integration-tests) for details.
 
 ### Run tests
 

--- a/nms/README.md
+++ b/nms/README.md
@@ -6,7 +6,7 @@ The Magma NMS provides an enterprise grade GUI for provisioning and operating ma
 >
 > This document is written to help with development of the Magma NMS
 >
-> See the [**docs**](https://docs.magmacore.org/docs/next/nms/overview) for a user-focused guide.
+> See the [**docs**](https://magma.github.io/magma/docs/next/nms/overview) for a user-focused guide.
 
 ## Project Layout
 

--- a/orc8r/cloud/deploy/bare-metal-ansible/README.md
+++ b/orc8r/cloud/deploy/bare-metal-ansible/README.md
@@ -9,7 +9,7 @@ hide_title: true
 This page walks through a full, vanilla Orchestrator install using Ansible on bare metal or a virtual machine.
 
 If you want to install a specific release version, see the notes in the
-[deployment intro](https://docs.magmacore.org/docs/orc8r/deploy_intro).
+[deployment intro](https://magma.github.io/magma/docs/orc8r/deploy_intro).
 
 ## Advanced users
 
@@ -19,7 +19,7 @@ deployment, refer to the [advanced deployment notes](docs/advanced_notes.md).
 ## Prerequisites
 
 We assume `MAGMA_ROOT` is set as described in the
-[deployment intro](https://docs.magmacore.org/docs/orc8r/deploy_intro).
+[deployment intro](https://magma.github.io/magma/docs/orc8r/deploy_intro).
 
 This walkthrough assumes you already have the following
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Many links in the docs were out of date, either showing a 404 error or being redirected to github.com / magma.github.to. Here, we improve these redirects.

## Test Plan

- Check the links.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
