### PR TITLE
fix(agw): restart mme as a single service for one single containerize…

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py
@@ -109,7 +109,10 @@ class Test3485TimerForDefaultBearerWithMmeRestart(unittest.TestCase):
 
         print('************************* Restarting MME service on gateway')
         wait_for_restart = 20
-        self._s1ap_wrapper.magmad_util.restart_services(
+
+        # MME is explicitly restarted as a single service here to avoid a race
+        # condition between the container restarts and the T3485 timer.
+        self._s1ap_wrapper.magmad_util.restart_single_service(
             ['mme'], wait_for_restart,
         )
 


### PR DESCRIPTION
…d AGW integ test

Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Analyzing the failing S1AP integration tests based on a containerized AGW, `s1aptests/test_3485_timer_for_default_bearer_with_mme_restart.py` fails consistently. We suspect a race condition between the container restarts and the T3485 timer. For this test only, we only restart the MME container to mitigate the race condition.

Background information:
In the systemd-base AGW, magma services do have a cascading restart mechanism: if one of them restarts, several other restart as well. This was mirrored in the S1AP test framework for the containerized AGW case. In production, every container is on its own. We now restart the mme container on its own for this particular test.

## Test Plan

- [x] [Test the extended test suite](https://github.com/mpfirrmann/magma/actions/runs/4075112233)
- [x] [Test the mentioned test (+its predecessor test) 20 times](https://github.com/mpfirrmann/magma/actions/runs/4075119379)

## Additional Information

- The cascading restart dependencies are (possibly not fully) depicted in [THIS](https://excalidraw.com/#room=9b3ea34b6f337ccab568,F2DMzJxlW8yjKZtjQ2djtA) drawing.

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
