### PR TITLE
docs: update FAQ on IPv6

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.4.X/faq/faq_magma.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.X/faq/faq_magma.md
@@ -67,8 +67,8 @@ This section lists some of the commonly asked questions related to Magma operati
     - From the popup window, select tab **COMMANDS**. Then, check section **Reboot**.
     - Click on **Reboot** to reboot the AGW node.
 
-### Does AGW supports IPv6?
-  - IPv6 and dual stack IPv4V6 session support are currently under active development and we are working towards making this feature ready as part of release 1.4.
+### Does the AGW support IPv6?
+  - IPv6 and dual stack IPv4V6 session support are currently under active development and we are working towards making this feature ready as part of a future release.
 
 ### How to change hardware UUID of AGW?
   - Hardware UUID is in `/etc/snowflake`.

--- a/docs/docusaurus/versioned_docs/version-1.5.X/faq/faq_magma.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/faq/faq_magma.md
@@ -67,8 +67,8 @@ This section lists some of the commonly asked questions related to Magma operati
     - From the popup window, select tab **COMMANDS**. Then, check section **Reboot**.
     - Click on **Reboot** to reboot the AGW node.
 
-### Does AGW supports IPv6?
-  - IPv6 and dual stack IPv4V6 session support are currently under active development and we are working towards making this feature ready as part of release 1.4.
+### Does the AGW support IPv6?
+  - IPv6 and dual stack IPv4V6 session support are currently under active development and we are working towards making this feature ready as part of a future release.
 
 ### How to change hardware UUID of AGW?
   - Hardware UUID is in `/etc/snowflake`.

--- a/docs/docusaurus/versioned_docs/version-1.7.0/faq/faq_magma.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/faq/faq_magma.md
@@ -80,9 +80,9 @@ This section lists some of the commonly asked questions related to Magma operati
     - From the popup window, select tab **COMMANDS**. Then, check section **Reboot**.
     - Click on **Reboot** to reboot the AGW node.
 
-### Does AGW supports IPv6?
+### Does the AGW support IPv6?
 
-- IPv6 and dual stack IPv4V6 session support are currently under active development and we are working towards making this feature ready as part of release 1.4.
+- IPv6 and dual stack IPv4v6 session support is implemented for Magma v1.7 and later.
 
 ### How to change hardware UUID of AGW?
 

--- a/docs/readmes/faq/faq_magma.md
+++ b/docs/readmes/faq/faq_magma.md
@@ -79,9 +79,9 @@ This section lists some of the commonly asked questions related to Magma operati
     - From the popup window, select tab **COMMANDS**. Then, check section **Reboot**.
     - Click on **Reboot** to reboot the AGW node.
 
-### Does AGW supports IPv6?
+### Does AGW support IPv6?
 
-- IPv6 and dual stack IPv4V6 session support are currently under active development and we are working towards making this feature ready as part of release 1.4.
+- IPv6 and dual stack IPv4v6 session support is implemented for Magma v1.7 and later.
 
 ### How to change hardware UUID of AGW?
 

--- a/docs/readmes/faq/faq_magma.md
+++ b/docs/readmes/faq/faq_magma.md
@@ -79,7 +79,7 @@ This section lists some of the commonly asked questions related to Magma operati
     - From the popup window, select tab **COMMANDS**. Then, check section **Reboot**.
     - Click on **Reboot** to reboot the AGW node.
 
-### Does AGW support IPv6?
+### Does the AGW support IPv6?
 
 - IPv6 and dual stack IPv4v6 session support is implemented for Magma v1.7 and later.
 


### PR DESCRIPTION
Closes #14409

## Summary

Update the FAQ entry on IPv6 to reflect the current status of IPv6 and IPv4v6 support of the AGW.

## Additional Information

- [ ] This change is backwards-breaking

