### PR TITLE
chore: Require codeowner for go.mod changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,7 +46,6 @@
 */cloud/ @magma/approvers-cloud
 
 # Generated code excluded from code ownership
-**/go.mod @ghost
 **/go.sum @ghost
 **/*.pb.go @ghost
 **/*_swaggergen.go @ghost


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Currently the `go.mod` files are not owned by any codeowner group. Instead they are handled, together with the generated files, e.g. `go.sum`, by the non-existent `@ghost` group.
  - The `go.mod` files are generated, however they should be reviewed as they define the pinning of dependencies for Go builds. 
- The problem with the current setup is that when PRs are opened that only change these files, e.g. by the dependabot, then no codeowner groups are notified and no codeowner approval is needed for any changes to these files.
  - See:
    - #14843 
    -  #14804 
    -  #14803
    - #14844 
-  The changes in this PR remove the `go.mod` files from the non-existent `@ghost` group and **implicitly** move them into the codeowner groups that own the folders where they are located.
   - Note that many `go.mod` files are located in `cloud` folders, which means that they are automatically owned via `*/cloud/ @magma/approvers-cloud`.
   - All `go.mod` files are located in folders owned by codeowners.
- Resolves #14868

## Test Plan

- Verify that all `go.mod` files are owned by the approver groups.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
