### PR TITLE
docs: remove docs.magmacore.org from versioned docs

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -1498,7 +1498,7 @@
       "version-1.6.X/orc8r/version-1.6.X-dev_minikube": {
         "title": "Deploy on Minikube"
       },
-      "version-1.6.X/orc8r/version-1.6.X-RDS_upgrade": {
+      "version-1.6.X/orc8r/version-1.6.X-rds_upgrade": {
         "title": "Orchestrator DB Upgrade"
       },
       "version-1.6.X/orc8r/version-1.6.X-upgrade_1_5": {

--- a/docs/docusaurus/versioned_docs/version-1.4.X/lte/ha_setup.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.X/lte/ha_setup.md
@@ -125,7 +125,7 @@ service magma@* status
 
 ### Access Gateway Configuration
 
-1. Follow the [configuration steps](https://docs.magmacore.org/docs/lte/config_agw) to register the new gateway.
+1. Follow the [configuration steps](https://magma.github.io/magma/docs/lte/config_agw) to register the new gateway.
 2. To configure the gateway to serve as a secondary use the Orc8r API (NMS does
 not currently support this functionality).
     1. Use the POST request endpoint `/lte/{network_id}/gateway_pools` to

--- a/docs/docusaurus/versioned_docs/version-1.4.X/orc8r/upgrade_1_4.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.X/orc8r/upgrade_1_4.md
@@ -19,7 +19,7 @@ The v1.4 upgrade follows a standard procedure:
 ## Prerequisites
 
 Build and publish the application containers and Helm charts on the head of the
-release branch by following the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build)
+release branch by following the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build)
 documentation.
 
 If you are using local Terraform state (the default), ensure all Terraform

--- a/docs/docusaurus/versioned_docs/version-1.5.X/howtos/inbound_roaming.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/howtos/inbound_roaming.md
@@ -50,9 +50,9 @@ time is not supported yet.
 Before starting to configure roaming setup, first you need to bring up a
 setup to handle your own/local subscribers. So before configuring Inbound
 Roaming you need:
-- Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
-- Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
+- Install [Or8cr](https://magma.github.io/magma/docs/orc8r/architecture_overview),
+- Install [Federatetion Gateway](https://magma.github.io/magma/docs/feg/deploy_intro) and,
+- Install [Access Gateway](https://magma.github.io/magma/docs/lte/setup_deb).
 - Create a Federate Deployment (see [below](#Create a Federated Deployment)).
 - Make sure your setup is able to serve calls with your local subscribers
 
@@ -67,7 +67,7 @@ from the `roaming` Networks and Gateways we will create in the next step.
 ### Create a Federated Deployment
 As mentioned, Inbound Roaming requires of a FeG gateway to reach the roaming
 network. That is why Federated Deployment is required. Please, configure it
-using this guide for [Federated Deployment](https://docs.magmacore.org/docs/feg/federated_FWA_setup_guide).
+using this guide for [Federated Deployment](https://magma.github.io/magma/docs/feg/federated_FWA_setup_guide).
 
 All architectures requiere a Local FeG Network to exist. However depending on
 your architecture, you may not need to create a local FeG Gateway inside that

--- a/docs/docusaurus/versioned_docs/version-1.5.X/lte/ha_setup.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/lte/ha_setup.md
@@ -125,7 +125,7 @@ service magma@* status
 
 ### Access Gateway Configuration
 
-1. Follow the [configuration steps](https://docs.magmacore.org/docs/lte/deploy_config_agw) to register the new gateway.
+1. Follow the [configuration steps](https://magma.github.io/magma/docs/lte/deploy_config_agw) to register the new gateway.
 2. To configure the gateway to serve as a secondary use the Orc8r API (NMS does
 not currently support this functionality).
     1. Use the POST request endpoint `/lte/{network_id}/gateway_pools` to

--- a/docs/docusaurus/versioned_docs/version-1.5.X/orc8r/upgrade_1_4.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/orc8r/upgrade_1_4.md
@@ -19,7 +19,7 @@ The v1.4 upgrade follows a standard procedure:
 ## Prerequisites
 
 Build and publish the application containers and Helm charts on the head of the
-release branch by following the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build)
+release branch by following the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build)
 documentation.
 
 If you are using local Terraform state (the default), ensure all Terraform

--- a/docs/docusaurus/versioned_docs/version-1.5.X/orc8r/upgrade_1_5.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/orc8r/upgrade_1_5.md
@@ -21,7 +21,7 @@ Current Terraform scripts are *not* compatible with Terraform `0.15.0`.
 
 Have all application containers, and Helm charts built and published.
 These should be from the head of the release branch.
-You can follow the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build)
+You can follow the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build)
 guide for instructions on this process.
 
 **Terraform State**

--- a/docs/docusaurus/versioned_docs/version-1.6.X/lte/ha_setup.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/lte/ha_setup.md
@@ -125,7 +125,7 @@ service magma@* status
 
 ### Access Gateway Configuration
 
-1. Follow the [configuration steps](https://docs.magmacore.org/docs/lte/deploy_config_agw) to register the new gateway.
+1. Follow the [configuration steps](https://magma.github.io/magma/docs/lte/deploy_config_agw) to register the new gateway.
 2. To configure the gateway to serve as a secondary use the Orc8r API (NMS does
 not currently support this functionality).
     1. Use the POST request endpoint `/lte/{network_id}/gateway_pools` to

--- a/docs/docusaurus/versioned_docs/version-1.6.X/nms/alerts_troubleshooting.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/nms/alerts_troubleshooting.md
@@ -29,12 +29,12 @@ It is one of the key KPI and may impact network deployment/expansion/operations 
 ### Troubleshooting steps
 
 1. If any Orchestrator pods has some issue, please try to resolve that first.
-2. Make sure that Gateways are successfully checking in. If they are not checked-in, means that their metrics won’t be reported. Please follow [these steps](https://docs.magmacore.org/docs/howtos/troubleshooting/agw_unable_to_checkin) to troubleshoot.
+2. Make sure that Gateways are successfully checking in. If they are not checked-in, means that their metrics won’t be reported. Please follow [these steps](https://magma.github.io/magma/docs/howtos/troubleshooting/agw_unable_to_checkin) to troubleshoot.
 3. Perform relevant sync/changes if any update has been performed on NMS -> Network.
-4. Make sure that configuration for [Gateway](https://docs.magmacore.org/docs/lte/deploy_config_agw), [eNodeB](https://docs.magmacore.org/docs/lte/deploy_config_enodebd) and [APN ](https://docs.magmacore.org/docs/lte/deploy_config_apn)has been followed.
+4. Make sure that configuration for [Gateway](https://magma.github.io/magma/docs/lte/deploy_config_agw), [eNodeB](https://magma.github.io/magma/docs/lte/deploy_config_enodebd) and [APN ](https://magma.github.io/magma/docs/lte/deploy_config_apn)has been followed.
 5. If any faulty Gateway has been identified, please consider rebooting _enodebd_ service. Please consider rebooting the device (this should be done in minimal traffic duration) if need be.
 6. If still not resolved, then capture trace on eth1 interface on issue Gateway(s) to identify the case. Try to analyze and identify the cause. This will give an indication of any parameter inserted by eNodeB causing the issue.
-7. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
+7. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
 
 ### Causes / Effects/ Solutions
 
@@ -78,13 +78,13 @@ Subscribers will not be able to access the services.
 ### Troubleshooting steps
 
 1. Perform relevant sync/changes if any update has been performed on NMS -> Network.
-2. Make sure that configuration for [Gateway](https://docs.magmacore.org/docs/lte/deploy_config_agw), [eNodeB](https://docs.magmacore.org/docs/lte/deploy_config_enodebd) and [APN ](https://docs.magmacore.org/docs/lte/deploy_config_apn)has been followed.
-3. Please follow troubleshooting steps from [here](https://docs.magmacore.org/docs/howtos/troubleshooting/user_unable_to_attach) for issue Gateway. Please note the error code.
+2. Make sure that configuration for [Gateway](https://magma.github.io/magma/docs/lte/deploy_config_agw), [eNodeB](https://magma.github.io/magma/docs/lte/deploy_config_enodebd) and [APN ](https://magma.github.io/magma/docs/lte/deploy_config_apn)has been followed.
+3. Please follow troubleshooting steps from [here](https://magma.github.io/magma/docs/howtos/troubleshooting/user_unable_to_attach) for issue Gateway. Please note the error code.
 4. Please check mme logs, verify if the service request failures are coming from a specific user/device/model/firmware.
 5. You may use PromQL _ue_attach{networkID=&lt;NetworkID>,result="failure"}_ to isolate further.
 6. If required, please consider rebooting the problematic device (this should be done in minimal traffic duration).
 7. If still not resolved, then capture trace on eth1 interface on issue Gateway(s) to identify the case.
-8. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
+8. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
 
 ### Causes / Effects/ Solutions
 
@@ -111,7 +111,7 @@ Network, eNodeB, Gateway, Subscribers.
 
 ### Description
 
-It was observed that AGW is not able to check-in to Orchestrator as described [here](https://docs.magmacore.org/docs/lte/deploy_config_agw).
+It was observed that AGW is not able to check-in to Orchestrator as described [here](https://magma.github.io/magma/docs/lte/deploy_config_agw).
 
 ### Why is this important?
 
@@ -126,8 +126,8 @@ Visibility of AGW will be lost. That means admins cannot perform AGW related con
 
 ### Troubleshooting steps
 
-1. Please follow [this section](https://docs.magmacore.org/docs/howtos/troubleshooting/agw_unable_to_checkin) for troubleshooting steps.
-2. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech).
+1. Please follow [this section](https://magma.github.io/magma/docs/howtos/troubleshooting/agw_unable_to_checkin) for troubleshooting steps.
+2. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech).
 
 ### Causes / Effects/ Solutions
 
@@ -171,8 +171,8 @@ Impacts the new radio deployment.
 ### Troubleshooting steps
 
 1. Please make sure that IP reachability is ok between eNodeB and AGW.
-2. Please make sure to that all the steps mentioned [here](https://docs.magmacore.org/docs/lte/deploy_config_enodebd) are followed properly.
-3. If issue still persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech).
+2. Please make sure to that all the steps mentioned [here](https://magma.github.io/magma/docs/lte/deploy_config_enodebd) are followed properly.
+3. If issue still persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech).
 
 ### Causes / Effects/ Solutions
 

--- a/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/rds_upgrade.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/rds_upgrade.md
@@ -1,5 +1,5 @@
 ---
-id: version-1.6.X-RDS_upgrade
+id: version-1.6.X-rds_upgrade
 title: Orchestrator DB Upgrade
 hide_title: true
 original_id: RDS_upgrade

--- a/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/upgrade_1_5.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/upgrade_1_5.md
@@ -21,7 +21,7 @@ Current Terraform scripts are *not* compatible with Terraform `0.15.0`.
 
 Have all application containers, and Helm charts built and published.
 These should be from the head of the release branch.
-You can follow the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build)
+You can follow the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build)
 guide for instructions on this process.
 
 **Terraform State**

--- a/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/upgrade_1_6.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/upgrade_1_6.md
@@ -79,8 +79,8 @@ terraform apply  # check this output VERY carefully
 
 [AWS is terminating support for Postgres 9.6 on November 11, 2021](https://aws.amazon.com/blogs/database/upgrading-from-amazon-rds-for-postgresql-version-9-5/), in accordance with the [Postgres versioning policy](https://www.postgresql.org/support/versioning/). Postgres 9.6 was the default Orc8r DB target for the past several Magma releases.
 
-To upgrade your Postgres database to the correct version follow [these instructions](https://docs.magmacore.org/docs/orc8r/rds_upgrade#logs-and-validation).
+To upgrade your Postgres database to the correct version follow [these instructions](https://magma.github.io/magma/docs/orc8r/rds_upgrade#logs-and-validation).
 
 ### Host custom artifacts
 
-If you wish to use your own artifacts, follow the follow the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build) page to build and publish your own artifacts from the [v1.6 branch of the Magma repo](https://github.com/magma/magma/tree/v1.6), then update your `main.tf` file to point to the appropriate artifactories.
+If you wish to use your own artifacts, follow the follow the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build) page to build and publish your own artifacts from the [v1.6 branch of the Magma repo](https://github.com/magma/magma/tree/v1.6), then update your `main.tf` file to point to the appropriate artifactories.

--- a/docs/docusaurus/versioned_docs/version-1.7.0/howtos/inbound_roaming.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/howtos/inbound_roaming.md
@@ -19,7 +19,7 @@ At the bottom of this document you have
 [configuration example](#configuration-example)
 
 TEID allocation is described on
-[Technical Reference](https://docs.magmacore.org/docs/lte/dev_teid_allocation)
+[Technical Reference](https://magma.github.io/magma/docs/lte/dev_teid_allocation)
 section.
 
 ## Architecture
@@ -97,9 +97,9 @@ Before starting to configure roaming setup, first you need to bring up a
 setup to handle your own/local subscribers. So before configuring Inbound
 Roaming you need:
 
-- Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
-- Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
+- Install [Or8cr](https://magma.github.io/magma/docs/orc8r/architecture_overview),
+- Install [Federatetion Gateway](https://magma.github.io/magma/docs/feg/deploy_intro) and,
+- Install [Access Gateway](https://magma.github.io/magma/docs/lte/setup_deb).
 - Create a Federate Deployment (see [below](#Create a Federated Deployment)).
 - Make sure your setup is able to serve calls with your local subscribers
 
@@ -116,7 +116,7 @@ from the `roaming` Networks and Gateways we will create in the next step.
 
 As mentioned, Inbound Roaming requires of a FeG gateway to reach the roaming
 network. That is why Federated Deployment is required. Please, configure it
-using this guide for [Federated Deployment](https://docs.magmacore.org/docs/feg/federated_FWA_setup_guide).
+using this guide for [Federated Deployment](https://magma.github.io/magma/docs/feg/federated_FWA_setup_guide).
 
 All architectures requiere a Local FeG Network to exist. However depending on
 your architecture, you may not need to create a local FeG Gateway inside that

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/ha_setup.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/ha_setup.md
@@ -125,7 +125,7 @@ service magma@* status
 
 ### Access Gateway Configuration
 
-1. Follow the [configuration steps](https://docs.magmacore.org/docs/lte/deploy_config_agw) to register the new gateway.
+1. Follow the [configuration steps](https://magma.github.io/magma/docs/lte/deploy_config_agw) to register the new gateway.
 2. To configure the gateway to serve as a secondary use the Orc8r API (NMS does
 not currently support this functionality).
     1. Use the POST request endpoint `/lte/{network_id}/gateway_pools` to

--- a/docs/docusaurus/versioned_docs/version-1.7.0/nms/alerts_troubleshooting.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/nms/alerts_troubleshooting.md
@@ -29,12 +29,12 @@ It is one of the key KPI and may impact network deployment/expansion/operations 
 ### Troubleshooting steps
 
 1. If any Orchestrator pods has some issue, please try to resolve that first.
-2. Make sure that Gateways are successfully checking in. If they are not checked-in, means that their metrics won’t be reported. Please follow [these steps](https://docs.magmacore.org/docs/howtos/troubleshooting/agw_unable_to_checkin) to troubleshoot.
+2. Make sure that Gateways are successfully checking in. If they are not checked-in, means that their metrics won’t be reported. Please follow [these steps](https://magma.github.io/magma/docs/howtos/troubleshooting/agw_unable_to_checkin) to troubleshoot.
 3. Perform relevant sync/changes if any update has been performed on NMS -> Network.
-4. Make sure that configuration for [Gateway](https://docs.magmacore.org/docs/lte/deploy_config_agw), [eNodeB](https://docs.magmacore.org/docs/lte/deploy_config_enodebd) and [APN](https://docs.magmacore.org/docs/lte/deploy_config_apn)has been followed.
+4. Make sure that configuration for [Gateway](https://magma.github.io/magma/docs/lte/deploy_config_agw), [eNodeB](https://magma.github.io/magma/docs/lte/deploy_config_enodebd) and [APN](https://magma.github.io/magma/docs/lte/deploy_config_apn)has been followed.
 5. If any faulty Gateway has been identified, please consider rebooting _enodebd_ service. Please consider rebooting the device (this should be done in minimal traffic duration) if need be.
 6. If still not resolved, then capture trace on eth1 interface on issue Gateway(s) to identify the case. Try to analyze and identify the cause. This will give an indication of any parameter inserted by eNodeB causing the issue.
-7. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
+7. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
 
 ### Causes / Effects/ Solutions
 
@@ -76,13 +76,13 @@ Subscribers will not be able to access the services.
 ### Troubleshooting steps
 
 1. Perform relevant sync/changes if any update has been performed on NMS -> Network.
-2. Make sure that configuration for [Gateway](https://docs.magmacore.org/docs/lte/deploy_config_agw), [eNodeB](https://docs.magmacore.org/docs/lte/deploy_config_enodebd) and [APN](https://docs.magmacore.org/docs/lte/deploy_config_apn)has been followed.
-3. Please follow troubleshooting steps from [here](https://docs.magmacore.org/docs/howtos/troubleshooting/user_unable_to_attach) for issue Gateway. Please note the error code.
+2. Make sure that configuration for [Gateway](https://magma.github.io/magma/docs/lte/deploy_config_agw), [eNodeB](https://magma.github.io/magma/docs/lte/deploy_config_enodebd) and [APN](https://magma.github.io/magma/docs/lte/deploy_config_apn)has been followed.
+3. Please follow troubleshooting steps from [here](https://magma.github.io/magma/docs/howtos/troubleshooting/user_unable_to_attach) for issue Gateway. Please note the error code.
 4. Please check mme logs, verify if the service request failures are coming from a specific user/device/model/firmware.
 5. You may use PromQL _ue_attach{networkID=&lt;NetworkID>,result="failure"}_ to isolate further.
 6. If required, please consider rebooting the problematic device (this should be done in minimal traffic duration).
 7. If still not resolved, then capture trace on eth1 interface on issue Gateway(s) to identify the case.
-8. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
+8. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech). Report issue with eNodeB (vendor, firmware etc) and Magma node details along with any issue found in step 6.
 
 ### Causes / Effects/ Solutions
 
@@ -107,7 +107,7 @@ Network, eNodeB, Gateway, Subscribers.
 
 ### Description
 
-It was observed that AGW is not able to check-in to Orchestrator as described [here](https://docs.magmacore.org/docs/lte/deploy_config_agw).
+It was observed that AGW is not able to check-in to Orchestrator as described [here](https://magma.github.io/magma/docs/lte/deploy_config_agw).
 
 ### Why is this important?
 
@@ -122,8 +122,8 @@ Visibility of AGW will be lost. That means admins cannot perform AGW related con
 
 ### Troubleshooting steps
 
-1. Please follow [this section](https://docs.magmacore.org/docs/howtos/troubleshooting/agw_unable_to_checkin) for troubleshooting steps.
-2. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech).
+1. Please follow [this section](https://magma.github.io/magma/docs/howtos/troubleshooting/agw_unable_to_checkin) for troubleshooting steps.
+2. If issue persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech).
 
 ### Causes / Effects/ Solutions
 
@@ -165,8 +165,8 @@ Impacts the new radio deployment.
 ### Troubleshooting steps
 
 1. Please make sure that IP reachability is ok between eNodeB and AGW.
-2. Please make sure to that all the steps mentioned [here](https://docs.magmacore.org/docs/lte/deploy_config_enodebd) are followed properly.
-3. If issue still persists then get higher level support by providing relevant traces/logs and [additional files](https://docs.magmacore.org/docs/lte/debug_show_tech).
+2. Please make sure to that all the steps mentioned [here](https://magma.github.io/magma/docs/lte/deploy_config_enodebd) are followed properly.
+3. If issue still persists then get higher level support by providing relevant traces/logs and [additional files](https://magma.github.io/magma/docs/lte/debug_show_tech).
 
 ### Causes / Effects/ Solutions
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/upgrade_1_4.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/upgrade_1_4.md
@@ -19,7 +19,7 @@ The v1.4 upgrade follows a standard procedure:
 ## Prerequisites
 
 Build and publish the application containers and Helm charts on the head of the
-release branch by following the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build)
+release branch by following the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build)
 documentation.
 
 If you are using local Terraform state (the default), ensure all Terraform

--- a/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/upgrade_1_5.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/upgrade_1_5.md
@@ -21,7 +21,7 @@ Current Terraform scripts are *not* compatible with Terraform `0.15.0`.
 
 Have all application containers, and Helm charts built and published.
 These should be from the head of the release branch.
-You can follow the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build)
+You can follow the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build)
 guide for instructions on this process.
 
 ### Terraform State

--- a/docs/docusaurus/versioned_docs/version-1.8.0/howtos/inbound_roaming.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/howtos/inbound_roaming.md
@@ -19,7 +19,7 @@ At the bottom of this document you have
 [configuration example](#configuration-example)
 
 TEID allocation is described on
-[Technical Reference](https://docs.magmacore.org/docs/lte/dev_teid_allocation)
+[Technical Reference](https://magma.github.io/magma/docs/lte/dev_teid_allocation)
 section.
 
 ## Architecture
@@ -97,9 +97,9 @@ Before starting to configure roaming setup, first you need to bring up a
 setup to handle your own/local subscribers. So before configuring Inbound
 Roaming you need:
 
-- Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
-- Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
+- Install [Or8cr](https://magma.github.io/magma/docs/orc8r/architecture_overview),
+- Install [Federatetion Gateway](https://magma.github.io/magma/docs/feg/deploy_intro) and,
+- Install [Access Gateway](https://magma.github.io/magma/docs/lte/setup_deb).
 - Create a Federate Deployment (see [below](#Create a Federated Deployment)).
 - Make sure your setup is able to serve calls with your local subscribers
 
@@ -116,7 +116,7 @@ from the `roaming` Networks and Gateways we will create in the next step.
 
 As mentioned, Inbound Roaming requires of a FeG gateway to reach the roaming
 network. That is why Federated Deployment is required. Please, configure it
-using this guide for [Federated Deployment](https://docs.magmacore.org/docs/feg/federated_FWA_setup_guide).
+using this guide for [Federated Deployment](https://magma.github.io/magma/docs/feg/federated_FWA_setup_guide).
 
 All architectures requiere a Local FeG Network to exist. However depending on
 your architecture, you may not need to create a local FeG Gateway inside that

--- a/docs/docusaurus/versioned_docs/version-1.8.0/lte/suci_extensions.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/lte/suci_extensions.md
@@ -71,7 +71,7 @@ This flow diagram represents the network create/update flow and the modules invo
 
 ## Prerequisites
 
-Prior to configuring the SUCI extensions, you must first support [integrated 5G SA FWA](https://docs.magmacore.org/docs/lte/integrated_5g_sa) (5G Standalone Architecture Fixed Wireless Access).
+Prior to configuring the SUCI extensions, you must first support [integrated 5G SA FWA](https://magma.github.io/magma/docs/lte/integrated_5g_sa) (5G Standalone Architecture Fixed Wireless Access).
 
 ## High Level Call Flow
 

--- a/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
@@ -255,7 +255,7 @@
           "version-1.6.X-orc8r/dev_security",
           "version-1.6.X-orc8r/dev_indexers",
           "version-1.6.X-orc8r/dev_dependencies",
-          "version-1.6.X-orc8r/RDS_upgrade"
+          "version-1.6.X-orc8r/rds_upgrade"
         ]
       },
       {

--- a/docs/readmes/lte/extended_5g_sa_features.md
+++ b/docs/readmes/lte/extended_5g_sa_features.md
@@ -79,7 +79,7 @@ Here, Rule 1 is the default QoS policy and Rule 2 is the QoS policy configured a
 
 In compliance with 5G standards and to provide enhanced security, SUCI based registration has been introduced in the current release supporting both Profile-A and Profile-B configuration using ECIES-based protection scheme. With this feature end devices (UE/CPE) can encrypt the identifiers (IMSI) during the registration request using the pre-shared keys which will be then decrypted and processed by AMF.
 
-In this release AGW supports two different profiles of [SUCI Extensions](https://docs.magmacore.org/docs/next/lte/suci_extensions).
+In this release AGW supports two different profiles of [SUCI Extensions](https://magma.github.io/magma/docs/next/lte/suci_extensions).
 
 ## Stateless feature
 

--- a/docs/readmes/lte/integrated_5g_sa.md
+++ b/docs/readmes/lte/integrated_5g_sa.md
@@ -26,9 +26,9 @@ Following diagram gives an overview of the 5G SA components.
 
 Before starting to configure 5G SA setup, first you need to bring up a setup to handle your own/local subscribers. So before configuring Inbound Roaming you need:
 
-- Install [Or8cr](https://docs.magmacore.org/docs/orc8r/architecture_overview),
-- Install [Federatetion Gateway](https://docs.magmacore.org/docs/feg/deploy_intro) and,
-- Install [Access Gateway](https://docs.magmacore.org/docs/lte/setup_deb).
+- Install [Or8cr](https://magma.github.io/magma/docs/orc8r/architecture_overview),
+- Install [Federatetion Gateway](https://magma.github.io/magma/docs/feg/deploy_intro) and,
+- Install [Access Gateway](https://magma.github.io/magma/docs/lte/setup_deb).
 - Make sure your setup is able to serve calls with your local subscribers
 
 Once you are done you need to enable the 5G feature set from the orchestrator. Also need to ensure that this AGW serves the mapped PLMN.Once done we can connect Magma AGW with GNB and the 5G supported UE.

--- a/docs/readmes/orc8r/upgrade_1_4.md
+++ b/docs/readmes/orc8r/upgrade_1_4.md
@@ -18,7 +18,7 @@ The v1.4 upgrade follows a standard procedure:
 ## Prerequisites
 
 Build and publish the application containers and Helm charts on the head of the
-release branch by following the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build)
+release branch by following the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build)
 documentation.
 
 If you are using local Terraform state (the default), ensure all Terraform

--- a/docs/readmes/orc8r/upgrade_1_5.md
+++ b/docs/readmes/orc8r/upgrade_1_5.md
@@ -20,7 +20,7 @@ Current Terraform scripts are *not* compatible with Terraform `0.15.0`.
 
 Have all application containers, and Helm charts built and published.
 These should be from the head of the release branch.
-You can follow the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build)
+You can follow the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build)
 guide for instructions on this process.
 
 ### Terraform State

--- a/docs/readmes/orc8r/upgrade_1_6.md
+++ b/docs/readmes/orc8r/upgrade_1_6.md
@@ -78,7 +78,7 @@ terraform apply  # check this output VERY carefully
 
 [AWS is terminating support for Postgres 9.6 on November 11, 2021](https://aws.amazon.com/blogs/database/upgrading-from-amazon-rds-for-postgresql-version-9-5/), in accordance with the [Postgres versioning policy](https://www.postgresql.org/support/versioning/). Postgres 9.6 was the default Orc8r DB target for the past several Magma releases.
 
-To upgrade your Postgres database to the correct version follow [these instructions](https://magma.github.io/magma/docs/orc8r/RDS_upgrade#logs-and-validation).
+To upgrade your Postgres database to the correct version follow [these instructions](https://magma.github.io/magma/docs/orc8r/rds_upgrade#logs-and-validation).
 
 ### Host custom artifacts
 

--- a/docs/readmes/orc8r/upgrade_1_6.md
+++ b/docs/readmes/orc8r/upgrade_1_6.md
@@ -78,8 +78,8 @@ terraform apply  # check this output VERY carefully
 
 [AWS is terminating support for Postgres 9.6 on November 11, 2021](https://aws.amazon.com/blogs/database/upgrading-from-amazon-rds-for-postgresql-version-9-5/), in accordance with the [Postgres versioning policy](https://www.postgresql.org/support/versioning/). Postgres 9.6 was the default Orc8r DB target for the past several Magma releases.
 
-To upgrade your Postgres database to the correct version follow [these instructions](https://docs.magmacore.org/docs/orc8r/rds_upgrade#logs-and-validation).
+To upgrade your Postgres database to the correct version follow [these instructions](https://magma.github.io/magma/docs/orc8r/RDS_upgrade#logs-and-validation).
 
 ### Host custom artifacts
 
-If you wish to use your own artifacts, follow the follow the [Build Orchestrator](https://docs.magmacore.org/docs/orc8r/deploy_build) page to build and publish your own artifacts from the [v1.6 branch of the Magma repo](https://github.com/magma/magma/tree/v1.6), then update your `main.tf` file to point to the appropriate artifactories.
+If you wish to use your own artifacts, follow the follow the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build) page to build and publish your own artifacts from the [v1.6 branch of the Magma repo](https://github.com/magma/magma/tree/v1.6), then update your `main.tf` file to point to the appropriate artifactories.


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR switches the remaining links to `docs.magmacore.org` to their respective location at `magma.github.io`. The changes 

## Test Plan

`make dev` and click the links.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
