### PR TITLE
fix(ci): Modify mypy configuration

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -49,7 +49,7 @@ jobs:
             javascript:
               - ["nms/**", "**/*.js"]
             python:
-              - ["lte/gateway/python/**", "orc8r/gateway/python/**"]
+              - ["**/*.py"]
             terraform:
               - ["**/*.tf"]
 
@@ -208,8 +208,9 @@ jobs:
         uses: tsuyoshicho/action-mypy@176f65a2ad781202baffaf870e5715d768d799a8 # pin@v3.9.2
         with:
           github_token: ${{ secrets.github_token }}
-          filter_mode: added
+          filter_mode: file
           reporter: github-pr-review
+          fail_on_error: true
 
   shellcheck:
     name: shellcheck

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,3 +10,11 @@ explicit_package_bases = True
 install_types = True
 non_interactive = True
 follow_imports = silent
+# Exclude several paths and files 
+exclude = (?x)(         # Exclude:
+    ^bazel[^/]+/ |      # bazel-bin, bazel-out folders etc.
+    /build/ |           # generated build folders
+    hil_testing/ |      # hil_testing folder
+    /?fabfile\.py$ |    # all fabric files
+    /?setup\.py$        # all setup files
+  )


### PR DESCRIPTION
## Summary

Closes https://github.com/magma/magma/issues/13935

This PR makes several changes to the way mypy is configured to run in the CI:
1. `filter_mode` is changed from `added` to `file`. This is what resolves https://github.com/magma/magma/issues/13935. As I understand it, `added` has the problem with mypy that if I make a change to line x that results in a mypy error on line y != x, but I have not modified y, the error will not be reported by reviewdog because y is not touched in the diff. This can often happen. With the change to `file`, :warning: ALL errors in the modified file get reported to the PR :warning:, modulo the fact that there is a maximum number that are reported to one PR (see [here](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md#limitations)). However, I think this PR is an improvement, because I would favour slight overreporting versus underreporting, and the number of mypy errors in any given file at present seems acceptable, especially since there is an effort to reduce the number of mypy errors we have. That said, this solution is not ideal and so should potentially be revisited in the future.
2. `fail_on_error` is set to `true`, which means that if mypy errors are reported in modified files, the check will be red in the CI. The hope in setting this is that it makes it more likely that mypy errors will be addressed. Of course, this is a non-required check, so the mypy errors don't have to be fixed for a PR to be merged.
3. Until now, the reviewdog mypy action only triggers if files are modified in the lte or orc8r gateway files, but mypy is then run on all python files. This PR changes this so that the step is run if any python files are changed.
4. In the mypy configuration file, several files or paths on which we don't want mypy to run are excluded. In particular, generated files, the hil_testing folder, which is not being developed, and setup and fabric files.

## Test Plan

Introduced some errors on [my fork](https://github.com/voisey/magma/pull/23) to check things are working as expected:
- mypy check [fails](https://github.com/voisey/magma/actions/runs/4014807659/jobs/6895780278) due to errors in files
- Run triggered despite no changes to lte or orc8r
- No error reported in fabfile.py due to exclusion
- Error reported in request_router.py despite the error not being on a line within the diff
- Error reported in fake_sas.py (as well as error that already existed in file...)
