### PR TITLE
chore(cwg): improve provisioning of CWF VMs

### DIFF
--- a/cwf/gateway/Vagrantfile
+++ b/cwf/gateway/Vagrantfile
@@ -110,6 +110,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define :cwag_test, primary: true do |cwag_test|
     cwag_test.vm.box = "generic/ubuntu2004"
     cwag_test.vm.box_version = "4.0.2"
+    cwag_test.vbguest.auto_update = false
     cwag_test.vm.hostname = "cwag-test"
     cwag_test.vm.network "private_network", ip: "192.168.70.102", nic_type: "82540EM"
     cwag_test.vm.network "private_network", ip: "192.168.40.12", nic_type: "82540EM"

--- a/cwf/gateway/deploy/cwag.yml
+++ b/cwf/gateway/deploy/cwag.yml
@@ -18,7 +18,7 @@
       tags:
          - install
       vars:
-        distribution: "bionic"
+        distribution: "focal"
         repo: "cwf-prod"
         preburn: true
     - role: ovs

--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -18,12 +18,12 @@
     - magma_root: /home/{{ ansible_user }}/magma
     - user: "{{ ansible_user }}"
     - full_provision: yes
-    - docker_host_distribution: bionic
+    - docker_host_distribution: focal
   roles:
     - role: gomod_cache
     - role: distro_snapshot
       vars:
-        distro: bionic
+        distro: focal
         distro_root: "{{ lookup('env', 'CWAG_DISTRO_ARCHIVE') | regex_replace('(^.*/+|)([^/]+)\\.tar\\.gz$', '\\2') }}"
         distro_archive: "{{ lookup('env', 'CWAG_DISTRO_ARCHIVE') }}"
         distro_sha256: "{{ lookup('env', 'CWAG_DISTRO_SHA256') }}"
@@ -31,9 +31,11 @@
       vars:
         override_nameserver: 8.8.8.8
     - role: apt_cache
+      vars:
+        distribution: focal
     - role: pkgrepo
       vars:
-        distribution: "bionic"
+        distribution: "focal"
         repo: "cwf-prod"
         preburn: true
     - role: test_certs

--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -34,10 +34,6 @@
       vars:
         distribution: focal
     - role: pkgrepo
-      vars:
-        distribution: "focal"
-        repo: "cwf-prod"
-        preburn: true
     - role: test_certs
     - role: ovs
     - role: golang
@@ -59,6 +55,8 @@
     - include_role:
         name: docker
         tasks_from: install
+      vars:
+        preburn: true
 
     - name: Create snowflake file
       copy:

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -20,11 +20,9 @@
   roles:
     - role: gomod_cache
     - role: apt_cache
-    - role: pkgrepo
       vars:
-        distribution: "focal"
-        repo: "cwf-prod"
-        preburn: true
+        distribution: focal
+    - role: pkgrepo
     - role: ovs
     - role: resolv_conf
       vars:

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -22,7 +22,7 @@
     - role: apt_cache
     - role: pkgrepo
       vars:
-        distribution: "bionic"
+        distribution: "focal"
         repo: "cwf-prod"
         preburn: true
     - role: ovs


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Some improvements in the CWF VM provisioning:
- The cwag Ansible files still pull Ubuntu 18.04 `bionic` packages. This is changed to `focal` here. 
- The variable handling is adapted:
    - The `pkgrepo` role does not need any input variables.
    - The `apt_cache` role requires a `distribution` input.
    - The `install` task from the `docker` role requires `preburn: true`.
    - The `repo` variable is not used anywhere (grep for any form of `{{ repo }}`)

## Test Plan

- [x] [CWF integ tests](https://github.com/mpfirrmann/magma/actions/runs/4181751219)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
