### PR TITLE
fix(ci): making sure OAI CI pipeline runs when bazel changes

### DIFF
--- a/ci-scripts/check_pr_modified_files_for_oai_pipeline.py
+++ b/ci-scripts/check_pr_modified_files_for_oai_pipeline.py
@@ -20,6 +20,9 @@ list_files = subprocess.check_output(cmd, shell=True, universal_newlines=True)  
 mme_is_impacted = False
 
 for line in list_files.split('\n'):
+    res = re.search('lte/gateway/c/core/BUILD.bazel', line)
+    if res is not None:
+        mme_is_impacted = True
     res = re.search('lte/gateway/Makefile', line)
     if res is not None:
         mme_is_impacted = True


### PR DESCRIPTION
## Summary

Touching lte/gateway/c/core/BUILD.bazel should trigger OAI CI pipeline

## Test Plan

none needed

## Additional Information

