### PR TITLE
chore(ci): refactor getting test summaries from VMs

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -227,13 +227,13 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
 
       - name: Create test_results directory
-        run: mkdir -p lte/gateway/test-results
+        run: mkdir -p lte/gateway/test_results
 
       - name: Download test results of precommit tests
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
         with:
-          name: test-results-precommit
-          path: "${{ github.workspace }}/lte/gateway/test-results"
+          name: test_results_precommit
+          path: "${{ github.workspace }}/lte/gateway/test_results"
 
       - name: Download final status of precommit tests
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
@@ -243,8 +243,8 @@ jobs:
       - name: Download test results of extended tests
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
         with:
-          name: test-results-extended_tests
-          path: "${{ github.workspace }}/lte/gateway/test-results"
+          name: test_results_extended_tests
+          path: "${{ github.workspace }}/lte/gateway/test_results"
 
       - name: Download final status of of extended tests
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
@@ -254,8 +254,8 @@ jobs:
       - name: Download test results of long extended tests
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
         with:
-          name: test-results-extended_tests_long
-          path: "${{ github.workspace }}/lte/gateway/test-results"
+          name: test_results_extended_tests_long
+          path: "${{ github.workspace }}/lte/gateway/test_results"
 
       - name: Download final status of of long extended tests
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
@@ -294,7 +294,7 @@ jobs:
           REPORT_FILENAME: "lte_integ_test_containerized${{ github.sha }}.html"
         run: |
           npm install -g xunit-viewer
-          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -d "lte/gateway/test_results/" ] && { xunit-viewer -r lte/gateway/test_results/ -o "$REPORT_FILENAME"; }
           [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
           [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
           python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} containerized_lte --url $URL

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -177,7 +177,7 @@ jobs:
         if: always()
         run: |
           cd lte/gateway
-          fab get-test-summaries --integration-tests --dst-path="test-results"
+          fab get-test-summaries --integration-tests
           ls -R
       - name: Upload test results
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -183,8 +183,8 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
-          name: test-results
-          path: lte/gateway/test-results/**/*.xml
+          name: test_results
+          path: lte/gateway/test_results/**/*.xml
       - name: Get test logs
         if: always()
         run: |
@@ -201,7 +201,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/composite@46ab8d49369d898e381a607119161771bc65c2a6 # pin@v2.2.0
         with:
           check_name: FEG integration test results
-          junit_files: lte/gateway/test-results/**/*.xml
+          junit_files: lte/gateway/test_results/**/*.xml
           check_run_annotations: all tests
       - name: Publish results to Firebase
         if: always() && github.event_name == 'push'
@@ -210,7 +210,7 @@ jobs:
           REPORT_FILENAME: "feg_integ_test_${{ github.sha }}.html"
         run: |
           npm install -g xunit-viewer
-          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -d "lte/gateway/test_results/" ] && { xunit-viewer -r lte/gateway/test_results/ -o "$REPORT_FILENAME"; }
           [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
           [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
           python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} feg --url $URL

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -87,14 +87,14 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
-          name: test-results
-          path: lte/gateway/test-results/**/*.xml
+          name: test_results
+          path: lte/gateway/test_results/**/*.xml
       - name: Publish Unit Test Results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action/composite@46ab8d49369d898e381a607119161771bc65c2a6 # pin@v2.2.0
         with:
           check_name: LTE Debian integration test results
-          junit_files: lte/gateway/test-results/**/*.xml
+          junit_files: lte/gateway/test_results/**/*.xml
           check_run_annotations: all tests
 
       - name: Get test logs
@@ -116,7 +116,7 @@ jobs:
           REPORT_FILENAME: "lte_integ_test_magma_deb_${{ github.event.client_payload.trigger_sha }}.html"
         run: |
           npm install -g xunit-viewer
-          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -d "lte/gateway/test_results/" ] && { xunit-viewer -r lte/gateway/test_results/ -o "$REPORT_FILENAME"; }
           [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
           [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
           python ci-scripts/firebase_publish_report.py -id ${{ github.event.client_payload.trigger_sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} debian_lte_integ_test --url $URL

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -81,7 +81,7 @@ jobs:
         if: always()
         working-directory: 'lte/gateway/'
         run: |
-          fab get-test-summaries --integration-tests --dst-path="test-results" --dev-vm-name="magma_deb"
+          fab get-test-summaries --integration-tests
           ls -R
       - name: Upload test results
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -110,7 +110,7 @@ jobs:
         if: always()
         working-directory: lte/gateway
         run: |
-          fab get-test-summaries --integration-tests --dst-path="test-results" --dev-vm-name="magma_deb"
+          fab get-test-summaries --integration-tests
       - name: Publish Unit Test Results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action/composite@46ab8d49369d898e381a607119161771bc65c2a6 # pin@v2.2.0

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -116,7 +116,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/composite@46ab8d49369d898e381a607119161771bc65c2a6 # pin@v2.2.0
         with:
           check_name: LTE containerizes integ test results - ${{ inputs.test_targets }}
-          junit_files: lte/gateway/test-results/**/*.xml
+          junit_files: lte/gateway/test_results/**/*.xml
           check_run_annotations: all tests
       - name: Adapt name of file containing final status
         if: always()
@@ -131,8 +131,8 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
-          name: test-results-${{ inputs.test_targets }}
-          path: lte/gateway/test-results/**/*.xml
+          name: test_results_${{ inputs.test_targets }}
+          path: lte/gateway/test_results/**/*.xml
       - name: Upload final_status
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -71,7 +71,7 @@ jobs:
         if: always()
         working-directory: 'lte/gateway/'
         run: |
-          fab get-test-summaries --integration-tests --dst-path="test-results" --dev-vm-name="magma_deb"
+          fab get-test-summaries --integration-tests
           ls -R
       - name: Upload test results
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -77,14 +77,14 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
-          name: test-results
-          path: lte/gateway/test-results/**/*.xml
+          name: test_results
+          path: lte/gateway/test_results/**/*.xml
       - name: Publish Unit Test Results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action/composite@46ab8d49369d898e381a607119161771bc65c2a6 # pin@v2.2.0
         with:
           check_name: LTE Debian integration test results
-          junit_files: lte/gateway/test-results/**/*.xml
+          junit_files: lte/gateway/test_results/**/*.xml
           check_run_annotations: all tests
       - name: Get test logs
         if: always()

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -75,7 +75,7 @@ jobs:
         if: always()
         run: |
           cd lte/gateway
-          fab get-test-summaries --integration-tests --sudo-tests --dst-path="test-results"
+          fab get-test-summaries --integration-tests
           ls -R
       - name: Upload test results
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -81,8 +81,8 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
-          name: test-results
-          path: lte/gateway/test-results/**/*.xml
+          name: test_results
+          path: lte/gateway/test_results/**/*.xml
       - name: Get test logs
         if: always()
         run: |
@@ -99,5 +99,5 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/composite@46ab8d49369d898e381a607119161771bc65c2a6 # pin@v2.2.0
         with:
           check_name: LTE integration test results
-          junit_files: lte/gateway/test-results/**/*.xml
+          junit_files: lte/gateway/test_results/**/*.xml
           check_run_annotations: all tests

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -74,14 +74,14 @@ jobs:
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         if: always()
         with:
-          name: test-results
-          path: lte/gateway/test-results/**/*.xml
+          name: test_results
+          path: lte/gateway/test_results/**/*.xml
       - name: Publish Unit Test Results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action/composite@46ab8d49369d898e381a607119161771bc65c2a6 # pin@v2.2.0
         with:
           check_name: Sudo Python test results
-          junit_files: lte/gateway/test-results/**/*.xml
+          junit_files: lte/gateway/test_results/**/*.xml
           check_run_annotations: all tests
       - name: Publish results to Firebase
         if: always() && github.event_name == 'push'
@@ -90,7 +90,7 @@ jobs:
           REPORT_FILENAME: "sudo_python_tests_${{ github.sha }}.html"
         run: |
           npm install -g xunit-viewer
-          [ -d "lte/gateway/test-results/" ] && { xunit-viewer -r lte/gateway/test-results/ -o "$REPORT_FILENAME"; }
+          [ -d "lte/gateway/test_results/" ] && { xunit-viewer -r lte/gateway/test_results/ -o "$REPORT_FILENAME"; }
           [ -f "$REPORT_FILENAME" ] && { python ci-scripts/firebase_upload_file.py -f "$REPORT_FILENAME" -o out_url.txt; }
           [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
           python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} sudo_python_tests --url $URL

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -68,7 +68,7 @@ jobs:
         if: always()
         run: |
           cd lte/gateway
-          fab get-test-summaries --sudo-tests --dst-path="test-results"
+          fab get-test-summaries --sudo-tests
           ls -R
       - name: Upload test results
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -528,7 +528,6 @@ def run_with_retry(c_gw, command, retries=10):
 def get_test_summaries(c, sudo_tests=False, integration_tests=False):
     results_folder = "test_results"
     results_dir = "/var/tmp/"
-    dst_path = "test-results"
 
     c.run('mkdir -p ' + results_folder)
 

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -525,32 +525,32 @@ def run_with_retry(c_gw, command, retries=10):
 
 
 @task
-def get_test_summaries(
-        c,
-        dst_path="/tmp",
-        integration_tests=False,
-        sudo_tests=False,
-        dev_vm_name="magma",
-):
-    c.run('mkdir -p ' + dst_path)
-
-    if sudo_tests:
-        _get_test_summaries_from_vm(c, dst_path, dev_vm_name)
-    if integration_tests:
-        _get_test_summaries_from_vm(c, dst_path, "magma_test")
-
-
-def _get_test_summaries_from_vm(c, dst_path, vm_name):
+def get_test_summaries(c, sudo_tests=False, integration_tests=False):
     results_folder = "test_results"
     results_dir = "/var/tmp/"
-    with vagrant_connection(c, vm_name) as c_gw:
-        if c_gw.run(
+    dst_path = "test-results"
+
+    c.run('mkdir -p ' + results_folder)
+
+    if not (sudo_tests and integration_tests):
+        print(
+            "Specify either \'sudo-tests\' or \'integration-tests\'"
+            "to get test summaries",
+        )
+        return
+    if sudo_tests:
+        vm_name = "magma"
+    if integration_tests:
+        vm_name = "magma_test"
+
+    with vagrant_connection(c, vm_name) as c_vm:
+        if c_vm.run(
             f"test -e {results_dir}{results_folder}", warn=True,
         ).ok:
             # Fix the permissions on the files -- they have permissions 000
             # otherwise
-            c_gw.run(f'sudo chmod 755 {results_dir}{results_folder}')
-            _get_folder(c_gw, results_folder, results_dir, dst_path)
+            c_vm.run(f'sudo chmod 755 {results_dir}{results_folder}')
+            _get_folder(c_vm, results_folder, results_dir, results_folder)
 
 
 @task


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Two step refactoring PR:

1. Split the function to get CI test summaries into one for integ tests and the python sudo tests. This simplifies function calls the the CI workflow files.
2. Test are now collected into the `test_results` folder instead of the `test-results` folder. This allows for less code and adds consistency.
Part of #14909. 

## Test Plan

- [ ] [Magma Build, Publish & Test Federated Integration](https://github.com/mpfirrmann/magma/actions/runs/4161623353)
- [ ] [AGW Test LTE Integration With Bazel Debian Build](https://github.com/mpfirrmann/magma/actions/runs/4161625179)
- [ ] [AGW Test LTE Integration With Make Containerized Build](https://github.com/mpfirrmann/magma/actions/runs/4163533065)
- [ ] [AGW Test LTE Integration With Make Debian Build](https://github.com/mpfirrmann/magma/actions/runs/4161629953)
- [ ] [AGW Build & Test LTE Integration With Make Dev Build](https://github.com/mpfirrmann/magma/actions/runs/4161633030)
- [ ] [AGW Test Sudo Python](https://github.com/mpfirrmann/magma/actions/runs/4161638483)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
