### PR TITLE
docs: Remove unused AGW subsection from sidebars

### DIFF
--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -25,11 +25,6 @@
       },
       {
         "type": "subcategory",
-        "label": "Access Gateway",
-        "ids": []
-      },
-      {
-        "type": "subcategory",
         "label": "NMS",
         "ids": [
           "nms/overview",

--- a/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
@@ -20,11 +20,6 @@
       },
       {
         "type": "subcategory",
-        "label": "Access Gateway",
-        "ids": []
-      },
-      {
-        "type": "subcategory",
         "label": "Orchestrator",
         "ids": [
           "version-1.5.X-howtos/thanos"

--- a/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
@@ -20,11 +20,6 @@
       },
       {
         "type": "subcategory",
-        "label": "Access Gateway",
-        "ids": []
-      },
-      {
-        "type": "subcategory",
         "label": "NMS",
         "ids": [
           "version-1.6.X-nms/overview",

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -23,11 +23,6 @@
       },
       {
         "type": "subcategory",
-        "label": "Access Gateway",
-        "ids": []
-      },
-      {
-        "type": "subcategory",
         "label": "NMS",
         "ids": [
           "version-1.7.0-nms/overview",

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -24,11 +24,6 @@
       },
       {
         "type": "subcategory",
-        "label": "Access Gateway",
-        "ids": []
-      },
-      {
-        "type": "subcategory",
         "label": "NMS",
         "ids": [
           "version-1.8.0-nms/overview",


### PR DESCRIPTION
## Summary

This removes an unused sidebar from the docs configuration, which has been unused since being introduced [here](https://github.com/magma/magma/pull/5733/files#diff-d93a04e99f75fbb5acb6cc1aad2718fbdbf754d6894419e4430046e99c47dd5fR24).

## Test Plan

- I ran `cd $MAGMA_ROOT/docs && make dev` successfully locally
- I checked that for each of the modified versions, the "Usage" sidebar looks the same on master and this branch