### PR TITLE
fix(ci): Remove `fail_on_error: true` from mypy step in CI

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -210,7 +210,6 @@ jobs:
           github_token: ${{ secrets.github_token }}
           filter_mode: file
           reporter: github-pr-review
-          fail_on_error: true
 
   shellcheck:
     name: shellcheck


### PR DESCRIPTION
## Summary

Revert to a change made in https://github.com/magma/magma/pull/14896. This is being done due to the CI failing despite there being no relevant mypy errors, e.g. [here](https://github.com/magma/magma/actions/runs/4051490505/jobs/6973473427). It seems that `fail_on_error` is leading to non-zero exit codes being returned despite no mypy errors being present in the modified files.

## Test Plan

- [x] mypy step goes from red to [green](https://github.com/voisey/magma/actions/runs/4054332351/jobs/6976042194) on https://github.com/magma/magma/pull/14806 with this change, as expected
