### PR TITLE
fix(ci): adapt failing behavior of containerized integ tests

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -263,6 +263,7 @@ jobs:
           name: test-status-extended_tests_long
 
       - name: Determine end result for all test targets
+        id: determine_end_result
         run: |
           result_precommit=$(cat test_status_precommit.txt)
           result_extended=$(cat test_status_extended_tests.txt)
@@ -270,8 +271,10 @@ jobs:
           if [ $result_precommit == $result_extended ] && [ $result_precommit == $result_extended_long ]
           then
             mv test_status_precommit.txt test_status.txt
+            echo "result=$result_precommit" >> $GITHUB_OUTPUT
           else
             echo fail > test_status.txt
+            echo "result=fail" >> $GITHUB_OUTPUT
           fi
           rm test_status_*.txt
 
@@ -297,7 +300,7 @@ jobs:
           python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} containerized_lte --url $URL
 
       - name: Notify failure to slack
-        if: failure()
+        if: ${{ steps.determine_end_result.outputs.result == 'fail' }}
         env:
           SLACK_WEBHOOK: "${{ secrets.SLACK_WEBHOOK }}"
           SLACK_USERNAME: "${{ github.workflow }}"

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -262,12 +262,12 @@ jobs:
         with:
           name: test-status-extended_tests_long
 
-      - name: Determine end result for both tests
+      - name: Determine end result for all test targets
         run: |
           result_precommit=$(cat test_status_precommit.txt)
           result_extended=$(cat test_status_extended_tests.txt)
           result_extended_long=$(cat test_status_extended_tests_long.txt)
-          if [ $result_precommit == $result_extended && $result_precommit == $result_extended_long ]
+          if [ $result_precommit == $result_extended ] && [ $result_precommit == $result_extended_long ]
           then
             mv test_status_precommit.txt test_status.txt
           else


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

There are two bugs in the "AGW Build, Publish & Test Container" workflow regarding the handling of a failing run:

1. The comparison of the individual results of the test handles is not correct bash syntax.
2. No slack notification about failing runs were ever sent because the condition is wrong.

Both these bugs are fixed here.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
