### PR TITLE
fix(ci): Bump wemake-python-styleguide action version

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -260,7 +260,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: wemake-python-styleguide
-        uses: wemake-services/wemake-python-styleguide@b8260e79fcbc2feeae2dd4aae2b59ed86aafbf9d # pin@0.15.2
+        uses: wemake-services/wemake-python-styleguide@657508a0b169e15faeda641c4d9c7bc2afda484b # pin@0.17.0
         with:
           reporter: github-pr-review
           path: ${{ steps.py-changes.outputs.py }}

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -259,11 +259,21 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
+      - name: Get changed Python files
+        id: py-changes
+        # Set outputs.py_files_list to be a list of modified python files.
+        # It is important to use the github.event.pull_request.head.sha here,
+        # because the github.sha is identical to the github.event.pull_request.base.sha
+        # due to the pull_request_target trigger.
+        run: |
+          echo "py_files_list=$(git diff --name-only --diff-filter=ACMRT \
+            ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
+            | grep .py$ | xargs)" >> $GITHUB_OUTPUT
       - name: wemake-python-styleguide
         uses: wemake-services/wemake-python-styleguide@657508a0b169e15faeda641c4d9c7bc2afda484b # pin@0.17.0
         with:
           reporter: github-pr-review
-          path: ${{ steps.py-changes.outputs.py }}
+          path: ${{ steps.py-changes.outputs.py_files_list }}
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
 

--- a/lte/gateway/docker/python-precommit/Dockerfile
+++ b/lte/gateway/docker/python-precommit/Dockerfile
@@ -1,20 +1,14 @@
-FROM python:3.8-alpine as builder
-
-RUN addgroup -S linter && adduser -S -G linter linter
-RUN apk add --no-cache git gcc musl-dev # temp
-
-COPY lte/gateway/docker/python-precommit/requirements.txt /
-RUN pip wheel -r /requirements.txt --wheel-dir=/wheelhouse/
-
-
-FROM python:3.8-alpine as runner
+FROM python:3.9.10-alpine
 
 RUN addgroup -S linter && adduser -S -G linter linter
 
-RUN apk add --no-cache jq
-
-COPY --from=builder /wheelhouse/ /wheelhouse/
-RUN pip install /wheelhouse/*
+# Installing wemake-python-styleguide==0.17.0 is not
+# working with a requirements.in file.
+# hadolint ignore=DL3013
+RUN pip install --no-cache-dir wemake-python-styleguide==0.17.0 \
+                add-trailing-comma \
+                isort \
+                autopep8
 
 USER linter
 WORKDIR /code/

--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -29,7 +29,7 @@ LINT_DOCKER_PATH = os.path.join(
 IMAGE_NAME = 'magma/py-lint'
 ORC8R_PYTHON_PATH = 'orc8r/gateway/python/magma'
 LTE_PYTHON_PATH = 'lte/gateway/python/magma'
-GITHUB_IMAGE_NAME = 'ghcr.io/magma/magma/python-precommit:sha-b22d512'
+GITHUB_IMAGE_NAME = 'ghcr.io/magma/magma/python-precommit:latest'
 
 
 def main() -> None:


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Bump `wemake-python-styleguide` action version to latest release and update the Python-precommit Docker image to use the same version.
  - Follow up task to refactor the Docker setup https://github.com/magma/magma/issues/15000 
  - Updated the tag used in `precommit.py` to use the container with the new version.
- Current job failure is due to known issue, see
  - https://github.com/wemake-services/wemake-python-styleguide/issues/2436
  - https://github.com/wemake-services/wemake-python-styleguide/issues/2369
- :warning: The job has been broken for as long as the GitHub logs are retained. 
  - There has been a lot of regression!
  - The job is not 'required' however.
  - Follow-up issue to fix the regression: https://github.com/magma/magma/issues/14999
- Installing `wemake-python-styleguide` is not working with a `requirements.in` file anymore for the Docker build, due to version clashes of dependencies. Instead it can be installed directly in the Docker image.
  - The Docker image is published in CI, but only downloaded for local development.
  - The Docker image is rebuild in CI for every PR in the `AGW Build & Format Python` workflow/ `Python format check` job
    - This job only runs on changed Python files. 
  - The new Dockerfile is based on this [Dockerfile](https://github.com/wemake-services/wemake-python-styleguide/blob/master/Dockerfile).
- Resolves #14850

## Test Plan

- The job run on this PR is expected to fail, because the workflow trigger is `pull_request_target` and the workflow file is taken from master and does not include the changes from this PR.

- I created a [test PR on my fork](https://github.com/LKreutzer/magma/pull/15), see [run results](https://github.com/LKreutzer/magma/actions/runs/4144843259/jobs/7168411744), [newer run](https://github.com/LKreutzer/magma/actions/runs/4163632756/jobs/7204274718).
  - When the crypto folder is removed [the error vanishes](https://github.com/LKreutzer/magma/actions/runs/4144952580/jobs/7168664674), all other warnings remain. Same logging can be reproduced locally.
- Test local commands, see `lte/gateway/docker/python-precommit/README.md`.
  - To reproduce the issues that the new linter version mentions in CI (takes ca. 6 min.), run:
    - `./lte/gateway/python/precommit.py  --build ./`
    - `./lte/gateway/python/precommit.py  --lint  --local --paths ./`
    - Locally this can also include errors from the `docs` or `build` folders.
    - The default options do not specify `--paths` and only run on the changes of the last commit.
- [`Python format check` run on test PR](https://github.com/LKreutzer/magma/actions/runs/4163103843/jobs/7203083061)
  - This job builds the container again in CI. 
  - The job only runs on Python changes - the test file does not have any issues, but the Docker build works.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
