### PR TITLE
build: Pin versions to make it possible to build all dependencies

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -131,6 +131,8 @@ setup(
         'ovs>=2.13,<2.17.0',
         'prometheus-client>=0.3.1',
         'aioeventlet==0.5.1',  # aioeventlet-build.sh
+        'typing-extensions<4',
+        'jsonref==0.2',
     ],
     extras_require={
         'dev': [

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -131,8 +131,9 @@ setup(
         'ovs>=2.13,<2.17.0',
         'prometheus-client>=0.3.1',
         'aioeventlet==0.5.1',  # aioeventlet-build.sh
-        'typing-extensions<4',
+        'astroid==2.4.2',
         'jsonref==0.2',
+        'typing-extensions<4',
     ],
     extras_require={
         'dev': [

--- a/lte/gateway/release/magma.lockfile.ubuntu
+++ b/lte/gateway/release/magma.lockfile.ubuntu
@@ -566,23 +566,29 @@
           "root": true,
           "source": "pypi",
           "sysdep": "python3-aiohttp",
-          "version": "3.6.2"
+          "version": "3.8.4"
+        },
+        "aiosignal": {
+          "root": false,
+          "source": "pypi",
+          "sysdep": "python3-aiosignal",
+          "version": "1.3.1"
         },
         "astroid": {
-          "root": false,
-          "source": "apt",
+          "root": true,
+          "source": "pypi",
           "sysdep": "python3-astroid",
           "version": "2.4.2"
         },
         "async-timeout": {
           "root": false,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-async-timeout",
-          "version": "3.0.1"
+          "version": "4.0.2"
         },
         "attrs": {
           "root": false,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-attrs",
           "version": "19.3.0"
         },
@@ -593,10 +599,16 @@
           "version": "5.16.1"
         },
         "certifi": {
-          "root": true,
+          "root": false,
           "source": "apt",
           "sysdep": "python3-certifi",
           "version": "2019.11.28"
+        },
+        "charset-normalizer": {
+          "root": false,
+          "source": "pypi",
+          "sysdep": "python3-charset-normalizer",
+          "version": "3.0.1"
         },
         "click": {
           "root": true,
@@ -612,9 +624,9 @@
         },
         "cython": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-cython",
-          "version": "0.29.1"
+          "version": "0.29.33"
         },
         "docker": {
           "root": true,
@@ -652,6 +664,12 @@
           "sysdep": "python3-freezegun",
           "version": "0.3.15"
         },
+        "frozenlist": {
+          "root": false,
+          "source": "pypi",
+          "sysdep": "python3-frozenlist",
+          "version": "1.3.3"
+        },
         "glob2": {
           "root": true,
           "source": "apt",
@@ -666,27 +684,27 @@
         },
         "grpcio": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-grpcio",
-          "version": "1.34.0"
+          "version": "1.48.2"
         },
         "h2": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-h2",
-          "version": "3.2.0"
+          "version": "4.1.0"
         },
         "hpack": {
-          "root": true,
-          "source": "apt",
+          "root": false,
+          "source": "pypi",
           "sysdep": "python3-hpack",
-          "version": "3.0.0"
+          "version": "4.0.0"
         },
         "hyperframe": {
           "root": false,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-hyperframe",
-          "version": "5.2.0"
+          "version": "6.0.1"
         },
         "idna": {
           "root": true,
@@ -702,9 +720,9 @@
         },
         "isort": {
           "root": false,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-isort",
-          "version": "5.7.0"
+          "version": "5.12.0"
         },
         "itsdangerous": {
           "root": true,
@@ -743,8 +761,8 @@
           "version": "2.0"
         },
         "jsonref": {
-          "root": false,
-          "source": "apt",
+          "root": true,
+          "source": "pypi",
           "sysdep": "python3-jsonref",
           "version": "0.2"
         },
@@ -774,15 +792,15 @@
         },
         "msgpack": {
           "root": false,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-msgpack",
-          "version": "1.0.0"
+          "version": "1.0.4"
         },
         "multidict": {
           "root": false,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-multidict",
-          "version": "4.7.6"
+          "version": "6.0.4"
         },
         "netifaces": {
           "root": true,
@@ -792,9 +810,9 @@
         },
         "ovs": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-ovs",
-          "version": "2.13.3"
+          "version": "2.16.0"
         },
         "priority": {
           "root": false,
@@ -812,7 +830,7 @@
           "root": true,
           "source": "pypi",
           "sysdep": "python3-protobuf",
-          "version": "3.19.0"
+          "version": "3.20.1"
         },
         "psutil": {
           "root": true,
@@ -828,21 +846,21 @@
         },
         "pycryptodome": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-pycryptodome",
-          "version": "3.9.9"
+          "version": "3.17"
         },
         "pylint": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-pylint",
           "version": "2.6.0"
         },
         "pymemoize": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-pymemoize",
-          "version": "1.0.2"
+          "version": "1.0.3"
         },
         "pyrsistent": {
           "root": false,
@@ -852,9 +870,9 @@
         },
         "pystemd": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-pystemd",
-          "version": "0.8.0"
+          "version": "0.11.0"
         },
         "python-dateutil": {
           "root": true,
@@ -864,9 +882,9 @@
         },
         "python-redis-lock": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-python-redis-lock",
-          "version": "3.7.0"
+          "version": "4.0.0"
         },
         "python3-systemd": {
           "root": true,
@@ -876,9 +894,9 @@
         },
         "pytz": {
           "root": false,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-pytz",
-          "version": "2020.1"
+          "version": "2022.7.1"
         },
         "pyyaml": {
           "root": true,
@@ -941,7 +959,7 @@
           "version": "3.16.0"
         },
         "six": {
-          "root": true,
+          "root": false,
           "source": "apt",
           "sysdep": "python3-six",
           "version": "1.14.0"
@@ -954,15 +972,15 @@
         },
         "sortedcontainers": {
           "root": false,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-sortedcontainers",
-          "version": "2.3.0"
+          "version": "2.4.0"
         },
         "spyne": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-spyne",
-          "version": "2.13.15"
+          "version": "2.14.0"
         },
         "strict-rfc3339": {
           "root": true,
@@ -972,13 +990,13 @@
         },
         "swagger-spec-validator": {
           "root": false,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-swagger-spec-validator",
-          "version": "2.7.3"
+          "version": "3.0.3"
         },
         "systemd-python": {
           "root": true,
-          "source": "apt",
+          "source": "pypi",
           "sysdep": "python3-systemd-python",
           "version": "234"
         },
@@ -992,7 +1010,7 @@
           "root": false,
           "source": "apt",
           "sysdep": "python3-typing-extensions",
-          "version": "3.7.4.3"
+          "version": "3.7.4.1"
         },
         "webcolors": {
           "root": true,
@@ -1039,7 +1057,10 @@
           "version": "0.2.3"
         },
         "aiohttp": {
-          "version": "3.6.2"
+          "version": "3.8.4"
+        },
+        "astroid": {
+          "version": "2.4.2"
         },
         "bravado-core": {
           "version": "5.16.1"
@@ -1053,6 +1074,9 @@
         "cryptography": {
           "version": "2.8"
         },
+        "cython": {
+          "version": "0.29.33"
+        },
         "eventlet": {
           "version": "0.30.2"
         },
@@ -1063,7 +1087,10 @@
           "version": "1.1.1"
         },
         "grpcio": {
-          "version": "1.34.0"
+          "version": "1.48.2"
+        },
+        "h2": {
+          "version": "4.1.0"
         },
         "itsdangerous": {
           "version": "1.1.0"
@@ -1080,6 +1107,9 @@
         "jsonpointer": {
           "version": "2.0"
         },
+        "jsonref": {
+          "version": "0.2"
+        },
         "jsonschema": {
           "version": "3.1.0"
         },
@@ -1090,13 +1120,13 @@
           "version": "0.10.4"
         },
         "ovs": {
-          "version": "2.13.3"
+          "version": "2.16.0"
         },
         "prometheus-client": {
           "version": "0.3.1"
         },
         "protobuf": {
-          "version": "3.19.0"
+          "version": "3.20.1"
         },
         "psutil": {
           "version": "5.8.0"
@@ -1104,14 +1134,23 @@
         "pycares": {
           "version": "3.1.1"
         },
+        "pycryptodome": {
+          "version": "3.17"
+        },
         "pylint": {
           "version": "2.6.0"
         },
+        "pymemoize": {
+          "version": "1.0.3"
+        },
         "pystemd": {
-          "version": "0.8.0"
+          "version": "0.11.0"
+        },
+        "python-redis-lock": {
+          "version": "4.0.0"
         },
         "pytz": {
-          "version": "2020.1"
+          "version": "2022.7.1"
         },
         "pyyaml": {
           "version": "5.3.1"
@@ -1141,7 +1180,7 @@
           "version": "0.0.3"
         },
         "spyne": {
-          "version": "2.13.15"
+          "version": "2.14.0"
         },
         "strict-rfc3339": {
           "version": "0.7"

--- a/lte/gateway/release/pydep
+++ b/lte/gateway/release/pydep
@@ -1086,7 +1086,7 @@ def main(args):
             pip_packages = [req.key for req in repo_installable]
             subprocess.call(shlex.split('sudo pip3 uninstall -y '
                                         + ' '.join(pip_packages)))
-            subprocess.call(shlex.split('sudo apt install -y '
+            subprocess.call(shlex.split('sudo apt reinstall -y '
                                         + ' '.join(repo_pkgs)))
         except Exception:
             log.error('error trying to install repo packages')

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -73,7 +73,7 @@ setup(
         'protobuf==3.20.1',
         'Jinja2>=2.8',
         'netifaces>=0.10.4',
-        'pylint>=1.7.1,<=2.14.0',
+        'pylint==2.6.0',
         'PyYAML>=3.12',
         'pytz>=2014.4',
         'prometheus_client==0.3.1',


### PR DESCRIPTION
## Summary
This PR will enable us to build and package all magma python dependencies on 1.8 again. The issue with the current workflow is that it still relies on `fpm` to package python dependencies into `.deb` files. `fpm` cannot build newer versions of dependencies if they no longer provide a `setup.py` file. (See also PR 1982 on the `fpm` github page and the linked issues). As more and more of our dependencies rely on more modern python `pyproject.toml` structures we have to add version constraints our `setup.py` files. 

We will eventually overcome this issue by switching to `bazel`, which is why we don't attempt a greater fix of this issue at the moment.

I attempted to minimize the changes in this PR while obtaining a full set of magma dependencies.
- Add version constraint for `astroid`, `typing-extensions`, and `jsonref`
- Tighten version constraint for `pylint`
- Use `reinstall` instead of install in `pydep` (See https://github.com/magma/magma/pull/13799)

<!-- Enumerate changes you made and why you made them -->

Open questions:
- [x] Should the lockfile also be updated in this PR? -> Yes
- [x] Does this need to be backported to v1.8 or will we use the changes elsewhere?
  - These changes are only required on v1.8 

## Test Plan
Testing takes unfortunately quite a long time since we need to build all the packages and check if they can be installed and run.

- Start magma dev VM on this branch.
- Disable LF artifactory `sudo rm /etc/apt/sources.list.d/magma.list && sudo apt-get update` .
- Run `fab dev package` on host machine. Python dependencies appear in `~/magma-packages` folder.
- Move `magma-packages` under `magma` to make it available in all VMs.
- `vagrant halt magma`
- Switch to master branch (magma_deb does not exist on v1.8).
- Start `magma_deb` without installing magma.
	- Simply comment out lines 129-141 in lte/gateway/deploy/roles/magma_deploy/tasks/main.yml (magma install).
	- Add an ansible step to create the `/etc/magma` and `/etc/magma/templates` directories
- `sudo rm /etc/apt/sources.list.d/magma.list && sudo apt-get update` # Disable LF artifactory
- [x] Install created python3 packages (`sudo apt-get install ./python3*.deb`) (works)
- [x] `sudo apt-get install ./magma-sctpd*.deb`
- `magma_1.8.0*.deb` depends on a couple more `*.deb` files which are on the LF artifactory and are not python3 dependencies, we can try to run `apt-get install` to see what is missing.
- Re-enable the LF artifactory.
  - `sudo su`
  - `echo "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main" > /etc/apt/sources.list.d/magma.list`
  - `ctrl + D` to exit super user mode.
- [x] `sudo apt-get install ./magma_1.8.0*.deb`
  - You would get some prompts about which config to use. You should use the configs provided by the `magma_1.8.0*.deb` over the existing ones.
- Run `magma-start` to start the services.
- [x] Check services are running with `magma-status`.
  - Regression is possible over time, so we may need another round of version fixing.
- [x] Repeat above steps without removing `magma.list` while building.

- [ ] Remaining issue: Fix linter issues?
```
E           AssertionError: PyLint found errors:
E           ************* Module pipelined.app.uplink_bridge
E           E0602: 65, 42: Undefined variable 'UplinkBridgeConfig' (undefined-variable)
E           ************* Module pipelined.app.he
E           E0602: 133, 51: Undefined variable 'UplinkHEConfig' (undefined-variable)
E           ************* Module pipelined.qos.tc_ops
E           E0012: 13, 0: Bad option value 'unnecessary-ellipsis' (bad-option-value)
```