### PR TITLE
chore(ci): explicitly cache boxes in Cwf integ test

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -63,11 +63,16 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
           ref: ${{ github.sha }}
-      - name: Cache Vagrant Boxes
+      - name: Cache ubuntu generic box for CWF VMs
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
-          path: ~/.vagrant.d/boxes
-          key: vagrant-boxes-cwf-v1.3.20221230
+          path: ~/.vagrant.d/boxes/generic-VAGRANTSLASH-ubuntu2004
+          key: vagrant-box-generic-ubuntu2004-v4.0.2
+      - name: Cache magma-trfserver-box
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        with:
+          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
+          key: vagrant-box-magma-trfserver-v1.3.20221230
       - name: Log in to vagrant cloud
         run: |
           if [[ -n "${{ secrets.VAGRANT_TOKEN }}" ]]


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

All vagrant boxes were cached for the CWF integration tests. This is not necessary and only needs cache space. For this workflow, three VMs are built: cwag, cwag_test, and magma_trfserver. The two cwag VMs are base on the `generic/ubuntu2004` box and the traffic server is based on our own `magmacore/trfserver` box.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
