### PR TITLE
chore(agw): Add deprecation warnings to AGW Makefiles

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -1,5 +1,16 @@
 .PHONY: all build clean run test
 
+define DEPRECATION_WARNING
+
+Warning: As part of the Make to Bazel switch-over of the AGW this Makefile
+will be deprecated soon, see https://github.com/magma/magma/issues/14971.
+Do not add any new Make targets for the AGW!
+All new targets should be integrated with the Bazel build system,
+see https://magma.github.io/magma/docs/next/bazel/agw_with_bazel.
+
+endef
+export DEPRECATION_WARNING
+
 GATEWAY_C_DIR = $(MAGMA_ROOT)/lte/gateway/c
 GRPC_CPP_PLUGIN_PATH ?= `which grpc_cpp_plugin`
 BUILD_TYPE ?= Debug
@@ -57,15 +68,19 @@ all: build
 build: build_python build_common build_oai build_sctpd build_session_manager build_connection_tracker build_envoy_controller build_li_agent ## Build all
 
 clean: clean_python clean_envoy_controller ## Clean all builds
+	@echo "$$DEPRECATION_WARNING"
 	rm -rf $(C_BUILD)
 
 clean_python: ## Clean Python-only builds
+	@echo "$$DEPRECATION_WARNING"
 	make -C $(MAGMA_ROOT)/lte/gateway/python clean
 
 clean_envoy_controller: ## Clean envoy controller build
+	@echo "$$DEPRECATION_WARNING"
 	rm -rf  $(GO_BUILD)/envoy_controller
 
 run: build ## Build and run all services
+	@echo "$$DEPRECATION_WARNING"
 	sudo service magma@* stop
 	sudo service magma@magmad start
 
@@ -85,13 +100,16 @@ cd $(2) && ctest --output-on-failure -R $(5)
 endef
 
 build_python: ## Build Python environment
+	@echo "$$DEPRECATION_WARNING"
 	sudo service magma@* stop
 	make -C $(MAGMA_ROOT)/lte/gateway/python buildenv
 
 build_common: ## Build shared libraries
+	@echo "$$DEPRECATION_WARNING"
 	$(call run_cmake, $(C_BUILD)/magma_common, $(MAGMA_ROOT)/orc8r/gateway/c/common, $(COMMON_FLAGS))
 
 build_oai: ## Build OAI
+	@echo "$$DEPRECATION_WARNING"
 	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS) $(OAI_NOTEST_FLAGS))
 
 format_all:
@@ -103,21 +121,27 @@ format_all:
 	/usr/bin/clang-format-11 -i {} \;
 
 build_sctpd:
+	@echo "$$DEPRECATION_WARNING"
 	$(call run_cmake, $(C_BUILD)/sctpd, $(GATEWAY_C_DIR)/sctpd, )
 
 build_session_manager: build_common ## Build session manager
+	@echo "$$DEPRECATION_WARNING"
 	$(call run_cmake, $(C_BUILD)/session_manager, $(GATEWAY_C_DIR)/session_manager, )
 
 build_li_agent: ## Build li agent
+	@echo "$$DEPRECATION_WARNING"
 	$(call run_cmake, $(C_BUILD)/li_agent, $(GATEWAY_C_DIR)/li_agent, )
 
 build_connection_tracker:
+	@echo "$$DEPRECATION_WARNING"
 	$(call run_cmake, $(C_BUILD)/connection_tracker, $(GATEWAY_C_DIR)/connection_tracker, )
 
 build_envoy_controller: ## Build envoy controller
+	@echo "$$DEPRECATION_WARNING"
 	cd $(MAGMA_ROOT)/feg/gateway && $(MAKE) install_envoy_controller
 
 # Catch all for c service tests
 # This works with test_dpi and test_session_manager
 test_%: build_common
+	@echo "$$DEPRECATION_WARNING"
 	$(call run_ctest, $(C_BUILD)/$*, $(C_BUILD)/$*, $(GATEWAY_C_DIR)/$*, )

--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -2,6 +2,17 @@ include $(MAGMA_ROOT)/lte/gateway/python/defs.mk
 # Contains common targets for gateway python development
 include $(MAGMA_ROOT)/orc8r/gateway/python/python.mk
 
+define DEPRECATION_WARNING
+
+Warning: As part of the Make to Bazel switch-over of the AGW this Makefile
+will be deprecated soon, see https://github.com/magma/magma/issues/14971.
+Do not add any new Make targets for the AGW!
+All new targets should be integrated with the Bazel build system,
+see https://magma.github.io/magma/docs/next/bazel/agw_with_bazel.
+
+endef
+export DEPRECATION_WARNING
+
 # Set up some pattern rules
 define setup_rules
 	$(eval PSRC := $1)
@@ -12,13 +23,16 @@ endef
 _ := $(foreach python_src, $(PYTHON_SRCS), $(eval $(call setup_rules,$(python_src))))
 
 snowflake:
+	@echo "$$DEPRECATION_WARNING"
 	sudo env PATH=${PYTHON_BUILD}/bin:${PATH} snowflake --make-snowflake
 
 buildenv: setupenv protos swagger $(BUILD_LIST) py_patches snowflake
 $(BUILD_LIST): %_build:
+	@echo "$$DEPRECATION_WARNING"
 	make -C $* install_egg
 
 test_all: buildenv $(BIN)/pytest $(BIN)/pytest-cov $(TEST_LIST)
+	@echo "$$DEPRECATION_WARNING"
 $(TEST_LIST): %_test:
 	make -C $* .test
 
@@ -31,6 +45,7 @@ endef
 
 # unit_tests (UT_PATH=unit_test_path|MAGMA_SERVICE=service_name)[DONT_BUILD_ENV=1]
 unit_tests: $(TESTS)
+	@echo "$$DEPRECATION_WARNING"
 ifndef MAGMA_SERVICE
 ifndef UT_PATH
 	@echo "usage: make unit_tests (UT_PATH=unit_test_path|MAGMA_SERVICE=service_name)[DONT_BUILD_ENV=1]"
@@ -73,6 +88,7 @@ check:
 	./precommit.py --format --diff
 
 clean: $(CLEAN_LIST)
+	@echo "$$DEPRECATION_WARNING"
 	sudo rm -rf $(PYTHON_BUILD)/
 	sudo find . -name '*.pyc' -o -name '__pycache__' -prune -exec rm -rf {} \;
 $(CLEAN_LIST): %_clean:

--- a/lte/gateway/release/Makefile
+++ b/lte/gateway/release/Makefile
@@ -10,9 +10,22 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ################################################################################
+
+define DEPRECATION_WARNING
+
+Warning: As part of the Make to Bazel switch-over of the AGW this Makefile
+will be deprecated soon, see https://github.com/magma/magma/issues/14971.
+Do not add any new Make targets for the AGW!
+All new targets should be integrated with the Bazel build system,
+see https://magma.github.io/magma/docs/next/bazel/agw_with_bazel.
+
+endef
+export DEPRECATION_WARNING
+
 MAGMA_ROOT = ~/magma
 PY_LTE     = $(MAGMA_ROOT)/lte/gateway/python
 PY_ORC8R   = $(MAGMA_ROOT)/orc8r/gateway/python
 
 magma.lockfile: $(PY_LTE)/setup.py $(PY_ORC8R)/setup.py
+	@echo "$$DEPRECATION_WARNING"
 	./pydep finddep --install-from-repo -l ./magma.lockfile.$(os_release)  $(PY_ORC8R)/setup.py $(PY_LTE)/setup.py


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
- Resolves https://github.com/magma/magma/issues/15005
- Print deprecation warning for all relevant AGW Make targets.
  - [Stackoverflow thread on multiline strings in Makefiles](https://stackoverflow.com/questions/649246/is-it-possible-to-create-a-multi-line-string-variable-in-a-makefile)
  - ![Screenshot from 2023-02-14 11-37-24](https://user-images.githubusercontent.com/34488763/218711378-8dc688b4-58e8-4e56-a305-6f1807ef450c.png)


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
