### PR TITLE
chore: unify bare ubuntu boxes

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Cache ubuntu generic box for CWF VMs
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
-          path: ~/.vagrant.d/boxes/generic-VAGRANTSLASH-ubuntu2004
-          key: vagrant-box-generic-ubuntu2004-v4.0.2
+          path: ~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-focal64
+          key: vagrant-box-ubuntu-focal64-v20230207.0.0
       - name: Cache magma-trfserver-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-focal64
-          key: vagrant-box-magma-deb-focal64-20220804.0.0
+          key: vagrant-box-ubuntu-focal64-v20230207.0.0
       - name: Cache magma-test-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:
           path: ~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-focal64
-          key: vagrant-box-magma-deb-focal64-20220804.0.0
+          key: vagrant-box-ubuntu-focal64-v20230207.0.0
       - name: Cache magma-test-box
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
         with:

--- a/cwf/gateway/Vagrantfile
+++ b/cwf/gateway/Vagrantfile
@@ -21,16 +21,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder "../..", "/home/vagrant/magma"
 
   config.vm.define :cwag, primary: true do |cwag|
-    cwag.vm.box = "generic/ubuntu2004"
-    cwag.vm.box_version = "4.0.2"
+    cwag.vm.box = "ubuntu/focal64"
+    cwag.vm.box_version = "20230207.0.0"
     cwag.vbguest.auto_update = false
     cwag.vm.hostname = "cwag-dev"
     cwag.vm.network "private_network", ip: "192.168.70.101", nic_type: "82540EM"
     # Set to an internal network to prevent possible connection to vagrant host instead of other VM
     cwag.vm.network "private_network", ip: "192.168.129.23", nic_type: "82540EM", virtualbox__intnet: "ipv4_sgi"
     cwag.vm.network "private_network", ip: "192.168.40.11", nic_type: "82540EM"
-    cwag.ssh.password = "vagrant"
-    cwag.ssh.insert_key = true
 
     cwag.vm.provider "virtualbox" do |vb|
       vb.name = "cwag-dev"
@@ -108,14 +106,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define :cwag_test, primary: true do |cwag_test|
-    cwag_test.vm.box = "generic/ubuntu2004"
-    cwag_test.vm.box_version = "4.0.2"
+    cwag_test.vm.box = "ubuntu/focal64"
+    cwag_test.vm.box_version = "20230207.0.0"
     cwag_test.vm.hostname = "cwag-test"
     cwag_test.vm.network "private_network", ip: "192.168.70.102", nic_type: "82540EM"
     cwag_test.vm.network "private_network", ip: "192.168.40.12", nic_type: "82540EM"
     cwag_test.vm.network "forwarded_port", guest: 40000, host: 40000
-    cwag_test.ssh.password = "vagrant"
-    cwag_test.ssh.insert_key = true
 
     cwag_test.vm.provider "virtualbox" do |vb|
       vb.name = "cwag-test"

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -215,7 +215,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define :magma_deb, autostart: false do |magma_deb|
 
     magma_deb.vm.box = "ubuntu/focal64"
-    magma_deb.vm.box_version = "20220804.0.0"
+    magma_deb.vm.box_version = "20230207.0.0"
     magma_deb.vm.hostname = "magma-deb"
     magma_deb.vbguest.auto_update = false
 


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

We use bare Ubuntu boxes as a basis for several Magma VMs. So far, two different boxes have been used, `generic/ubuntu2004` and `ubuntu/focal64`. 

- For easier maintenance we change these machines to all be based on `ubuntu/focal64`.
- The used version was bumped to the most recent, `v20230207.0.0`.
- Closes #14984.

## Test Plan

- [ ] [CWF integ tests](https://github.com/mpfirrmann/magma/actions/runs/4142039235)
- [ ] [LTE integ tests on `magma_deb` built with `make`](https://github.com/mpfirrmann/magma/actions/runs/4142034171)
- [ ] [LTE integ tests on `magma_deb` built with `bazel`
](https://github.com/mpfirrmann/magma/actions/runs/4142035890)

## Additional Information

- This also has the benefit of less caching space needed in GitHub actions.

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
