### PR TITLE
chore(agw): Add description to MME Bazel targets

### DIFF
--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1180,6 +1180,8 @@ cc_library(
     deps = MME_DEPS,
 )
 
+# This is the default version of the MME service,
+# with OpenFlow and gRPC over S6a.
 cc_binary(
     name = "agw_of",
     srcs = ["oai/oai_mme/oai_mme.c"],
@@ -1193,6 +1195,7 @@ cc_binary(
     deps = [":lib_agw_of"],
 )
 
+# This is the OAI version of the MME service.
 cc_binary(
     name = "mme_oai",
     srcs = ["oai/oai_mme/oai_mme.c"],


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Add description to MME Bazel targets
- Resolves https://github.com/magma/magma/issues/14900

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

The current description in the Makefile is:
```
# FEATURES: What kind of flavours do you want your MME or AGW have in it
# MME is MME as described in 3GPP specs, it has at least S1AP, S11, S6a
# interfaces.
# AGW means Acces GateWay, is the result of the aggregation of MME, SGW and PGW.
# First in FEATURES, select what to you want to build : mme or agw with OpenFlow
# (OVS): FEATURE=mme_oai or agw_of
# Then you can have other features that can be built for mme or agw :
# s6a with fd (freeDiameter)

# Default is agw with OpenFlow, gRPC over S6a , (no freeDiameter over s6a).
FEATURES ?= agw_of
# AVAILABLE_FEATURE_LIST : every feature not in this list will trigger an error.
AVAILABLE_FEATURE_LIST = agw_of mme_oai
REQUESTED_FEATURE_LIST = $(sort $(FEATURES))
```


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
