### PR TITLE
fix(cwg): fix radius udp listener

### DIFF
--- a/feg/radius/src/filters/filterstest/filter_mock.go
+++ b/feg/radius/src/filters/filterstest/filter_mock.go
@@ -35,6 +35,9 @@ func (m *MockFilter) Init(c *config.ServerConfig) error {
 // Process ...
 func (m *MockFilter) Process(c *modules.RequestContext, l string, r *radius.Request) error {
 	args := m.Called(c, l, r)
-	err := args.Get(0).(error)
-	return err
+	err := args.Get(0)
+	if err == nil {
+		return nil
+	}
+	return err.(error)
 }

--- a/feg/radius/src/server/server_test.go
+++ b/feg/radius/src/server/server_test.go
@@ -55,7 +55,6 @@ type FullRADIUSSessiontWithAnalyticsModulesTestParam struct {
 
 // TestAnalyticsModulesAuthenticate tests the Analytics module handling of the Authenticate RADIUS packet
 func TestAnalyticsModulesAuthenticate(t *testing.T) {
-	t.Skip("Skipped because test runs for 10 minutes before failing") // TODO GH14659
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
@@ -66,7 +65,6 @@ func TestAnalyticsModulesAuthenticate(t *testing.T) {
 
 // TestAnalyticsModulesAccountingStart test the processing of Accounting-Start RADIUS packet, with/out processing of Auth-Request
 func TestAnalyticsModulesAccountingStart(t *testing.T) {
-	t.Skip("Skipped because test runs for 10 minutes before failing") // TODO GH14659
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
@@ -84,7 +82,6 @@ func TestAnalyticsModulesAccountingStart(t *testing.T) {
 
 // TestAnalyticsModulesAccountingUpdate test the processing of Accounting-Update RADIUS packet, with/out processing of Auth-Request
 func TestAnalyticsModulesAccountingUpdate(t *testing.T) {
-	t.Skip("Skipped because test runs for 10 minutes before failing") // TODO GH14659
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
@@ -102,7 +99,6 @@ func TestAnalyticsModulesAccountingUpdate(t *testing.T) {
 
 // TestAnalyticsModulesAccountingStop test the processing of Accounting-Stop RADIUS packet, with/out processing of Auth-Request
 func TestAnalyticsModulesAccountingStop(t *testing.T) {
-	t.Skip("Skipped because test runs for 10 minutes before failing") // TODO GH14659
 
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
@@ -121,7 +117,6 @@ func TestAnalyticsModulesAccountingStop(t *testing.T) {
 
 // full session lifetime test of Analytics module.
 func TestFullRADIUSSessiontWithAnalyticsModules(t *testing.T) {
-	t.Skip("Skipped because test runs for 10 minutes before failing") // TODO GH14659
 
 	// Arrange
 	logger, err := zap.NewDevelopment()
@@ -143,7 +138,6 @@ func TestFullRADIUSSessiontWithAnalyticsModules(t *testing.T) {
 }
 
 func TestRequestWithModules(t *testing.T) {
-	t.Skip("Skipped because test runs for 10 minutes before failing") // TODO GH14659
 
 	// Arrange
 	logger, err := zap.NewDevelopment()
@@ -249,7 +243,6 @@ func TestModuleFailsToInit(t *testing.T) {
 }
 
 func TestModuleFailsToHandle(t *testing.T) {
-	t.Skip("Skipped because test runs for 10 minutes before failing") // TODO GH14659
 
 	// Arrange
 	logger, err := zap.NewDevelopment()
@@ -309,7 +302,6 @@ func TestFilterFailsToInit(t *testing.T) {
 }
 
 func TestFilterFailsToProcess(t *testing.T) {
-	t.Skip("Skipped because test runs for 10 minutes before failing") // TODO GH14659
 
 	// Arrange
 	config := getConfigWithFilters(t, []string{"filter.1"})
@@ -349,7 +341,6 @@ func TestFilterFailsToProcess(t *testing.T) {
 }
 
 func TestDedup(t *testing.T) {
-	t.Skip("Skipped because test runs for 10 minutes before failing") // TODO GH14659
 
 	// Arrange
 	logger, err := zap.NewDevelopment()

--- a/feg/radius/src/server/server_test.go
+++ b/feg/radius/src/server/server_test.go
@@ -55,7 +55,6 @@ type FullRADIUSSessiontWithAnalyticsModulesTestParam struct {
 
 // TestAnalyticsModulesAuthenticate tests the Analytics module handling of the Authenticate RADIUS packet
 func TestAnalyticsModulesAuthenticate(t *testing.T) {
-
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
 	testParam := analyticsModuleTestEnvCreate(t, logger)
@@ -65,7 +64,6 @@ func TestAnalyticsModulesAuthenticate(t *testing.T) {
 
 // TestAnalyticsModulesAccountingStart test the processing of Accounting-Start RADIUS packet, with/out processing of Auth-Request
 func TestAnalyticsModulesAccountingStart(t *testing.T) {
-
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
 	testParam := analyticsModuleTestEnvCreate(t, logger)
@@ -82,7 +80,6 @@ func TestAnalyticsModulesAccountingStart(t *testing.T) {
 
 // TestAnalyticsModulesAccountingUpdate test the processing of Accounting-Update RADIUS packet, with/out processing of Auth-Request
 func TestAnalyticsModulesAccountingUpdate(t *testing.T) {
-
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
 	testParam := analyticsModuleTestEnvCreate(t, logger)
@@ -99,7 +96,6 @@ func TestAnalyticsModulesAccountingUpdate(t *testing.T) {
 
 // TestAnalyticsModulesAccountingStop test the processing of Accounting-Stop RADIUS packet, with/out processing of Auth-Request
 func TestAnalyticsModulesAccountingStop(t *testing.T) {
-
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
 	testParam := analyticsModuleTestEnvCreate(t, logger)
@@ -117,7 +113,6 @@ func TestAnalyticsModulesAccountingStop(t *testing.T) {
 
 // full session lifetime test of Analytics module.
 func TestFullRADIUSSessiontWithAnalyticsModules(t *testing.T) {
-
 	// Arrange
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
@@ -138,7 +133,6 @@ func TestFullRADIUSSessiontWithAnalyticsModules(t *testing.T) {
 }
 
 func TestRequestWithModules(t *testing.T) {
-
 	// Arrange
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
@@ -243,7 +237,6 @@ func TestModuleFailsToInit(t *testing.T) {
 }
 
 func TestModuleFailsToHandle(t *testing.T) {
-
 	// Arrange
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
@@ -251,7 +244,7 @@ func TestModuleFailsToHandle(t *testing.T) {
 
 	loader := loaderstest.MockLoader{}
 
-	mModule1 := createMockHandlerWithReturn(nil, errors.New("failed to handle"))
+	mModule1 := createMockHandlerWithReturnForFailure(&modules.Response{Code: radius.CodeAccessAccept}, errors.New("failed to handle"))
 
 	loader.On("LoadModule", "module.auth.1").Return(mModule1, nil)
 
@@ -261,7 +254,7 @@ func TestModuleFailsToHandle(t *testing.T) {
 	require.True(t, isReady, "failed to initialize the server")
 
 	// Act
-	packet := radius.New(radius.CodeAccessRequest, []byte(config.Secret))
+	packet := radius.New(radius.CodeAccountingRequest, []byte(config.Secret))
 	client := radius.Client{
 		Retry: 0,
 	}
@@ -302,7 +295,6 @@ func TestFilterFailsToInit(t *testing.T) {
 }
 
 func TestFilterFailsToProcess(t *testing.T) {
-
 	// Arrange
 	config := getConfigWithFilters(t, []string{"filter.1"})
 
@@ -311,7 +303,7 @@ func TestFilterFailsToProcess(t *testing.T) {
 	loader := loaderstest.MockLoader{}
 	loader.On("LoadFilter", "filter.1").Return(mFilter1, nil)
 
-	mModule1 := createMockHandlerWithReturn(&modules.Response{}, nil)
+	mModule1 := createMockHandlerWithReturn(&modules.Response{Code: radius.CodeAccessAccept}, nil)
 	loader.On("LoadModule", "module.auth.1").Return(mModule1, nil)
 
 	server, err := New(config, zap.NewNop(), &loader)
@@ -320,7 +312,7 @@ func TestFilterFailsToProcess(t *testing.T) {
 	require.True(t, isReady, "failed to initialize the server")
 
 	// Act
-	packet := radius.New(radius.CodeAccessRequest, []byte(config.Secret))
+	packet := radius.New(radius.CodeAccountingRequest, []byte(config.Secret))
 	client := radius.Client{
 		Retry: 0,
 	}
@@ -341,14 +333,13 @@ func TestFilterFailsToProcess(t *testing.T) {
 }
 
 func TestDedup(t *testing.T) {
-
 	// Arrange
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err, "failed to get logger")
 	moduleChain := []string{"auth"}
 	moduleCount := []int{1}
 	config := getConfigWithAuthListener(t, moduleChain, moduleCount, true)
-	mModule1 := createMockHandlerWithReturn(nil, nil)
+	mModule1 := createMockHandlerWithReturnForFailure(&modules.Response{Code: radius.CodeAccessAccept}, nil)
 
 	loader := loaderstest.MockLoader{}
 	loader.On("LoadModule", "module.auth.1").Return(mModule1, nil)
@@ -356,14 +347,15 @@ func TestDedup(t *testing.T) {
 	server, err := New(config, logger, &loader)
 	assert.Equal(t, err, nil)
 	isReady := server.StartAndWait()
+
 	require.True(t, isReady, "failed to initialize the server")
-	packet := radius.New(radius.CodeAccessRequest, []byte(config.Secret))
+	packet := radius.New(radius.CodeAccountingRequest, []byte(config.Secret))
 	rfc2865.UserName_SetString(packet, "tim")
 	rfc2865.UserPassword_SetString(packet, "12345")
 
 	// Act (no response, package will be sent multiple times)
-	radius.DefaultClient.Retry, _ = time.ParseDuration("10ms")
-	deadline := time.Now().Add(time.Millisecond * 100)
+	radius.DefaultClient.Retry = 10 * time.Millisecond
+	deadline := time.Now().Add(100 * time.Millisecond)
 	d, cancelFunc := context.WithDeadline(context.Background(), deadline)
 	port := config.Listeners[0].Extra["Port"].(int)
 	_, _ = radius.Exchange(
@@ -397,7 +389,7 @@ func getConfigWithFilters(t *testing.T, filterNames []string) config.ServerConfi
 // getConfigWithAuthListener create a config with a chain of modules as set by args:
 // moduleChain the names of modules to chain - ordered is maintained
 // moduleCount the numner of module instances from the name in the same index within 'moduleChain'
-func getConfigWithAuthListener(t *testing.T, moduleChain []string, moduleCount []int, beutifyName bool) config.ServerConfig {
+func getConfigWithAuthListener(t *testing.T, moduleChain []string, moduleCount []int, beautifyName bool) config.ServerConfig {
 	require.Equal(t, len(moduleChain), len(moduleCount),
 		"chain of module must have same number of elements in names & count")
 	initialPort := 2000 + rand.Intn(5000)
@@ -424,7 +416,7 @@ func getConfigWithAuthListener(t *testing.T, moduleChain []string, moduleCount [
 		// Add module instances
 		for j := 1; j <= moduleCount[mi]; j++ {
 			modName := moduleChain[mi]
-			if beutifyName {
+			if beautifyName {
 				modName = fmt.Sprintf("module.%s.%d", moduleName, j)
 			}
 			listenerCfg.Modules = append(
@@ -458,14 +450,50 @@ func createMockHandlerWithReturn(r *modules.Response, err error) *modulestest.Mo
 	return &mModule
 }
 
+func createMockHandlerWithReturnForFailure(r *modules.Response, err error) *modulestest.MockModule {
+	mModule := modulestest.MockModule{}
+	mModule.On("Init", mock.Anything, mock.Anything).
+		Return(nil).On(
+		"Handle",
+		mock.AnythingOfType("*modules.RequestContext"),
+		mock.MatchedBy(func(req *radius.Request) bool {
+			return req.Packet.Code == radius.CodeAccountingRequest
+		}),
+		mock.AnythingOfType("modules.Middleware"),
+	).Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(*modules.RequestContext)
+		req := args.Get(1).(*radius.Request)
+		next := args.Get(2).(modules.Middleware)
+		next(ctx, req)
+	}).Return(nil, err).On(
+		"Handle",
+		mock.AnythingOfType("*modules.RequestContext"),
+		mock.AnythingOfType("*radius.Request"),
+		mock.AnythingOfType("modules.Middleware"),
+	).Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(*modules.RequestContext)
+		req := args.Get(1).(*radius.Request)
+		next := args.Get(2).(modules.Middleware)
+		next(ctx, req)
+	}).Return(r, nil)
+	return &mModule
+}
+
 func createMockFilterWithReturn(err error) *filterstest.MockFilter {
 	mFilter := filterstest.MockFilter{}
 	mFilter.On("Init", mock.Anything).Return(nil).On(
 		"Process",
 		mock.AnythingOfType("*modules.RequestContext"),
 		mock.AnythingOfType("string"),
+		mock.MatchedBy(func(req *radius.Request) bool {
+			return req.Packet.Code == radius.CodeAccountingRequest
+		}),
+	).Return(err).On(
+		"Process",
+		mock.AnythingOfType("*modules.RequestContext"),
+		mock.AnythingOfType("string"),
 		mock.AnythingOfType("*radius.Request"),
-	).Return(err)
+	).Return(nil)
 	return &mFilter
 }
 


### PR DESCRIPTION
Part of #14659 
Closes #14879 

## Summary

This PR fixes the `UDPListener` by replacing the broken logic in `ListenAndServe` with a health check, which waits until the Listener is reachable. The health check is done by sending `CodeAccessRequest` packets to the server until a response is received or a timeout is reached.

For some tests the mocks needed to be changed slightly to make the health check work, but keep the remaining test logic as is, as these tests deal with e.g. intended unresponsive radius servers.

* `TestDedup`: This test makes a mocked radius server where the handler returns `nil` responses, which will not be send. The purpose is to check the deduplication function of the UDP listener (i.e. to drop repeated identical requests from the same source). Since there is no response coming back, the request will automatically be resend. The mock is adjusted so that the radius server will respond to the health check, but not to the test packet by using different packet codes.
* `TestModuleFailsToHandle`: Similar to `TestDedup`, but the radius server sends an error. Same principle of adjusting the mock.
* `TestFilterFailsToProcess`: The packet filter is mocked to always return an error, which interferes with the health check as well. The filter mock is adjusted to return a `nil` error for the health check, and the mock function was adjusted to allow `nil` errors.

## Test Plan

Run `go clean -testcache && gotestsum -- -p 1 ./...` in /magma/feg/radius/src/server

## Additional Information

- [ ] This change is backwards-breaking

