### PR TITLE
refactor(agw): Work in progress on performance gw_mac_address

### DIFF
--- a/lte/gateway/python/magma/pipelined/gw_mac_address.py
+++ b/lte/gateway/python/magma/pipelined/gw_mac_address.py
@@ -108,7 +108,6 @@ def _get_gw_mac_address_v4(gw_ip: str, vlan: str, non_nat_arp_egress_port: str) 
         )
         eth_mac_src, psrc = _get_addresses(non_nat_arp_egress_port)
         pkt = _create_arp_packet(eth_mac_src, psrc, gw_ip, vlan)
-        logging.debug("ARP Req pkt:\n%s", pkt.pprint())
 
         res = _send_packet_and_receive_response(pkt, vlan, non_nat_arp_egress_port)
         if res is None:


### PR DESCRIPTION
Closes #14818

## Summary

- Only removed a print statement right now. `pprint` was always printing to stdout, regardless of the loglevel.

I did some analysis and comparison of the overall behavior between the old and the new implementation. The two flaky tests are `testFlowVlanSnapshotMatch_static1` and `testFlowVlanSnapshotMatch_static2`.

The first thing to note is that the 2 second timeout was chosen to match the 2 second timeout that was previously passed into scapy's send and receive logic. However, these are now different timeouts. Our current implementation uses the 2 second timeout for the socket timeout option. In scapy the timeout parameter is used in some scapy specific logic and no socket timeout is set. I did some timings and the receive message step in `gw_mac_address` often does take a bit longer than two seconds.

It is important to understand that we are not trying to locally reproduce all of scapy's steps. Instead, we are using our own logic to get the same result.

I still don't fully understand if there are any fundamental differences between how the tests are run. I measured the time it takes to receive an ARP response both with the old and the new implementation. However, I found that we had a different number of ARP packets sent and received overall. Perhaps there were some more changes in the mean time. I used master for comparison.


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
