### PR TITLE
docs: Remove unused Tutorials section from sidebars

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -2089,7 +2089,6 @@
     },
     "categories": {
       "Getting Started": "Getting Started",
-      "Tutorials": "Tutorials",
       "Usage": "Usage",
       "Architecture": "Architecture",
       "Deploy": "Deploy",

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -6,7 +6,6 @@
       "basics/quick_start_guide",
       "bazel/agw_with_bazel"
     ],
-    "Tutorials": [],
     "Usage": [
       {
         "type": "subcategory",

--- a/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
@@ -5,7 +5,6 @@
       "version-1.5.X-basics/prerequisites",
       "version-1.5.X-basics/quick_start_guide"
     ],
-    "Tutorials": [],
     "Usage": [
       {
         "type": "subcategory",

--- a/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
@@ -5,7 +5,6 @@
       "version-1.6.X-basics/prerequisites",
       "version-1.6.X-basics/quick_start_guide"
     ],
-    "Tutorials": [],
     "Usage": [
       {
         "type": "subcategory",

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -5,7 +5,6 @@
       "version-1.7.0-basics/prerequisites",
       "version-1.7.0-basics/quick_start_guide"
     ],
-    "Tutorials": [],
     "Usage": [
       {
         "type": "subcategory",

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -5,7 +5,6 @@
       "version-1.8.0-basics/prerequisites",
       "version-1.8.0-basics/quick_start_guide"
     ],
-    "Tutorials": [],
     "Usage": [
       {
         "type": "subcategory",


### PR DESCRIPTION
## Summary

Removes an unused field from the docs sidebars which has been empty since being introduced [here](https://github.com/magma/magma/pull/5733/files#diff-d93a04e99f75fbb5acb6cc1aad2718fbdbf754d6894419e4430046e99c47dd5f).

## Test Plan

- [x] Run `cd $MAGMA_ROOT/docs && make dev`
