### PR TITLE
chore(agw): Move `make format_all` into a separate bash script

### DIFF
--- a/dev_tools/clang_format.sh
+++ b/dev_tools/clang_format.sh
@@ -10,6 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script formats all C/C++ files in the magma repo using clang-format-11.
+# The script can be executed on the dev VM or on the
+# host machine if clang-format-11 is installed.
+
 set -eou pipefail
 
 CLANG_FILE=/usr/bin/clang-format-11

--- a/dev_tools/clang_format.sh
+++ b/dev_tools/clang_format.sh
@@ -18,12 +18,16 @@ set -eou pipefail
 
 CLANG_FILE=/usr/bin/clang-format-11
 if test ! -f "$CLANG_FILE"; then
-  echo "clang-format-11 not found. You should execute the script on the dev VM
-    or install clang-format-11 on your host machine."
+  echo "clang-format-11 not found. You should execute the script on the dev VM or install clang-format-11 on your host machine."
   exit 1
 fi
 
-for dir in /orc8r/gateway/c/ /lte/gateway/c/ /lte/gateway/python/;
+if [ -z ${MAGMA_ROOT+x} ]; then
+  echo "MAGMA_ROOT variable is not set. Please set MAGMA_ROOT to the root of the magma repository."
+  exit 1
+fi
+
+for dir in orc8r/gateway/c/ lte/gateway/c/ lte/gateway/python/;
 do
   FILES=$(find "${MAGMA_ROOT}/${dir}" \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) -print)
   for FILE in $FILES;

--- a/docs/readmes/lte/dev_unit_testing.md
+++ b/docs/readmes/lte/dev_unit_testing.md
@@ -113,8 +113,8 @@ cd $MAGMA/lte/gateway/python
 To run formatting for each C/C++ service, run the following from inside the magma-dev VM
 
 ```bash
-[VM] cd magma/lte/gateway
-[VM] ./format_all.sh
+[VM] cd magma/dev_tools
+[VM] ./clang_format.sh
 ```
 
 #### Apply IWYU

--- a/docs/readmes/lte/dev_unit_testing.md
+++ b/docs/readmes/lte/dev_unit_testing.md
@@ -68,7 +68,7 @@ We have several C/C++ services that live in `lte/gateway/c/`. We will list some 
 From inside the repository, run
 
 ```bash
-bazel test //lte/gateway/c/session_manager/...:* # to test all targets under lte/gateway/c/session_manager 
+bazel test //lte/gateway/c/session_manager/...:* # to test all targets under lte/gateway/c/session_manager
 bazel test //orc8r/gateway/c/...:* //lte/gateway/c/...:* # to test all C/C++ targets
 ```
 
@@ -114,7 +114,7 @@ To run formatting for each C/C++ service, run the following from inside the magm
 
 ```bash
 [VM] cd magma/lte/gateway
-[VM] make format_all
+[VM] ./format_all.sh
 ```
 
 #### Apply IWYU

--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -112,14 +112,6 @@ build_oai: ## Build OAI
 	@echo "$$DEPRECATION_WARNING"
 	$(call run_cmake, $(C_BUILD)/core, $(GATEWAY_C_DIR)/core, $(OAI_FLAGS) $(COMMON_FLAGS) $(OAI_NOTEST_FLAGS))
 
-format_all:
-	find $(MAGMA_ROOT)/orc8r/gateway/c/ \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) -exec \
-	/usr/bin/clang-format-11 -i {} \;
-	find $(MAGMA_ROOT)/lte/gateway/c/ \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h"  -o -iname "*.hpp" \) -exec \
-	/usr/bin/clang-format-11 -i {} \;
-	find $(MAGMA_ROOT)/lte/gateway/python/ \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h"  -o -iname "*.hpp" \) -exec \
-	/usr/bin/clang-format-11 -i {} \;
-
 build_sctpd:
 	@echo "$$DEPRECATION_WARNING"
 	$(call run_cmake, $(C_BUILD)/sctpd, $(GATEWAY_C_DIR)/sctpd, )

--- a/lte/gateway/format_all.sh
+++ b/lte/gateway/format_all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2021 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+for dir in /orc8r/gateway/c/ /lte/gateway/c/ /lte/gateway/python/;
+do
+  find "${MAGMA_ROOT}/${dir}" \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) -exec /usr/bin/clang-format-11 -i {} \;
+done

--- a/lte/gateway/format_all.sh
+++ b/lte/gateway/format_all.sh
@@ -21,5 +21,10 @@ fi
 
 for dir in /orc8r/gateway/c/ /lte/gateway/c/ /lte/gateway/python/;
 do
-  find "${MAGMA_ROOT}/${dir}" \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) -exec $CLANG_FILE -i {} \;
+  FILES=$(find "${MAGMA_ROOT}/${dir}" \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) -print)
+  for FILE in $FILES;
+  do
+    echo "Formatting $FILE"
+    $CLANG_FILE -i "$FILE"
+  done
 done

--- a/lte/gateway/format_all.sh
+++ b/lte/gateway/format_all.sh
@@ -12,7 +12,14 @@
 
 set -eou pipefail
 
+CLANG_FILE=/usr/bin/clang-format-11
+if test ! -f "$CLANG_FILE"; then
+  echo "clang-format-11 not found. You should execute the script on the dev VM
+    or install clang-format-11 on your host machine."
+  exit 1
+fi
+
 for dir in /orc8r/gateway/c/ /lte/gateway/c/ /lte/gateway/python/;
 do
-  find "${MAGMA_ROOT}/${dir}" \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) -exec /usr/bin/clang-format-11 -i {} \;
+  find "${MAGMA_ROOT}/${dir}" \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) -exec $CLANG_FILE -i {} \;
 done

--- a/lte/gateway/format_all.sh
+++ b/lte/gateway/format_all.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021 The Magma Authors.
+# Copyright 2023 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -9,6 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -eou pipefail
 
 for dir in /orc8r/gateway/c/ /lte/gateway/c/ /lte/gateway/python/;
 do


### PR DESCRIPTION
Closes #14904 
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- [x] Moved the make action into a separate bash script.
- [x] Introduced a loop to decrease code redundancy.
- [x] Updated a relevant readme.
- [x] Communicate the change with the community.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

- [x] Executing the script locally fixes formatting errors in the three defined folders.

