### PR TITLE
docs: Add FeG docker page to sidebars

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -81,7 +81,7 @@
       "feg/dev_testing": {
         "title": "Test Federation Gateway"
       },
-      "feg/docker_setup": {
+      "feg/docker": {
         "title": "FeG Docker Setup"
       },
       "feg/s1ap_federated_tests": {
@@ -1610,7 +1610,7 @@
       "version-1.7.0/feg/version-1.7.0-dev_testing": {
         "title": "Test Federation Gateway"
       },
-      "version-1.7.0/feg/version-1.7.0-docker_setup": {
+      "version-1.7.0/feg/version-1.7.0-docker": {
         "title": "FeG Docker Setup"
       },
       "version-1.7.0/feg/version-1.7.0-s1ap_federated_test": {

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -329,6 +329,7 @@
         "label": "Federation Gateway",
         "ids": [
           "feg/dev_testing",
+          "feg/docker",
           "feg/s1ap_federated_tests",
           "feg/session_proxy"
         ]

--- a/docs/docusaurus/versioned_docs/version-1.7.0/feg/docker.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/feg/docker.md
@@ -1,8 +1,8 @@
 ---
-id: version-1.7.0-docker_setup
+id: version-1.7.0-docker
 title: FeG Docker Setup
 hide_title: true
-original_id: docker_setup
+original_id: docker
 ---
 # FeG Docker Setup
 

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -332,6 +332,7 @@
         "label": "Federation Gateway",
         "ids": [
           "version-1.7.0-feg/dev_testing",
+          "version-1.7.0-feg/docker",
           "version-1.7.0-feg/s1ap_federated_test"
         ]
       },

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -337,6 +337,7 @@
         "label": "Federation Gateway",
         "ids": [
           "version-1.8.0-feg/dev_testing",
+          "version-1.8.0-feg/docker",
           "version-1.8.0-feg/s1ap_federated_tests"
         ]
       },

--- a/docs/readmes/feg/docker.md
+++ b/docs/readmes/feg/docker.md
@@ -1,5 +1,5 @@
 ---
-id: docker_setup
+id: docker
 title: FeG Docker Setup
 hide_title: true
 ---


### PR DESCRIPTION
## Summary

Related to https://github.com/magma/magma/issues/14958. Fixes the fact that the "FeG Docker Setup" page is not displayed in the sidebars. This fixes it for master and the supported releases (1.7, 1.8). This also changes the id in the relevant pages so it matches the convention described in https://github.com/magma/magma/issues/14965.

## Test Plan

- Ran `cd $MAGMA_ROOT/docs && make dev` successfully locally
- Checked that for each of the modified versions (1.7, 1.8, master), the page appears in the sidebar as expected
