### PR TITLE
fix(ci): Fix envoy_controller link for integ tests

### DIFF
--- a/lte/gateway/deploy/magma_dev.yml
+++ b/lte/gateway/deploy/magma_dev.yml
@@ -38,7 +38,7 @@
       vars:
         c_build: /home/{{ ansible_user }}/build/c
         oai_build: "{{ c_build }}/core/oai"
-        go_build: /home/{{ ansible_user }}/go/bin/
+        go_build: /home/{{ ansible_user }}/go/bin
         magma_repo: /home/{{ ansible_user }}/magma-packages
         magma_deps: /home/{{ ansible_user }}/magma-deps
     - role: bazel

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -159,7 +159,7 @@
     - { src: '{{ c_build }}/li_agent/src/liagentd', path: bin/liagentd }
     - { src: '{{ c_build }}/session_manager/sessiond', path: bin/sessiond }
     - { src: '{{ c_build }}/sctpd/src/sctpd', path: sbin/sctpd }
-    - { src: '{{ go_build }}/envoy_controller', path: envoy_controller }
+    - { src: '{{ go_build }}/envoy_controller', path: bin/envoy_controller }
     - { src: '{{ oai_build }}/oai_mme/mme', path: bin/mme }
   when: full_provision
 


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- The LTE Make dev build integ tests are broken due to an incorrect link to the envoy_controller executable in the magma_dev VM.
- This PR fixes the link by specifying the `bin` folder.
- The change to the `go_build` variable is not strictly necessary, but it removes a doubled slash in the linking of the envoy_controller. The variable is not used anywhere else.
- The bug was found during the testing of https://github.com/magma/magma/pull/14912/

## Test Plan

- [Link to LTE Make dev build integ workflow runs](https://github.com/LKreutzer/magma/actions/workflows/lte-integ-test.yml?query=branch%3Afix_integ)
  - [Only test_3485_timer_for_default_bearer_with_mme_restart failed](https://github.com/LKreutzer/magma/actions/runs/4062738354/jobs/6994141076).
  - [Fully green run](https://github.com/LKreutzer/magma/actions/runs/4062846341)
- Manual testing: Build VM, run `cd magma/lte/gateway && make`, check that the executable is there and that it can be started.

## Additional Information



- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
