### PR TITLE
docs: Fixed a symbolic link

### DIFF
--- a/lte/README.md
+++ b/lte/README.md
@@ -1,1 +1,1 @@
-../docs/readmes/lte/README_AGW.md
+../docs/readmes/lte/readme_agw.md

--- a/third_party/build/patches/aioeventlet/aioeventlet.py38.patch
+++ b/third_party/build/patches/aioeventlet/aioeventlet.py38.patch
@@ -1,1 +1,0 @@
-../../../../lte/gateway/deploy/roles/magma/files/patches/aioeventlet.py38.patch

--- a/third_party/build/patches/aioeventlet/aioeventlet_fd_exception.patch
+++ b/third_party/build/patches/aioeventlet/aioeventlet_fd_exception.patch
@@ -1,1 +1,0 @@
-../../../../lte/gateway/deploy/roles/magma/files/patches/aioeventlet_fd_exception.patch


### PR DESCRIPTION
Signed-off-by: Moritz Huebner <moritz.huebner@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

One symbolic link was broken in https://github.com/magma/magma/pull/14923. 
By running `find . -xtype l` I found two addtional broken links connected to #13044 which can be safely removed

## Test Plan

Running `find . -xtype l` in the `$MAGMA_ROOT` directory shows the broken symlinks. We could consider adding a CI check to ensure that there are no broken symlinks.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
