### PR TITLE
fix: order in CODEOWNERS file ensures correct revier group assignment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,49 +1,49 @@
-# approvers-infra
+/.bazel-cache/ @magma/approvers-infra
+/.bazel-cache-repo/ @magma/approvers-infra
 /.github/workflows/ @magma/approvers-infra
+
+/bazel/ @magma/approvers-infra
+
 /ci-scripts/ @magma/approvers-infra
+/cwf/ @magma/approvers-gw
 /cwf/gateway/Vagrantfile @magma/approvers-infra
+
+/dp/ @magma/approvers-cloud
+/docs/ @magma/approvers-infra
+/docs/readmes/proposals @magma/approvers-tsc
+
+/feg/ @magma/approvers-gw
+
+/lte/gateway @magma/approvers-gw
 /lte/gateway/release @magma/approvers-infra
 /lte/gateway/Vagrantfile @magma/approvers-infra
 /lte/gateway/docker @magma/approvers-infra
 /lte/gateway/python/integ_tests @magma/approvers-infra
-/orc8r/tools/packer/ @magma/approvers-infra
+/lte/protos @magma/approvers-gw
+
+/nms/ @magma/approvers-cloud
+
+/openwrt/ @magma/approvers-gw
+
+/orc8r/ @magma/approvers-cloud
 /orc8r/cloud/deploy/bare-metal/ @magma/approvers-infra
 /orc8r/cloud/deploy/bare-metal-ansible/ @magma/approvers-infra
-/third_party/build/ @magma/approvers-infra
-#  docs
-/docs/ @magma/approvers-infra
-#  bazel related
-/.bazel-cache/ @magma/approvers-infra
-/.bazel-cache-repo/ @magma/approvers-infra
-/.github/workflows/bazel.yml @magma/approvers-infra
-/bazel/ @magma/approvers-infra
-/.bazelignore @magma/approvers-infra
-/.bazelrc @magma/approvers-infra
-*.bazel @magma/approvers-infra
-
-# approvers-cloud
-*/cloud/ @magma/approvers-cloud
-/.golangci.yml @magma/approvers-cloud
-/dp/ @magma/approvers-cloud
-/nms/ @magma/approvers-cloud
-/orc8r/ @magma/approvers-cloud
-
-# approvers-gw
-/cwf/ @magma/approvers-gw
-/feg/ @magma/approvers-gw
-/lte/gateway @magma/approvers-gw
-/lte/protos @magma/approvers-gw
-/openwrt/ @magma/approvers-gw
 /orc8r/gateway/c/ @magma/approvers-gw
+/orc8r/gateway/python @magma/approvers-gw @magma/approvers-cloud
+/orc8r/tools/packer/ @magma/approvers-infra
+
 /show-tech/ @magma/approvers-gw
+
+/third_party/build/ @magma/approvers-infra
 /third_party/gtp_ovs @magma/approvers-gw
 
-# agw code related to orc8r
-/orc8r/gateway/python @magma/approvers-gw @magma/approvers-cloud
-
-# approvers-tsc
+/.bazelignore @magma/approvers-infra
+/.bazelrc @magma/approvers-infra
+/.golangci.yml @magma/approvers-cloud
 /CODEOWNERS @magma/approvers-tsc
-/docs/readmes/proposals @magma/approvers-tsc
+
+*.bazel @magma/approvers-infra
+*/cloud/ @magma/approvers-cloud
 
 # Generated code excluded from code ownership
 **/go.mod @ghost


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

In #14823 the CODEOWNER file was modified (codeowner groups were merged). In this context some entries were reordered -> clustering by codeowner group.

The CODEOWNER file is evaluated sequentially, i.e., if `some/path/file` is changed and we have
```
/some/path/ @group1
/some/ @group2
```
then `@group2` is assigned. If the entries in the CODEOWNER file are switched then `@group1` gets assigned (this is usually intended if a special group is set for a sub-path).

In some cases this case is currently problematic. See for example #14946 where `@magma/approvers-gw` was added because we have
```
/lte/gateway/python/integ_tests @magma/approvers-infra
/lte/gateway @magma/approvers-gw
```
This needs to be switched.

#### Here:
* order the entries by pathes and take care that special rules for sub-pathes are evaluated last.
* also remove `/.github/workflows/bazel.yml @magma/approvers-infra` as this is already covered by `/.github/workflows/ @magma/approvers-infra` (got visible by reordering) 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
