### PR TITLE
chore(agw): bump version number of AGW VMs

### DIFF
--- a/orc8r/tools/packer/vagrant-box-upload.sh
+++ b/orc8r/tools/packer/vagrant-box-upload.sh
@@ -7,7 +7,7 @@ FORCE="--no-force"
 
 USER=magmacore
 BOX=$(basename $BOX_FILE | cut -d_ -f1-2 | cut -d. -f1)
-VERSION="1.2.$(date +"%Y%m%d")"
+VERSION="1.3.$(date +"%Y%m%d")"
 BOX_PROVIDER=virtualbox
 if echo $BOX_FILE | grep -q libvirt; then
   BOX_PROVIDER=libvirt


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The latest AGW VMs are tagged with version `1.3.$DATE`. This was done manually via the vagrant CLI tool after uploading them. This PR reflects this change in the upload script.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
