### PR TITLE
Revert "chore(agw): Use system libraries for libfluid and lfds710 in Bazel (#14898)"

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -103,3 +103,39 @@ def cpp_repositories():
         strip_prefix = "libtins-4.2",
         sha256 = "a9fed73e13f06b06a4857d342bb30815fa8c359d00bd69547e567eecbbb4c3a1",
     )
+
+    new_git_repository(
+        name = "liblfds",
+        build_file = "//bazel/external:liblfds.BUILD",
+        commit = "b36a48014574225723779c7e1e9fb8cb6fa8f7f4",
+        remote = "https://liblfds.org/git/liblfds",
+        shallow_since = "1657356839 +0000",
+    )
+
+    new_git_repository(
+        name = "libfluid_base",
+        build_file = "//bazel/external:libfluid_base.BUILD",
+        commit = "56df5e20c49387ab8e6b5cd363c6c10d309f263e",
+        remote = "https://github.com/OpenNetworkingFoundation/libfluid_base",
+        shallow_since = "1448037833 -0200",
+        patches = [
+            "//third_party/build/patches/libfluid/libfluid_base_patches:EVLOOP_NO_EXIT_ON_EMPTY_compat.patch",
+            "//third_party/build/patches/libfluid/libfluid_base_patches:ExternalEventPatch.patch",
+        ],
+        patch_args = ["--strip=1"],
+    )
+
+    new_git_repository(
+        name = "libfluid_msg",
+        build_file = "//bazel/external:libfluid_msg.BUILD",
+        commit = "71a4fccdedfabece730082fbe87ef8ae5f92059f",
+        remote = "https://github.com/OpenNetworkingFoundation/libfluid_msg.git",
+        shallow_since = "1487696730 +0000",
+        patches = [
+            "//third_party/build/patches/libfluid/libfluid_msg_patches:0001-Add-TunnelIPv4Dst-support.patch",
+            "//third_party/build/patches/libfluid/libfluid_msg_patches:0002-Add-support-for-setting-OVS-reg8.patch",
+            "//third_party/build/patches/libfluid/libfluid_msg_patches:0003-Add-Reg-field-match-support.patch",
+            "//third_party/build/patches/libfluid/libfluid_msg_patches:0004-Add-TunnelIPv6Dst-support.patch",
+        ],
+        patch_args = ["--strip=1"],
+    )

--- a/bazel/external/libfluid_base.BUILD
+++ b/bazel/external/libfluid_base.BUILD
@@ -1,0 +1,54 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Manually generate config.h from config.h.in
+genrule(
+    name = "generate_config_h",
+    outs = ["config.h"],
+    cmd = "\n".join([
+        "touch $@",
+        "echo '#define HAVE_STRINGS_H 1' >> $@",
+        "echo '#define HAVE_STRING_H 1' >> $@",
+        "echo '#define HAVE_SYS_STAT_H 1' >> $@",
+        "echo '#define HAVE_SYS_TYPES_H 1' >> $@",
+        "echo '#define HAVE_TLS 1' >> $@",
+        "echo '#define HAVE_UNISTD_H 1' >> $@",
+    ]),
+)
+
+cc_library(
+    name = "fluid_base",
+    srcs = glob(
+        [
+            "fluid/*.cc",
+            "fluid/base/*.cc",
+        ],
+    ),
+    hdrs = glob(
+        [
+            "fluid/*.hh",
+            "fluid/base/*.hh",
+        ],
+    ) + [
+        ":generate_config_h",
+    ],
+    includes = [""],
+    linkopts = [
+        "-lssl",
+        "-lcrypto",
+        "-levent",
+        "-levent_pthreads",
+        "-levent_openssl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/external/libfluid_msg.BUILD
+++ b/bazel/external/libfluid_msg.BUILD
@@ -1,0 +1,54 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Manually generate config.h from config.h.in
+genrule(
+    name = "generate_config_h",
+    outs = ["config.h"],
+    cmd = "\n".join([
+        "touch $@",
+        "echo '#define HAVE_STRINGS_H 1' >> $@",
+        "echo '#define HAVE_STRING_H 1' >> $@",
+        "echo '#define HAVE_SYS_STAT_H 1' >> $@",
+        "echo '#define HAVE_SYS_TYPES_H 1' >> $@",
+        "echo '#define HAVE_UNISTD_H 1' >> $@",
+        "echo '#define HAVE_STDLIB_H 1' >> $@",
+        "echo '#define HAVE_STDINT_H 1' >> $@",
+        "echo '#define HAVE_PTHREAD 1' >> $@",
+        "echo '#define HAVE_MEMORY_H 1' >> $@",
+        "echo '#define HAVE_INTTYPES_H 1' >> $@",
+        "echo '#define HAVE_DLFCN_H 1' >> $@",
+    ]),
+)
+
+# util/util.h is included without the fluid prefix
+cc_library(
+    name = "util_h",
+    srcs = ["fluid/util/util.h"],
+    includes = ["fluid/"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "fluid_msg",
+    srcs = glob(
+        [
+            "fluid/**",
+        ],
+    ) + [
+        ":generate_config_h",
+    ],
+    includes = [""],
+    visibility = ["//visibility:public"],
+    deps = [":util_h"],
+)

--- a/bazel/external/liblfds.BUILD
+++ b/bazel/external/liblfds.BUILD
@@ -1,0 +1,20 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "lfds710",
+    srcs = glob(["liblfds/liblfds7.1.0/liblfds710/src/**"]),
+    hdrs = glob(["liblfds/liblfds7.1.0/liblfds710/inc/**"]),
+    includes = ["liblfds/liblfds7.1.0/liblfds710/inc"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/external/system_libraries.BUILD
+++ b/bazel/external/system_libraries.BUILD
@@ -68,24 +68,6 @@ cc_library(
 )
 
 cc_library(
-    name = "libfluid_base",
-    srcs = ["usr/lib/libfluid_base.so"],
-    linkopts = ["-lfluid_base"],
-)
-
-cc_library(
-    name = "libfluid_msg",
-    srcs = ["usr/lib/libfluid_msg.so"],
-    linkopts = ["-lfluid_msg"],
-)
-
-cc_library(
-    name = "liblfds710",
-    srcs = ["usr/local/lib/liblfds710.so"],
-    linkopts = ["-llfds710"],
-)
-
-cc_library(
     name = "libnettle",
     srcs = ["usr/lib/libnettle.so"],
     linkopts = ["-lnettle"],
@@ -94,10 +76,9 @@ cc_library(
 cc_library(
     name = "libglog",
     srcs = glob(
-        ["usr/lib/*-linux-gnu/libglog.so"],
+        ["usr/lib/*-linux-gnu/libglog.so.0"],
         allow_empty = False,
     ),
-    linkopts = ["-lglog"],
 )
 
 cc_library(

--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1031,8 +1031,8 @@ AGW_OF_DEPS = [
     "//lte/protos:pipelined_cpp_grpc",
     "//lte/protos/oai:sgw_state_cpp_proto",
     "//orc8r/gateway/c/common/ebpf",
-    "@system_libraries//:libfluid_base",
-    "@system_libraries//:libfluid_msg",
+    "@libfluid_base//:fluid_base",
+    "@libfluid_msg//:fluid_msg",
 ]
 
 MME_DEPS = [
@@ -1065,7 +1065,7 @@ MME_DEPS = [
     "//orc8r/gateway/c/common/service303",
     "//orc8r/protos:redis_cpp_proto",
     "@cpp_redis",
-    "@system_libraries//:liblfds710",
+    "@liblfds//:lfds710",
     "@system_libraries//:czmq",
     "@system_libraries//:libconfig",
     "@system_libraries//:libfd",

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -114,6 +114,7 @@ WORKDIR /magma
 # Copy Bazel files at root and third_party
 COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion ${MAGMA_ROOT}/
 COPY bazel/ ${MAGMA_ROOT}/bazel
+COPY third_party/build/patches/libfluid/ ${MAGMA_ROOT}/third_party/build/patches/libfluid/
 
 # Build external dependencies first. This will help not rebuilt all dependencies triggered by Magma changes.
 RUN bazel build \

--- a/third_party/build/patches/libfluid/libfluid_base_patches/BUILD.bazel
+++ b/third_party/build/patches/libfluid/libfluid_base_patches/BUILD.bazel
@@ -1,0 +1,10 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/third_party/build/patches/libfluid/libfluid_msg_patches/BUILD.bazel
+++ b/third_party/build/patches/libfluid/libfluid_msg_patches/BUILD.bazel
@@ -1,0 +1,10 @@
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION


This reverts commit afc5e8d3b837cbde8027434020d878ea2a70cee0.

Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Revert changes from https://github.com/magma/magma/pull/14898 due to issues with the Jenkins OAI job that was offline during the merge.
  - Cause of the workflow failure is a missing liblfds dynamic library in the OAI Jenkins Docker build. 
- [Slack discussion](https://magmacore.slack.com/archives/C03AXSD911T/p1675154137913399) 


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
