### PR TITLE
docs: Add missing CWF pages to sidebars

### DIFF
--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -133,6 +133,15 @@
         "ids": [
           "dp/deploy_build"
         ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Carrier WiFi",
+        "ids": [
+          "cwf/deploy_intro",
+          "cwf/deploy_build",
+          "cwf/deploy_install"
+        ]
       }
     ],
     "Configure": [
@@ -235,6 +244,7 @@
         "type": "subcategory",
         "label": "Carrier WiFi",
         "ids": [
+          "cwf/healthchecker",
           "cwf/pipelined_packet_tracer_debugging"
         ]
       },

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -129,6 +129,15 @@
         "ids": [
           "version-1.7.0-dp/deploy_build"
         ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Carrier WiFi",
+        "ids": [
+          "version-1.7.0-cwf/deploy_intro",
+          "version-1.7.0-cwf/deploy_build",
+          "version-1.7.0-cwf/deploy_install"
+        ]
       }
     ],
     "Configure": [
@@ -225,6 +234,13 @@
         "label": "Federated Gateway",
         "ids": [
           "version-1.7.0-feg/debug_cli"
+        ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Carrier WiFi",
+        "ids": [
+          "version-1.7.0-cwf/healthchecker"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -132,6 +132,15 @@
         "ids": [
           "version-1.8.0-dp/deploy_build"
         ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Carrier WiFi",
+        "ids": [
+          "version-1.8.0-cwf/deploy_intro",
+          "version-1.8.0-cwf/deploy_build",
+          "version-1.8.0-cwf/deploy_install"
+        ]
       }
     ],
     "Configure": [
@@ -228,6 +237,13 @@
         "label": "Federated Gateway",
         "ids": [
           "version-1.8.0-feg/debug_cli"
+        ]
+      },
+      {
+        "type": "subcategory",
+        "label": "Carrier WiFi",
+        "ids": [
+          "version-1.8.0-cwf/healthchecker"
         ]
       },
       {


### PR DESCRIPTION
## Summary

Related to https://github.com/magma/magma/issues/14958. Fixes the fact that several CWF pages are not displayed in the sidebars. This fixes the problem for master and the supported releases (1.7, 1.8).

## Test Plan

- Ran `cd $MAGMA_ROOT/docs && make dev` successfully locally
- Checked that for each of the modified versions (1.7, 1.8, master), the pages appear in the sidebar as expected