### PR TITLE
chore(agw): build python precommit container locally

### DIFF
--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -51,4 +51,4 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE }}
-          PUSH_TO_REGISTRY: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}
+          PUSH_TO_REGISTRY: false

--- a/docs/readmes/lte/dev_unit_testing.md
+++ b/docs/readmes/lte/dev_unit_testing.md
@@ -92,8 +92,6 @@ Refer to the script at `lte/gateway/python/precommit.py` for all available comma
 
 ```bash
 cd $MAGMA/lte/gateway/python
-# build the base image
-./precommit.py --build
 
 # run the flake8 linter by specifying paths
 ./precommit.py --lint -p PATH1 PATH2

--- a/lte/gateway/python/precommit.py
+++ b/lte/gateway/python/precommit.py
@@ -20,7 +20,7 @@ from typing import List
 if os.getenv('MAGMA_ROOT'):
     MAGMA_ROOT = os.environ["MAGMA_ROOT"]
 else:
-    raise Exception("'MAGMA_ROOT' needs to be set and point to the Magma root directory!")
+    raise KeyError("'MAGMA_ROOT' needs to be set and point to the Magma root directory!")
 
 LINT_DOCKER_PATH = os.path.join(
     MAGMA_ROOT,


### PR DESCRIPTION
Part of #15000 

## Summary

Build the python precommit container locally instead of downloading the image. The build takes <1min, and the CI respective jobs also build the image locally, so it should not be necessary to upload the container image.

## Test Plan

Run the script.

## Additional Information

- [ ] This change is backwards-breaking
