### PR TITLE
refactor(agw): Minor improvements to the fabfiles

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -64,12 +64,12 @@ def integ_test(
         services on. Formatted as "host:port". If not specified, defaults to
         the `cwag` vagrant box
 
-    test_host: The ssh address string of the machine to run the tests on
-        on. Formatted as "host:port". If not specified, defaults to the
+    test_host: The ssh address string of the machine to run the tests on.
+        Formatted as "host:port". If not specified, defaults to the
         `cwag_test` vagrant box
 
-    trf_host: The ssh address string of the machine to run the tests on
-        on. Formatted as "host:port". If not specified, defaults to the
+    trf_host: The ssh address string of the machine to run the tests on.
+        Formatted as "host:port". If not specified, defaults to the
         `magma_trfserver` vagrant box
 
     destroy_vm: When set to true, all VMs will be destroyed before running the
@@ -114,7 +114,7 @@ def integ_test(
         )
         return
 
-    # Setup the gateway: use the provided gateway if given, else default to the
+    # Set up the gateway: use the provided gateway if given, else default to the
     # vagrant machine
     c_cwf = _set_up_vm(
         c,
@@ -150,7 +150,7 @@ def integ_test(
 
         _run_gateway(c_cwf)
 
-    # Setup the trfserver: use the provided trfserver if given, else default to
+    # Set up the trfserver: use the provided trfserver if given, else default to
     # the vagrant machine
     with c.cd(LTE_AGW_ROOT):
         c_trf = _set_up_vm(
@@ -176,7 +176,7 @@ def integ_test(
         _set_cwag_configs(c_test, "gateway.mconfig")
         _start_ipfix_controller(c_test)
 
-    # Get back to the gateway vm to setup static arp
+    # Get back to the gateway vm to set up static arp
     with c_cwf:
         _set_cwag_networking(c_cwf, cwag_test_br_mac)
 
@@ -199,12 +199,12 @@ def integ_test(
     # HSSLESS tests are to be executed from gateway_host VM
     if tests_to_run.value == SubTests.HSSLESS.value:
         _run_integ_tests(
-            c, gateway_host, trf_host, tests_to_run, test_re, count,
+            gateway_host, trf_host, tests_to_run, test_re, count,
             test_result_xml, rerun_fails, c_cwf, c_trf,
         )
     else:
         _run_integ_tests(
-            c, test_host, trf_host, tests_to_run, test_re, count,
+            test_host, trf_host, tests_to_run, test_re, count,
             test_result_xml, rerun_fails, c_test, c_trf,
         )
 
@@ -217,6 +217,7 @@ def transfer_artifacts(
     """
     Fetches service logs from Docker and optionally gets core dumps
     Args:
+        c: Fabric connection
         gateway_vm: VM to fetch logs from
         gateway_ansible_file: Ansible file to use for VM
         services: A list of services for which services logs are requested
@@ -451,7 +452,7 @@ def _add_docker_host_remote_network_envvar(c_test):
 
 
 def _run_integ_tests(
-    c, test_host, trf_host, tests_to_run: SubTests, test_re, count,
+    test_host, trf_host, tests_to_run: SubTests, test_re, count,
     test_result_xml, rerun_fails, c_test_vm, c_trf,
 ):
     """ Run the integration tests """

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -60,49 +60,44 @@ def integ_test(
     machines, but can also be pointed to an arbitrary host (e.g. amazon) by
     passing "address:port" as arguments
 
-    gateway_host: The ssh address string of the machine to run the gateway
-        services on. Formatted as "host:port". If not specified, defaults to
-        the `cwag` vagrant box
-
-    test_host: The ssh address string of the machine to run the tests on.
-        Formatted as "host:port". If not specified, defaults to the
-        `cwag_test` vagrant box
-
-    trf_host: The ssh address string of the machine to run the tests on.
-        Formatted as "host:port". If not specified, defaults to the
-        `magma_trfserver` vagrant box
-
-    destroy_vm: When set to true, all VMs will be destroyed before running the
-     tests
-
-    provision_vm: When set to false, this script will not provision the VMs
-     before running the tests
-
-    build: When set to false, this script will skip rebuilding all docker images
-        in the CWAG VM
-
-    transfer_images: When set to true, the script will transfer all cwf_* docker
-        images from the host machine to the CWAG VM to use in the test
-
-    skip_docker_load: When set to true, /tmp/cwf_* will be copied into the CWAG VM
-        instead of loading the docker images then copying. This option only is
-        valid if transfer_images is set.
-
-    tar_path: The location where the tarred docker images will be copied from.
-        Only valid if transfer_images is set.
-
-    skip_unit_tests: When set to true, only integration tests will be run
-
-    run_tests: When set to false, no integration tests will be run
-
-    test_re: When set to a value, integrations tests that match the expression will be run.
-        (Ex: test_re=TestAuth will run all tests that start with TestAuth)
-
-    count: When set to a number, the integrations tests will be run that many times
-
-    test_result_xml: When set to a path, a JUnit style test summary in XML will be produced at the path
-
-    rerun_fails: Number of times to re-run a test on failure
+    Args:
+        c: Fabric connection.
+        gateway_host: The ssh address string of the machine to run the gateway
+            services on. Formatted as "host:port". If not specified, defaults
+            to the `cwag` vagrant box.
+        test_host: The ssh address string of the machine to run the tests on.
+            Formatted as "host:port". If not specified, defaults to the
+            `cwag_test` vagrant box.
+        trf_host: The ssh address string of the machine to run the tests on.
+            Formatted as "host:port". If not specified, defaults to the
+            `magma_trfserver` vagrant box.
+        gateway_vm: The name of the vagrant VM to use as the gateway.
+        gateway_ansible_file: The ansible file to use to provision the gateway.
+        destroy_vm: When set to true, all VMs will be destroyed before running
+            the tests.
+        provision_vm: When set to False, this script will not provision the VMs
+            before running the tests.
+        build: When set to false, this script will skip rebuilding all docker images
+            in the CWAG VM
+        tests_to_run: The tests to run. Valid values are in the SubTests enum.
+        transfer_images: When set to true, the script will transfer all cwf_*
+            docker images from the host machine to the CWAG VM to use in the
+            test.
+        skip_docker_load: When set to true, /tmp/cwf_* will be copied into the
+            CWAG VM instead of loading the docker images then copying.
+            This option only is valid if transfer_images is set.
+        tar_path: The location where the tarred docker images will be copied
+            from. Only valid if transfer_images is set.
+        skip_unit_tests: When set to true, only integration tests will be run.
+        run_tests: When set to false, no integration tests will be run.
+        test_re: When set to a value, integrations tests that match the
+            expression will be run.
+            (Ex: test_re=TestAuth will run all tests that start with TestAuth)
+        count: When set to a number, the integrations tests will be run that
+            many times.
+        test_result_xml: When set to a path, a JUnit style test summary in XML
+            will be produced at the path.
+        rerun_fails: Number of times to re-run a test on failure.
     """
     try:
         tests_to_run = SubTests(tests_to_run)

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -18,7 +18,7 @@ from enum import Enum
 from fabric import Connection, task
 
 sys.path.append('../../orc8r')
-from tools.fab.hosts import ansible_setup, vagrant_connection, vagrant_setup
+from tools.fab.hosts import ansible_setup, vagrant_connection
 
 CWAG_ROOT = "$MAGMA_ROOT/cwf/gateway"
 CWAG_INTEG_ROOT = "$MAGMA_ROOT/cwf/gateway/integ_tests"

--- a/feg/gateway/fabfile.py
+++ b/feg/gateway/fabfile.py
@@ -37,7 +37,7 @@ def register_feg_gw(c, location_docker_compose=FEG_DOCKER_LOCATION):
     Args:
         c: fabric Connection
         location_docker_compose: location of docker compose. Default set to
-        FEG_DOCKER_LOCATION
+            FEG_DOCKER_LOCATION.
     """
     _register_federation_network()
     _register_feg(c, location_docker_compose)
@@ -50,7 +50,7 @@ def deregister_feg_gw(c, location_docker_compose=FEG_DOCKER_LOCATION):
     Args:
         c: fabric Connection
         location_docker_compose: location of docker compose. Default set to
-        FEG_DOCKER_LOCATION
+            FEG_DOCKER_LOCATION.
     """
     _deregister_feg_gw(c, location_docker_compose)
     dev_utils.delete_gateway_certs_from_docker(c, location_docker_compose)
@@ -76,13 +76,13 @@ def check_feg_cloud_connectivity(c, timeout=5):
 class RadiusConfig:
     def __init__(
         self,
-        DAE_addr: str = '127.0.0.1:3799',
+        dae_addr: str = '127.0.0.1:3799',
         acct_addr: str = '127.0.0.1:1813',
         auth_addr: str = '127.0.0.1:1812',
         network: str = 'udp',
         secret: str = 'MTIzNDU2',
     ):
-        self.DAE_addr = DAE_addr
+        self.dae_addr = dae_addr
         self.acct_addr = acct_addr
         self.auth_addr = auth_addr
         self.network = network
@@ -164,10 +164,10 @@ class DiamServerConfig:
 class GxConfig:
     def __init__(
         self,
-        disableGx: bool = False,
+        disable_gx: bool = False,
         servers: List[DiamServerConfig] = None,
     ):
-        self.disableGx = disableGx
+        self.disable_gx = disable_gx
         if servers is None:
             servers = [DiamServerConfig()]
         self.servers = servers
@@ -176,11 +176,11 @@ class GxConfig:
 class GyConfig:
     def __init__(
         self,
-        disableGy: bool = False,
+        disable_gy: bool = False,
         init_method: int = 2,
         servers: List[DiamServerConfig] = None,
     ):
-        self.disableGy = disableGy
+        self.disable_gy = disable_gy
         self.init_method = init_method
         if servers is None:
             servers = [DiamServerConfig()]
@@ -262,7 +262,7 @@ class HssConfigs:
 class S6aConfigs:
     def __init__(
         self,
-        plmn_ids: List[str] = list(),
+        plmn_ids: List[str] = None,
         server: DiamServerConfig = DiamServerConfig(),
     ):
         if plmn_ids is None:
@@ -274,14 +274,14 @@ class S6aConfigs:
 class SwxConfigs:
     def __init__(
         self,
-        cache_TTL_seconds: int = 10800,
+        cache_ttl_seconds: int = 10800,
         derive_unregister_realm: bool = False,
         hlr_plmn_ids: List[str] = None,
         register_on_auth: bool = False,
         servers: List[DiamServerConfig] = None,
         verify_authorization: bool = False,
     ):
-        self.cache_TTL_seconds = cache_TTL_seconds
+        self.cache_ttl_seconds = cache_ttl_seconds
         self.derive_unregister_realm = derive_unregister_realm
         if hlr_plmn_ids is None:
             hlr_plmn_ids = ['00101']
@@ -336,14 +336,14 @@ class FederationNetworkConfigs:
 class FederationNetwork:
     def __init__(
         self,
-        id: str = NETWORK_ID,
+        network_id: str = NETWORK_ID,
         name: str = 'Testing',
         description: str = 'Test federation network',
         federation: FederationNetworkConfigs = FederationNetworkConfigs(),
         dns: types.NetworkDNSConfig = types.NetworkDNSConfig(),
         subscriber_config: SubConfig = SubConfig(),
     ):
-        self.id = id
+        self.id = network_id
         self.name = name
         self.description = description
         self.dns = dns
@@ -354,13 +354,13 @@ class FederationNetwork:
 class FederationGateway:
     def __init__(
         self,
-        id: str, name: str, description: str,
+        network_id: str, name: str, description: str,
         device: types.GatewayDevice,
         magmad: types.MagmadGatewayConfigs,
         tier: str = 'default',
         federation: FederationNetworkConfigs = FederationNetworkConfigs(),
     ):
-        self.id = id
+        self.id = network_id
         self.name = name
         self.description = description
         self.device = device
@@ -399,7 +399,7 @@ def _register_feg(c: Connection, location_docker_compose: str):
     gw_id = dev_utils.get_next_available_gateway_id(NETWORK_ID)
     md_gw = dev_utils.construct_magmad_gateway_payload(gw_id, hw_id)
     gw_payload = FederationGateway(
-        id=md_gw.id,
+        network_id=md_gw.id,
         name=md_gw.name,
         description=md_gw.description,
         device=md_gw.device,

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -95,7 +95,7 @@ def package(
             "\tfab [dev|release] package",
         )
 
-    hash = pkg.get_commit_hash(c)
+    commit_hash = pkg.get_commit_hash(c)
     commit_count = pkg.get_commit_count(c)
 
     with vagrant_connection(c, vm, destroy_vm=destroy_vm) as c_gw:
@@ -115,11 +115,11 @@ def package(
                 + f' {ORC8R_AGW_PYTHON_ROOT}/setup.py',
             )
 
-            print(f'Building magma package, picking up commit {hash}...')
+            print(f'Building magma package, picking up commit {commit_hash}...')
             c_gw.run('make clean')
             build_type = "Debug" if debug_mode else "RelWithDebInfo"
 
-            build_cmd = f'./release/build-magma.sh --hash {hash}' \
+            build_cmd = f'./release/build-magma.sh --commit_hash {commit_hash}' \
                         f' --commit-count {commit_count} --type {build_type}' \
                         f' --cert {cert_file} --proxy {proxy_config} --os {os}'
             # set '/usr/bin/' in PATH to ensure that the correct version of
@@ -190,7 +190,7 @@ def _redirect_feg_agw_to_vagrant_orc8r(c_gw):
     to point to localhost when Orc8r runs inside Vagrant
     """
     # This is only run in CI:
-    # on macos
+    # on macOS
     c_gw.local(
         f"sed -i '' 's/:10.0.2.2/:127.0.0.1/' "
         f"{FEG_INTEG_TEST_DOCKER_ROOT}/docker-compose.override.yml",
@@ -206,7 +206,7 @@ def federated_integ_test(
 ):
 
     if orc8r_on_vagrant:
-        # Modify Vagrantfile to allow access to Orc8r running inside Vagrant
+        # Modify Vagrantfile to allow access to orc8r running inside Vagrant
         open_orc8r_port_in_vagrant(c)
 
     if build_all:
@@ -314,8 +314,8 @@ def integ_test(
         services on. Formatted as "host:port". If not specified, defaults to
         the `magma` vagrant box.
 
-    test_host: The ssh address string of the machine to run the tests on
-        on. Formatted as "host:port". If not specified, defaults to the
+    test_host: The ssh address string of the machine to run the tests on.
+        Formatted as "host:port". If not specified, defaults to the
         `magma_test` vagrant box.
 
     trf_host: The ssh address string of the machine to run the TrafficServer
@@ -366,8 +366,8 @@ def integ_test_deb_installation(
         services on. Formatted as "host:port". If not specified, defaults to
         the `magma_deb` vagrant box.
 
-    test_host: The ssh address string of the machine to run the tests on
-        on. Formatted as "host:port". If not specified, defaults to the
+    test_host: The ssh address string of the machine to run the tests on.
+        Formatted as "host:port". If not specified, defaults to the
         `magma_test` vagrant box.
 
     trf_host: The ssh address string of the machine to run the TrafficServer
@@ -525,6 +525,7 @@ def get_test_logs(
     "/tmp/build_logs.tar.gz" by default.
 
     Args:
+        c: fabric connection
         gateway_host_name: name of the gateway machine
         gateway_host: The ssh address string of the gateway machine formatted
             as "host:port". If not specified, defaults to the `magma` vagrant box.

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -310,17 +310,20 @@ def integ_test(
     machines, but can also be pointed to an arbitrary host (e.g. amazon) by
     passing "address:port" as arguments
 
-    gateway_host: The ssh address string of the machine to run the gateway
-        services on. Formatted as "host:port". If not specified, defaults to
-        the `magma` vagrant box.
-
-    test_host: The ssh address string of the machine to run the tests on.
-        Formatted as "host:port". If not specified, defaults to the
-        `magma_test` vagrant box.
-
-    trf_host: The ssh address string of the machine to run the TrafficServer
-        on. Formatted as "host:port". If not specified, defaults to the
-        `magma_trfserver` vagrant box.
+    Args:
+        c: Fabric connection.
+        gateway_host: The ssh address string of the machine to run the gateway
+            services on. Formatted as "host:port". If not specified, defaults to
+            the `magma` vagrant box.
+        test_host: The ssh address string of the machine to run the tests on.
+            Formatted as "host:port". If not specified, defaults to the
+            `magma_test` vagrant box.
+        trf_host: The ssh address string of the machine to run the TrafficServer
+            on. Formatted as "host:port". If not specified, defaults to the
+            `magma_trfserver` vagrant box.
+        destroy_vm: If True, destroy the magma VM before running the tests.
+        provision_vm: When set to false, this script will not provision the VMs
+            before running the tests.
     """
 
     # Set up the gateway: use the provided gateway if given, else default to the
@@ -362,17 +365,20 @@ def integ_test_deb_installation(
     machines, but can also be pointed to an arbitrary host (e.g. amazon) by
     passing "address:port" as arguments
 
-    gateway_host: The ssh address string of the machine to run the gateway
-        services on. Formatted as "host:port". If not specified, defaults to
-        the `magma_deb` vagrant box.
-
-    test_host: The ssh address string of the machine to run the tests on.
-        Formatted as "host:port". If not specified, defaults to the
-        `magma_test` vagrant box.
-
-    trf_host: The ssh address string of the machine to run the TrafficServer
-        on. Formatted as "host:port". If not specified, defaults to the
-        `magma_trfserver` vagrant box.
+    Args:
+        c: Fabric connection.
+        gateway_host: The ssh address string of the machine to run the gateway
+            services on. Formatted as "host:port". If not specified, defaults to
+            the `magma_deb` vagrant box.
+        test_host: The ssh address string of the machine to run the tests on.
+            Formatted as "host:port". If not specified, defaults to the
+            `magma_test` vagrant box.
+        trf_host: The ssh address string of the machine to run the TrafficServer
+            on. Formatted as "host:port". If not specified, defaults to the
+            `magma_trfserver` vagrant box.
+        destroy_vm: If True, destroy the magma deb VM before running the tests.
+        provision_vm: If True, provision the magma deb VM before running the
+            tests.
     """
 
     # Set up the gateway: use the provided gateway if given, else default to the

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -206,7 +206,7 @@ def federated_integ_test(
 ):
 
     if orc8r_on_vagrant:
-        # Modify Vagrantfile to allow access to orc8r running inside Vagrant
+        # Modify Vagrantfile to allow access to Orc8r running inside Vagrant
         open_orc8r_port_in_vagrant(c)
 
     if build_all:

--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -139,7 +139,8 @@ def clear_orc8r_db(c):
 def install_agw(c, provision_vm=False):
     """
     Install a magma AGW debian package on the magma_deb Vagrant VM.
-
+    Args:
+        c: fabric connection.
        provision_vm: forces the reprovision of the magma VM
     """
     print('#### Installing AGW ####')


### PR DESCRIPTION
## Summary

- Fixed some typos and docstring formatting.
- Added missing docstrings for fabric connections.

- Renamed variables to snake_case.
- Renamed function arguments `id` to `network_id`. `id` shadows an in-built name.
- Renamed a variable `hash` to `commit_hash`. `hash` shadows an in-built name.

- Eliminated an unused connection variable.
- Eliminated an unused function argument in `_run_integ_tests`.
- Eliminated a `list()` default value.

## Test Plan
- [x] Run `fab integ-test` locally
- [x] ~Run AGW Integ Tests on CI https://github.com/magma/magma/actions/runs/4190570919/jobs/7264107426 (On magma origin repo because it does not work on my branch for some reason).~ Sorry, I should have done CWF, see below
- [x] https://github.com/magma/magma/actions/runs/4191459973