### PR TITLE
chore(ci): Move magma-libfluid dependency into the bazel-base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -125,7 +125,6 @@ RUN GOBIN="/usr/bin/" go install github.com/ezekg/xo@0f7f076932dd && \
 RUN apt-get install -y --no-install-recommends \
         libtins-dev \
         magma-cpp-redis \
-        magma-libfluid \
         python3-aioeventlet
 
 ##### libgtpnl

--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -83,6 +83,7 @@ RUN add-apt-repository 'deb https://linuxfoundation.jfrog.io/artifactory/magma-p
         bcc-tools \
         libfolly-dev \
         liblfds710 \
+        magma-libfluid \
         oai-asn1c \
         oai-gnutls \
         oai-nettle \


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Move magma-libfluid dependency from the devcontainer into the bazel-base image
- Preparation for https://github.com/magma/magma/pull/14898
  -  This change is required for the bazel builds to work, as otherwise the `.so` library does not exist.



## Test Plan

- Checked manually that this Docker build contains the right libraries.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
