### PR TITLE
chore(agw): Minor fabfile refactoring second attempt

### DIFF
--- a/feg/gateway/fabfile.py
+++ b/feg/gateway/fabfile.py
@@ -37,7 +37,7 @@ def register_feg_gw(c, location_docker_compose=FEG_DOCKER_LOCATION):
     Args:
         c: fabric Connection
         location_docker_compose: location of docker compose. Default set to
-        FEG_DOCKER_LOCATION
+            FEG_DOCKER_LOCATION.
     """
     _register_federation_network()
     _register_feg(c, location_docker_compose)
@@ -50,7 +50,7 @@ def deregister_feg_gw(c, location_docker_compose=FEG_DOCKER_LOCATION):
     Args:
         c: fabric Connection
         location_docker_compose: location of docker compose. Default set to
-        FEG_DOCKER_LOCATION
+            FEG_DOCKER_LOCATION.
     """
     _deregister_feg_gw(c, location_docker_compose)
     dev_utils.delete_gateway_certs_from_docker(c, location_docker_compose)
@@ -76,13 +76,13 @@ def check_feg_cloud_connectivity(c, timeout=5):
 class RadiusConfig:
     def __init__(
         self,
-        DAE_addr: str = '127.0.0.1:3799',
+        dae_addr: str = '127.0.0.1:3799',
         acct_addr: str = '127.0.0.1:1813',
         auth_addr: str = '127.0.0.1:1812',
         network: str = 'udp',
         secret: str = 'MTIzNDU2',
     ):
-        self.DAE_addr = DAE_addr
+        self.dae_addr = dae_addr
         self.acct_addr = acct_addr
         self.auth_addr = auth_addr
         self.network = network
@@ -164,10 +164,10 @@ class DiamServerConfig:
 class GxConfig:
     def __init__(
         self,
-        disableGx: bool = False,
+        disable_gx: bool = False,
         servers: List[DiamServerConfig] = None,
     ):
-        self.disableGx = disableGx
+        self.disable_gx = disable_gx
         if servers is None:
             servers = [DiamServerConfig()]
         self.servers = servers
@@ -176,11 +176,11 @@ class GxConfig:
 class GyConfig:
     def __init__(
         self,
-        disableGy: bool = False,
+        disable_gy: bool = False,
         init_method: int = 2,
         servers: List[DiamServerConfig] = None,
     ):
-        self.disableGy = disableGy
+        self.disable_gy = disable_gy
         self.init_method = init_method
         if servers is None:
             servers = [DiamServerConfig()]
@@ -262,7 +262,7 @@ class HssConfigs:
 class S6aConfigs:
     def __init__(
         self,
-        plmn_ids: List[str] = list(),
+        plmn_ids: List[str] = None,
         server: DiamServerConfig = DiamServerConfig(),
     ):
         if plmn_ids is None:
@@ -274,14 +274,14 @@ class S6aConfigs:
 class SwxConfigs:
     def __init__(
         self,
-        cache_TTL_seconds: int = 10800,
+        cache_ttl_seconds: int = 10800,
         derive_unregister_realm: bool = False,
         hlr_plmn_ids: List[str] = None,
         register_on_auth: bool = False,
         servers: List[DiamServerConfig] = None,
         verify_authorization: bool = False,
     ):
-        self.cache_TTL_seconds = cache_TTL_seconds
+        self.cache_ttl_seconds = cache_ttl_seconds
         self.derive_unregister_realm = derive_unregister_realm
         if hlr_plmn_ids is None:
             hlr_plmn_ids = ['00101']
@@ -336,14 +336,14 @@ class FederationNetworkConfigs:
 class FederationNetwork:
     def __init__(
         self,
-        id: str = NETWORK_ID,
+        network_id: str = NETWORK_ID,
         name: str = 'Testing',
         description: str = 'Test federation network',
         federation: FederationNetworkConfigs = FederationNetworkConfigs(),
         dns: types.NetworkDNSConfig = types.NetworkDNSConfig(),
         subscriber_config: SubConfig = SubConfig(),
     ):
-        self.id = id
+        self.id = network_id
         self.name = name
         self.description = description
         self.dns = dns
@@ -354,13 +354,13 @@ class FederationNetwork:
 class FederationGateway:
     def __init__(
         self,
-        id: str, name: str, description: str,
+        network_id: str, name: str, description: str,
         device: types.GatewayDevice,
         magmad: types.MagmadGatewayConfigs,
         tier: str = 'default',
         federation: FederationNetworkConfigs = FederationNetworkConfigs(),
     ):
-        self.id = id
+        self.id = network_id
         self.name = name
         self.description = description
         self.device = device
@@ -399,7 +399,7 @@ def _register_feg(c: Connection, location_docker_compose: str):
     gw_id = dev_utils.get_next_available_gateway_id(NETWORK_ID)
     md_gw = dev_utils.construct_magmad_gateway_payload(gw_id, hw_id)
     gw_payload = FederationGateway(
-        id=md_gw.id,
+        network_id=md_gw.id,
         name=md_gw.name,
         description=md_gw.description,
         device=md_gw.device,

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -121,7 +121,7 @@ def package(
             c_gw.run('make clean')
             build_type = "Debug" if debug_mode else "RelWithDebInfo"
 
-            build_cmd = f'./release/build-magma.sh --commit_hash {commit_hash}' \
+            build_cmd = f'./release/build-magma.sh --hash {commit_hash}' \
                         f' --commit-count {commit_count} --type {build_type}' \
                         f' --cert {cert_file} --proxy {proxy_config} --os {os}'
             # set '/usr/bin/' in PATH to ensure that the correct version of

--- a/lte/gateway/python/integ_tests/federated_tests/fabfile.py
+++ b/lte/gateway/python/integ_tests/federated_tests/fabfile.py
@@ -139,7 +139,8 @@ def clear_orc8r_db(c):
 def install_agw(c, provision_vm=False):
     """
     Install a magma AGW debian package on the magma_deb Vagrant VM.
-
+    Args:
+        c: fabric connection.
        provision_vm: forces the reprovision of the magma VM
     """
     print('#### Installing AGW ####')


### PR DESCRIPTION
## Summary

The `agw_build` job was broken after merging #15004. We did not realise during testing because `agw_build` did not run on the CI on my fork.

Changes:
- Reverted #15030 , see #15004 for a list of changes I am bringing back
- Fixed an error where I renamed a command line argument "hash" into "commit_hash"

## Test Plan

- [x] Ran `MAGMA_DEV_MEMORY_MB=4096 fab release package --destroy-vm` locally to verify that the error no longer occurs.