### PR TITLE
chore(ci): Use reviewdog action for cpplint job

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -75,19 +75,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
-        name: Install CPP Lint and ReviewDog
-      - run: |
-          wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
-          | sh -s -- -b .
-          pip install cpplint
-      - name: Run CPP Lint and push Annotations
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cpplint --recursive \
-            --filter=-build/include_subdir,-build/c++11,-build/include_what_you_use \
-            --linelength=120 ${{ github.workspace }} 2>&1 \
-            | ./reviewdog -efm="%f:%l: %m" -name="cpplint" -reporter="github-pr-review" -level="warning"
+      # TODO: Switch to a release version, once a release of action-cpplint is available.
+      # See also https://github.com/reviewdog/action-cpplint/issues/29
+      - name: cpplint
+        uses: reviewdog/action-cpplint@a5d486c641b1ae5fd018b4fe6bf7bef3bc6e506e
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          flags: --linelength=120
+          filter: "-build/include_subdir\
+            ,-build/c++11\
+            ,-build/include_what_you_use\
+            "
+          reviewdog_flags: -fail-on-error
 
   golangci-lint:
     needs: files_changed


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Use reviewdog action for cpplint job instead of running the commands manually.
- The flags are kept equivalent - with the exception of the `level`, which was moved to `-level="error"` to get the job to fail if errors are found. Some flags are already the default value and were removed.
- There is currently no released version of the action, however the action is used in many other repositories. For security the action is fixed to the currently newest commit. There is a comment to update the action to a release version once available.
- First step towards https://github.com/magma/magma/issues/14931


## Test Plan

- [Test PR on fork](https://github.com/LKreutzer/magma/pull/13), with this commit on the master branch. 
  - This is needed due to the `pull_request_target` trigger.
  - [Failing run](https://github.com/LKreutzer/magma/actions/runs/4104853872)
  - [Successful run](https://github.com/LKreutzer/magma/actions/runs/4104990377)
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
