### PR TITLE
docs: Clean up NMS architecture page in sidebars

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -281,7 +281,7 @@
       "nms/alerts_troubleshooting": {
         "title": "Alerts"
       },
-      "nms/nms_arch_overview": {
+      "nms/architecture_overview": {
         "title": "Overview"
       },
       "nms/dashboard": {
@@ -1282,7 +1282,7 @@
       "version-1.5.X/nms/version-1.5.X-alerts": {
         "title": "Alerts"
       },
-      "version-1.5.X/nms/version-1.5.X-nms_arch_overview": {
+      "version-1.5.X/nms/version-1.5.X-architecture_overview": {
         "title": "Overview"
       },
       "version-1.5.X/nms/version-1.5.X-deploy_config": {
@@ -1784,7 +1784,7 @@
       "version-1.7.0/nms/version-1.7.0-alerts_troubleshooting": {
         "title": "Alerts"
       },
-      "version-1.7.0/nms/version-1.7.0-nms_arch_overview": {
+      "version-1.7.0/nms/version-1.7.0-architecture_overview": {
         "title": "Overview"
       },
       "version-1.7.0/nms/version-1.7.0-dashboard": {
@@ -2033,7 +2033,7 @@
       "version-1.8.0/lte/version-1.8.0-suci_extensions": {
         "title": "SUCI Extensions"
       },
-      "version-1.8.0/nms/version-1.8.0-nms_arch_overview": {
+      "version-1.8.0/nms/version-1.8.0-architecture_overview": {
         "title": "Overview"
       },
       "version-1.8.0/nms/version-1.8.0-deploy_setup": {

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -67,7 +67,7 @@
         "type": "subcategory",
         "label": "NMS",
         "ids": [
-          "nms/nms_arch_overview"
+          "nms/architecture_overview"
         ]
       },
       {

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -60,8 +60,7 @@
         "ids": [
           "orc8r/architecture_overview",
           "orc8r/architecture_modularity",
-          "orc8r/architecture_security",
-          "nms/nms_arch_overview"
+          "orc8r/architecture_security"
         ]
       },
       {

--- a/docs/docusaurus/versioned_docs/version-1.5.X/nms/architecture_overview.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/nms/architecture_overview.md
@@ -1,8 +1,8 @@
 ---
-id: version-1.5.X-nms_arch_overview
+id: version-1.5.X-architecture_overview
 title: Overview
 hide_title: true
-original_id: nms_arch_overview
+original_id: architecture_overview
 ---
 # Overview
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/nms/architecture_overview.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/nms/architecture_overview.md
@@ -1,8 +1,8 @@
 ---
-id: version-1.7.0-nms_arch_overview
+id: version-1.7.0-architecture_overview
 title: Overview
 hide_title: true
-original_id: nms_arch_overview
+original_id: architecture_overview
 ---
 # Overview
 

--- a/docs/docusaurus/versioned_docs/version-1.8.0/nms/architecture_overview.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/nms/architecture_overview.md
@@ -1,8 +1,8 @@
 ---
-id: version-1.8.0-nms_arch_overview
+id: version-1.8.0-architecture_overview
 title: Overview
 hide_title: true
-original_id: nms_arch_overview
+original_id: architecture_overview
 ---
 # Overview
 

--- a/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
@@ -71,8 +71,7 @@
         "ids": [
           "version-1.5.X-orc8r/architecture_overview",
           "version-1.5.X-orc8r/architecture_modularity",
-          "version-1.5.X-orc8r/architecture_security",
-          "version-1.5.X-nms/nms_arch_overview"
+          "version-1.5.X-orc8r/architecture_security"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
@@ -78,7 +78,7 @@
         "type": "subcategory",
         "label": "NMS",
         "ids": [
-          "version-1.5.X-nms/nms_arch_overview"
+          "version-1.5.X-nms/architecture_overview"
         ]
       }
     ],

--- a/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
@@ -62,7 +62,7 @@
         "type": "subcategory",
         "label": "NMS",
         "ids": [
-          "version-1.6.X-nms/nms_arch_overview"
+          "version-1.6.X-nms/architecture_overview"
         ]
       }
     ],

--- a/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
@@ -55,8 +55,7 @@
         "ids": [
           "version-1.6.X-orc8r/architecture_overview",
           "version-1.6.X-orc8r/architecture_modularity",
-          "version-1.6.X-orc8r/architecture_security",
-          "version-1.6.X-nms/nms_arch_overview"
+          "version-1.6.X-orc8r/architecture_security"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -65,7 +65,7 @@
         "type": "subcategory",
         "label": "NMS",
         "ids": [
-          "version-1.7.0-nms/nms_arch_overview"
+          "version-1.7.0-nms/architecture_overview"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -58,8 +58,7 @@
         "ids": [
           "version-1.7.0-orc8r/architecture_overview",
           "version-1.7.0-orc8r/architecture_modularity",
-          "version-1.7.0-orc8r/architecture_security",
-          "version-1.7.0-nms/nms_arch_overview"
+          "version-1.7.0-orc8r/architecture_security"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -66,7 +66,7 @@
         "type": "subcategory",
         "label": "NMS",
         "ids": [
-          "version-1.8.0-nms/nms_arch_overview"
+          "version-1.8.0-nms/architecture_overview"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -59,8 +59,7 @@
         "ids": [
           "version-1.8.0-orc8r/architecture_overview",
           "version-1.8.0-orc8r/architecture_modularity",
-          "version-1.8.0-orc8r/architecture_security",
-          "version-1.8.0-nms/nms_arch_overview"
+          "version-1.8.0-orc8r/architecture_security"
         ]
       },
       {

--- a/docs/readmes/nms/architecture_overview.md
+++ b/docs/readmes/nms/architecture_overview.md
@@ -1,5 +1,5 @@
 ---
-id: nms_arch_overview
+id: architecture_overview
 title: Overview
 hide_title: true
 ---


### PR DESCRIPTION
## Summary

This removes the duplicate entry of the NMS architecture page in the documentation sidebars configuration. It also makes the ID of the page consistent with its file name in line with https://github.com/magma/magma/issues/14965.

## Test Plan

- I ran `cd $MAGMA_ROOT/docs && make dev` successfully locally
- I checked that for each of the modified versions, the "Architecture" sidebar looks the same on master and this branch
