### PR TITLE
docs: Fix ids of two proposals so they appear in sidebars

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -470,7 +470,7 @@
       "proposals/p015_tech_debt_week": {
         "title": "Tech Debt Week Processes"
       },
-      "proposals/p016_nms_regression_test": {
+      "proposals/p016_nms_regression_testing": {
         "title": "NMS Regression Testing"
       },
       "proposals/p017_apn_refactoring": {
@@ -1513,7 +1513,7 @@
       "version-1.6.X/proposals/version-1.6.X-p010_vendor_neutral_dp": {
         "title": "Vendor Neutral CBSD Domain Proxy"
       },
-      "version-1.6.X/proposals/version-1.6.X-p016_nms_regression_test": {
+      "version-1.6.X/proposals/version-1.6.X-p016_nms_regression_testing": {
         "title": "NMS Regression Testing"
       },
       "version-1.6.X/proposals/version-1.6.X-p017_apn_refactoring": {
@@ -1946,7 +1946,7 @@
       "version-1.7.0/proposals/version-1.7.0-p015_tech_debt_week": {
         "title": "Tech Debt Week Processes"
       },
-      "version-1.7.0/proposals/version-1.7.0-p016_nms_regression_test": {
+      "version-1.7.0/proposals/version-1.7.0-p016_nms_regression_testing": {
         "title": "NMS Regression Testing"
       },
       "version-1.7.0/proposals/version-1.7.0-p017_apn_refactoring": {

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -358,7 +358,7 @@
         "label": "Access Gateway",
         "ids": [
           "proposals/p003_qos_enforcement",
-          "proposals/p004_fua-restrict-feature",
+          "proposals/p004_fua_restrict_feature",
           "proposals/p007_header_enrichment",
           "proposals/p008_apn_correction",
           "proposals/p013_Ubuntu_upgrade",

--- a/docs/docusaurus/versioned_docs/version-1.6.X/proposals/p016_nms_regression_testing.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/proposals/p016_nms_regression_testing.md
@@ -1,8 +1,8 @@
 ---
-id: version-1.6.X-p016_nms_regression_test
+id: version-1.6.X-p016_nms_regression_testing
 title: NMS Regression Testing
 hide_title: true
-original_id: p016_nms_regression_test
+original_id: p016_nms_regression_testing
 ---
 
 # Proposal: NMS Regression Testing

--- a/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p016_nms_regression_testing.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p016_nms_regression_testing.md
@@ -1,8 +1,8 @@
 ---
-id: version-1.7.0-p016_nms_regression_test
+id: version-1.7.0-p016_nms_regression_testing
 title: NMS Regression Testing
 hide_title: true
-original_id: p016_nms_regression_test
+original_id: p016_nms_regression_testing
 ---
 
 # Proposal: NMS Regression Testing

--- a/docs/docusaurus/versioned_sidebars/version-1.4.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.4.X-sidebars.json
@@ -134,7 +134,7 @@
       "version-1.4.X-proposals/p001_vpn_config_from_api",
       "version-1.4.X-proposals/p002_scaled_prometheus_pipeline",
       "version-1.4.X-proposals/p003_qos_enforcement",
-      "version-1.4.X-proposals/p004_fua-restrict-feature",
+      "version-1.4.X-proposals/p004_fua_restrict_feature",
       "version-1.4.X-proposals/p005_call_tracing",
       "version-1.4.X-proposals/p007_header_enrichment",
       "version-1.4.X-proposals/p008_apn_correction",

--- a/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.5.X-sidebars.json
@@ -210,7 +210,7 @@
       "version-1.5.X-proposals/p001_vpn_config_from_api",
       "version-1.5.X-proposals/p002_scaled_prometheus_pipeline",
       "version-1.5.X-proposals/p003_qos_enforcement",
-      "version-1.5.X-proposals/p004_fua-restrict-feature",
+      "version-1.5.X-proposals/p004_fua_restrict_feature",
       "version-1.5.X-proposals/p005_call_tracing",
       "version-1.5.X-proposals/p007_header_enrichment",
       "version-1.5.X-proposals/p008_apn_correction",

--- a/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.6.X-sidebars.json
@@ -265,7 +265,7 @@
       "version-1.6.X-proposals/p001_vpn_config_from_api",
       "version-1.6.X-proposals/p002_scaled_prometheus_pipeline",
       "version-1.6.X-proposals/p003_qos_enforcement",
-      "version-1.6.X-proposals/p004_fua-restrict-feature",
+      "version-1.6.X-proposals/p004_fua_restrict_feature",
       "version-1.6.X-proposals/p005_call_tracing",
       "version-1.6.X-proposals/p007_header_enrichment",
       "version-1.6.X-proposals/p008_apn_correction",

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -360,7 +360,7 @@
         "label": "Access Gateway",
         "ids": [
           "version-1.7.0-proposals/p003_qos_enforcement",
-          "version-1.7.0-proposals/p004_fua-restrict-feature",
+          "version-1.7.0-proposals/p004_fua_restrict_feature",
           "version-1.7.0-proposals/p007_header_enrichment",
           "version-1.7.0-proposals/p008_apn_correction",
           "version-1.7.0-proposals/p013_Ubuntu_upgrade",

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -365,7 +365,7 @@
         "label": "Access Gateway",
         "ids": [
           "version-1.8.0-proposals/p003_qos_enforcement",
-          "version-1.8.0-proposals/p004_fua-restrict-feature",
+          "version-1.8.0-proposals/p004_fua_restrict_feature",
           "version-1.8.0-proposals/p007_header_enrichment",
           "version-1.8.0-proposals/p008_apn_correction",
           "version-1.8.0-proposals/p013_Ubuntu_upgrade",

--- a/docs/readmes/proposals/p016_nms_regression_testing.md
+++ b/docs/readmes/proposals/p016_nms_regression_testing.md
@@ -1,5 +1,5 @@
 ---
-id: p016_nms_regression_test
+id: p016_nms_regression_testing
 title: NMS Regression Testing
 hide_title: true
 ---


### PR DESCRIPTION
## Summary

There are two proposals that have not been displayed in the docs for several releases due to a mismatch in the `id` in `sidebars.json` and that in the proposal doc itself. For the "Service Restriction Feature" proposal, I fix this by correcting the ids in the sidebar files, while for the "NMS Regression Testing" proposal, I correct the ids in the proposal docs according to the convention described [here](https://github.com/magma/magma/issues/14965).

## Test Plan

- I ran `cd $MAGMA_ROOT/docs && make dev` successfully locally
- I checked that for each of the modified versions, the two proposal pages now appear in the sidebar as expected