### PR TITLE
chore(smsd): Complete smsd dependencies in build file

### DIFF
--- a/lte/gateway/python/magma/smsd/BUILD.bazel
+++ b/lte/gateway/python/magma/smsd/BUILD.bazel
@@ -47,7 +47,10 @@ py_library(
     srcs = ["relay.py"],
     visibility = ["//visibility:public"],
     deps = [
+        "//lte/protos:sms_orc8r_python_grpc",
+        "//orc8r/gateway/python/magma/common:job",
         "//orc8r/gateway/python/magma/common:rpc_utils",
+        "//orc8r/gateway/python/magma/configuration:mconfig_managers",
         "//orc8r/protos:directoryd_python_grpc",
     ],
 )


### PR DESCRIPTION
Signed-off-by: Lars Kreutzer <lars.kreutzer@tngtech.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Complete smsd dependencies in Bazel build file.
  - This error was noticed when testing a demo unit test on this library. 


## Test Plan

- Compare with the imports in `relay.py`.
- `bazel build //lte/gateway/python/magma/smsd:smsd_lib`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
