### PR TITLE
chore(cwg): Remove unused code from CWF fabfile

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -207,8 +207,6 @@ def integ_test(
             c, test_host, trf_host, tests_to_run, test_re, count,
             test_result_xml, rerun_fails, c_test, c_trf,
         )
-    print(f'Integration Test Passed for "{tests_to_run.value}"!')
-    sys.exit(0)
 
 
 @task
@@ -486,7 +484,7 @@ def _run_integ_tests(
                 # Clean up only for now when running locally
                 _clean_up(c_test_vm, c_trf)
 
-        print("Integration Test returned ", result.return_code)
+        print("Integration Test returned exit code ", result.return_code)
         sys.exit(result.return_code)
 
 


### PR DESCRIPTION
## Summary

In https://github.com/magma/magma/pull/14806 a change was made to the indentation of the logging and exiting [here](https://github.com/magma/magma/blob/4e46f1dcd2c996ba6ad7b1d20a57bb5583ceb030/cwf/gateway/fabfile.py#L489), which means that the logging and exiting [here](https://github.com/magma/magma/blob/4e46f1dcd2c996ba6ad7b1d20a57bb5583ceb030/cwf/gateway/fabfile.py#L210) will never be executed. One option would be to revert this behaviour, but here I have chosen to simply remove the surplus lines so that the exiting is only handled in one place. Let me know if you prefer a different solution.

I also amended the print statement slightly to make it a bit clearer.
 
## Test Plan

N/A