### PR TITLE
chore: gh caches are used for bazel caches - affects magma_test integ test env build

### DIFF
--- a/.github/workflows/composite/bazel-gh-cache/action.yml
+++ b/.github/workflows/composite/bazel-gh-cache/action.yml
@@ -1,0 +1,66 @@
+# Copyright 2023 The Magma Authors.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Update Bazel Caches on GitHub
+description: Pulls caches for .bazel-cache and .bazel-cache-repo for a given key prefix and purges them based on a threshold
+
+inputs:
+  cache-key-prefix:
+    description: A prefix used for cache keys
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set variables
+      shell: bash
+      run: |
+        echo "BAZEL_CACHE_NAME=${{ env.BAZEL_CACHE_NAME }}" >> $GITHUB_ENV
+        echo "BAZEL_CACHE_REPO_NAME=${{ env.BAZEL_CACHE_REPO_NAME }}" >> $GITHUB_ENV
+        echo "BAZEL_CACHE_CUTOFF_MB=${{ env.BAZEL_CACHE_CUTOFF_MB }}" >> $GITHUB_ENV
+        echo "BAZEL_CACHE_REPO_CUTOFF_MB=${{ env.BAZEL_CACHE_REPO_CUTOFF_MB }}" >> $GITHUB_ENV
+        echo "BAZEL_CACHE_DIR=.${{ env.BAZEL_CACHE_NAME }}" >> $GITHUB_ENV
+        echo "BAZEL_CACHE_REPO_DIR=.${{ env.BAZEL_CACHE_REPO_NAME }}" >> $GITHUB_ENV
+      env:
+        BAZEL_CACHE_NAME: bazel-cache
+        BAZEL_CACHE_REPO_NAME: bazel-cache-repo
+        BAZEL_CACHE_CUTOFF_MB: 500
+        BAZEL_CACHE_REPO_CUTOFF_MB: 500
+
+    - name: Bazel Cache
+      uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # pin@v3.2.4
+      with:
+        path: ${{ github.workspace }}/${{ env.BAZEL_CACHE_DIR }}
+        key: ${{ inputs.cache-key-prefix }}-${{ env.BAZEL_CACHE_NAME }}-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ env.BAZEL_CACHE_NAME }}-
+
+    - name: Bazel Cache Repo
+      uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # pin@v3.2.4
+      with:
+        path: ${{ github.workspace }}/${{ env.BAZEL_CACHE_REPO_DIR }}
+        key: ${{ inputs.cache-key-prefix }}-${{ env.BAZEL_CACHE_REPO_NAME }}-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ env.BAZEL_CACHE_REPO_NAME }}-
+
+    # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a
+    # situation where the cache never updates (e.g. due to exceeding GitHub's cache size limit)
+    # thereby only ever using the last successful cache version. This solution will result in a
+    # few slower CI actions around the time cache is detected to be too large, but it should
+    # incrementally improve thereafter.
+    - name: Ensure cache size BAZEL_CACHE
+      shell: bash
+      run: |
+        ./.github/workflows/scripts/check-bazel-cache-dir-size.sh "${{ env.BAZEL_CACHE_DIR }}" "${{ env.BAZEL_CACHE_CUTOFF_MB }}"
+    - name: Ensure cache size BAZEL_CACHE_REPO
+      shell: bash
+      run: |
+        ./.github/workflows/scripts/check-bazel-cache-dir-size.sh "${{ env.BAZEL_CACHE_REPO_DIR }}" "${{ env.BAZEL_CACHE_REPO_CUTOFF_MB }}"

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -129,6 +129,9 @@ jobs:
           else
             echo "Vagrant cloud token is not configured. Skipping login."
           fi
+      - uses: ./.github/workflows/composite/bazel-gh-cache
+        with:
+          cache-key-prefix: magma_test
       - name: Build test vms
         run: |
           cd ${{ env.AGW_ROOT }} && fab build_test_vms

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -20,6 +20,11 @@ on:
   repository_dispatch:
     types: [magma-debian-artifact]
 
+env:
+  BAZEL_CACHE: bazel-cache
+  BAZEL_CACHE_REPO: bazel-cache-repo
+  BAZEL_ENV: magma_test
+
 jobs:
   lte-integ-test-bazel-magma-deb:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
@@ -44,6 +49,40 @@ jobs:
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v1.3.20221230
+
+      - name: Bazel Cache
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # pin@v3.2.4
+        with:
+          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE }}
+          key: ${{ env.BAZEL_ENV }}-${{ env.BAZEL_CACHE }}-${{ github.sha }}
+          restore-keys: |
+            ${{ env.BAZEL_ENV }}-${{ env.BAZEL_CACHE }}-
+
+      - name: Bazel Cache Repo
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # pin@v3.2.4
+        with:
+          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE_REPO }}
+          key: ${{ env.BAZEL_ENV }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
+          restore-keys: |
+            ${{ env.BAZEL_ENV }}-${{ env.BAZEL_CACHE_REPO }}-
+
+      # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a
+      # situation where the cache never updates (e.g. due to exceeding GitHub's cache size limit)
+      # thereby only ever using the last successful cache version. This solution will result in a
+      # few slower CI actions around the time cache is detected to be too large, but it should
+      # incrementally improve thereafter.
+      - name: Ensure cache size BAZEL_CACHE
+        env:
+          BAZEL_CACHE_DIR: .${{ env.BAZEL_CACHE }}
+          BAZEL_CACHE_CUTOFF_MB: 500
+        run: |
+          ./.github/workflows/scripts/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
+      - name: Ensure cache size BAZEL_CACHE_REPO
+        env:
+          BAZEL_CACHE_REPO_DIR: .${{ env.BAZEL_CACHE_REPO }}
+          BAZEL_CACHE_REPO_CUTOFF_MB: 500
+        run: |
+          ./.github/workflows/scripts/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_REPO_DIR" "$BAZEL_CACHE_REPO_CUTOFF_MB"
 
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -20,11 +20,6 @@ on:
   repository_dispatch:
     types: [magma-debian-artifact]
 
-env:
-  BAZEL_CACHE: bazel-cache
-  BAZEL_CACHE_REPO: bazel-cache-repo
-  BAZEL_ENV: magma_test
-
 jobs:
   lte-integ-test-bazel-magma-deb:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
@@ -50,39 +45,9 @@ jobs:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v1.3.20221230
 
-      - name: Bazel Cache
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # pin@v3.2.4
+      - uses: ./.github/workflows/composite/bazel-gh-cache
         with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE }}
-          key: ${{ env.BAZEL_ENV }}-${{ env.BAZEL_CACHE }}-${{ github.sha }}
-          restore-keys: |
-            ${{ env.BAZEL_ENV }}-${{ env.BAZEL_CACHE }}-
-
-      - name: Bazel Cache Repo
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # pin@v3.2.4
-        with:
-          path: ${{ github.workspace }}/.${{ env.BAZEL_CACHE_REPO }}
-          key: ${{ env.BAZEL_ENV }}-${{ env.BAZEL_CACHE_REPO }}-${{ github.sha }}
-          restore-keys: |
-            ${{ env.BAZEL_ENV }}-${{ env.BAZEL_CACHE_REPO }}-
-
-      # This check is needed to ensure that Bazel's unbounded cache growth doesn't result in a
-      # situation where the cache never updates (e.g. due to exceeding GitHub's cache size limit)
-      # thereby only ever using the last successful cache version. This solution will result in a
-      # few slower CI actions around the time cache is detected to be too large, but it should
-      # incrementally improve thereafter.
-      - name: Ensure cache size BAZEL_CACHE
-        env:
-          BAZEL_CACHE_DIR: .${{ env.BAZEL_CACHE }}
-          BAZEL_CACHE_CUTOFF_MB: 500
-        run: |
-          ./.github/workflows/scripts/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_DIR" "$BAZEL_CACHE_CUTOFF_MB"
-      - name: Ensure cache size BAZEL_CACHE_REPO
-        env:
-          BAZEL_CACHE_REPO_DIR: .${{ env.BAZEL_CACHE_REPO }}
-          BAZEL_CACHE_REPO_CUTOFF_MB: 500
-        run: |
-          ./.github/workflows/scripts/check-bazel-cache-dir-size.sh "$BAZEL_CACHE_REPO_DIR" "$BAZEL_CACHE_REPO_CUTOFF_MB"
+          cache-key-prefix: magma_test
 
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -83,6 +83,9 @@ jobs:
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v1.3.20221230
+      - uses: ./.github/workflows/composite/bazel-gh-cache
+        with:
+          cache-key-prefix: magma_test
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:
           python-version: '3.8.10'

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v1.3.20221230
+      - uses: ./.github/workflows/composite/bazel-gh-cache
+        with:
+          cache-key-prefix: magma_test
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:
           python-version: '3.8.10'

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -48,6 +48,9 @@ jobs:
           else
             echo "Vagrant cloud token is not configured. Skipping login."
           fi
+      - uses: ./.github/workflows/composite/bazel-gh-cache
+        with:
+          cache-key-prefix: magma_test
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:
           python-version: '3.8.10'

--- a/.github/workflows/scripts/check-bazel-cache-dir-size.sh
+++ b/.github/workflows/scripts/check-bazel-cache-dir-size.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2023 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script should be run from $MAGMA_ROOT
+
+# Relative path to cache directory from $MAGMA_ROOT
+RELATIVE_CACHE_DIR="$1"
+CUTOFF_MB="$2"
+
+# See https://stackoverflow.com/a/27485157 for reference.
+CACHE_SIZE_MB=$(du -smc "$RELATIVE_CACHE_DIR" | grep "$RELATIVE_CACHE_DIR" | cut -f1)
+echo "Total size of the Bazel cache (rounded up to MBs): $CACHE_SIZE_MB"
+
+if [[ "$CACHE_SIZE_MB" -gt "$CUTOFF_MB" ]]; then
+    echo "Cache exceeds the cut-off size, emptying the cache. The following build will be slower and refill the cache."
+    rm -rf "$RELATIVE_CACHE_DIR"
+fi


### PR DESCRIPTION
Signed-off-by: Nils Semmelrock <nils.semmelrock@tngtech.com>

## Summary

After merging #14912 the CI runs executing integration tests on magma_test became substantially slower ~40 Minutes. The reason is the build time of the test environment with Bazel - without using any caches. This change mitigates this by using GitHub caches for managing Bazel caches (this method was used at the beginning of the Bazel effort for all Bazel caching). 

## Test Plan

Only build magma_test in workflow and execute `make prepare_environment`.

* First run without filled caches
  * https://github.com/nstng/magma/actions/runs/4135686749/attempts/1
  * ~1h
* Second run with filled caches
  * https://github.com/nstng/magma/actions/runs/4135686749/attempts/2
  * ~15min
* cache uses
  * ![01_caches](https://user-images.githubusercontent.com/42540177/218034868-40c8428a-20d2-4c38-801f-d29e388a7168.png)
  * (note: prefix `macOS` got renamed)

Updated run using the composite action introduced in second commit:
* https://github.com/nstng/magma/actions/runs/4143464564/attempts/1 initial run (~1h)
* https://github.com/nstng/magma/actions/runs/4143464564/attempts/2 second run (~15Min)
* created caches on GitHub are similar (modulo the name)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
