### PR TITLE
docs: Added better instructions for deploying helm charts

### DIFF
--- a/docs/readmes/orc8r/dev_minikube.md
+++ b/docs/readmes/orc8r/dev_minikube.md
@@ -150,6 +150,22 @@ helm dep update
 helm upgrade --install --namespace orc8r --values ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r.values.yaml orc8r .
 ```
 
+Optionally, install the `cwf-orc8r`, `feg-orc8r`, and `lte-orc8r` charts by modifying the file templates similarly to the `orc8r` values file.
+Move the value file to `${MAGMA_ROOT}/orc8r/cloud/helm/{component}.values.yaml`.
+For `lte-orc8r` you can find a `minikube.values.yaml` template file in the `${MAGMA_ROOT}/{component}/cloud/helm/{component}-orc8r/examples/` directory.
+For the other charts, you can find a `values.yaml` file in the main `${MAGMA_ROOT}/{component}/cloud/helm/{component}-orc8r/{component}-orc8r` directory.
+
+Add the following to the `{component}.values.yaml` file:
+
+```yaml
+image:
+# ...
+  env:
+      orc8r_domain_name: "magma.test"
+```
+
+
+```bash
 Optionally install other charts, like the `lte` charts, similarly
 
 ```bash

--- a/docs/readmes/orc8r/dev_minikube.md
+++ b/docs/readmes/orc8r/dev_minikube.md
@@ -122,6 +122,7 @@ Apply the secrets
 cd ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r
 helm template orc8r charts/secrets \
   --namespace orc8r \
+  --set-string secret.certs.enabled=true \
   --set-file 'secret.certs.files.fluentd\.pem'=${CERTS_DIR}/fluentd.pem \
   --set-file 'secret.certs.files.fluentd\.key'=${CERTS_DIR}/fluentd.key |
   kubectl apply -f -

--- a/docs/readmes/orc8r/dev_minikube.md
+++ b/docs/readmes/orc8r/dev_minikube.md
@@ -154,7 +154,7 @@ helm upgrade --install --namespace orc8r --values ${MAGMA_ROOT}/orc8r/cloud/helm
 Optionally, install the `cwf-orc8r`, `feg-orc8r`, and `lte-orc8r` charts by modifying the file templates similarly to the `orc8r` values file.
 Move the value file to `${MAGMA_ROOT}/orc8r/cloud/helm/{component}.values.yaml`.
 For `lte-orc8r` you can find a `minikube.values.yaml` template file in the `${MAGMA_ROOT}/{component}/cloud/helm/{component}-orc8r/examples/` directory.
-For the other charts, you can find a `values.yaml` file in the main `${MAGMA_ROOT}/{component}/cloud/helm/{component}-orc8r/{component}-orc8r` directory.
+For the other charts, you can find a `values.yaml` file in the main `${MAGMA_ROOT}/{component}/cloud/helm/{component}-orc8r/` directory.
 
 Add the following to the `{component}.values.yaml` file:
 

--- a/docs/readmes/orc8r/dev_minikube.md
+++ b/docs/readmes/orc8r/dev_minikube.md
@@ -123,8 +123,21 @@ cd ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r
 helm template orc8r charts/secrets \
   --namespace orc8r \
   --set-string secret.certs.enabled=true \
+  --set-file 'secret.certs.files.rootCA\.pem'=${CERTS_DIR}/rootCA.pem \
+  --set-file 'secret.certs.files.bootstrapper\.key'=${CERTS_DIR}/bootstrapper.key \
+  --set-file 'secret.certs.files.controller\.crt'=${CERTS_DIR}/controller.crt \
+  --set-file 'secret.certs.files.controller\.key'=${CERTS_DIR}/controller.key \
+  --set-file 'secret.certs.files.admin_operator\.pem'=${CERTS_DIR}/admin_operator.pem \
+  --set-file 'secret.certs.files.admin_operator\.key\.pem'=${CERTS_DIR}/admin_operator.key.pem \
+  --set-file 'secret.certs.files.certifier\.pem'=${CERTS_DIR}/certifier.pem \
+  --set-file 'secret.certs.files.certifier\.key'=${CERTS_DIR}/certifier.key \
+  --set-file 'secret.certs.files.nms_nginx\.pem'=${CERTS_DIR}/controller.crt \
+  --set-file 'secret.certs.files.nms_nginx\.key\.pem'=${CERTS_DIR}/controller.key \
   --set-file 'secret.certs.files.fluentd\.pem'=${CERTS_DIR}/fluentd.pem \
-  --set-file 'secret.certs.files.fluentd\.key'=${CERTS_DIR}/fluentd.key |
+  --set-file 'secret.certs.files.fluentd\.key'=${CERTS_DIR}/fluentd.key \
+  --set=docker.registry=${IMAGE_REGISTRY_URL} \
+  --set=docker.username=${IMAGE_REGISTRY_USERNAME} \
+  --set=docker.password=${IMAGE_REGISTRY_PASSWORD} |
   kubectl apply -f -
 ```
 
@@ -153,8 +166,8 @@ helm upgrade --install --namespace orc8r --values ${MAGMA_ROOT}/orc8r/cloud/helm
 
 Optionally, install the `cwf-orc8r`, `feg-orc8r`, and `lte-orc8r` charts by modifying the file templates similarly to the `orc8r` values file.
 Move the value file to `${MAGMA_ROOT}/orc8r/cloud/helm/{component}.values.yaml`.
-For `lte-orc8r` you can find a `minikube.values.yaml` template file in the `${MAGMA_ROOT}/{component}/cloud/helm/{component}-orc8r/examples/` directory.
-For the other charts, you can find a `values.yaml` file in the main `${MAGMA_ROOT}/{component}/cloud/helm/{component}-orc8r/` directory.
+For `lte-orc8r` charts you can find a `minikube.values.yaml` template file in the `${MAGMA_ROOT}/{component}/cloud/helm/{component}-orc8r/examples/` directory.
+For the other charts you can find a `values.yaml` file in the main `${MAGMA_ROOT}/{component}/cloud/helm/{component}-orc8r/` directory.
 
 Add the following to the `{component}.values.yaml` file:
 
@@ -165,8 +178,7 @@ image:
       orc8r_domain_name: "magma.test"
 ```
 
-```bash
-Optionally install other charts, like the `lte` charts, similarly
+And install the helm charts like this:
 
 ```bash
 cd ${MAGMA_ROOT}/lte/cloud/helm/lte-orc8r
@@ -324,15 +336,16 @@ curl \
 
 ### Access NMS
 
-Follow the instructions to [create an NMS admin user](./deploy_install.md#create-an-nms-admin-user)
+Follow the instructions to [create an NMS admin user](./deploy_install.md#create-an-nms-admin-user).
+Substitute the `host` organization with `magma-test` and choose some values for the user email and password, e.g. `admin@magma.test` and `password1234`.
 
-Port-forward Nginx
+Start port-forward for Nginx (this tab will hang):
 
 ```bash
 kubectl --namespace orc8r port-forward svc/nginx-proxy 8081:443
 ```
 
-Log in to NMS at <https://magma-test.localhost:8081> using credentials: `admin@magma.test/password1234`
+Log in to NMS at <https://magma-test.localhost:8081> using credentials you chose when creating the admin user.
 
 ## Appendix
 

--- a/docs/readmes/orc8r/dev_minikube.md
+++ b/docs/readmes/orc8r/dev_minikube.md
@@ -165,7 +165,6 @@ image:
       orc8r_domain_name: "magma.test"
 ```
 
-
 ```bash
 Optionally install other charts, like the `lte` charts, similarly
 
@@ -284,7 +283,7 @@ storage-provisioner                1/1     Running   0          3d
 Optionally, start the elasticsearch and kibana containers which handle the logs aggregated by fluentd
 
 ```bash
-cd ${MAGMA_ROOT}/cloud/docker
+cd ${MAGMA_ROOT}/orc8r/cloud/docker
 ./run.py
 ```
 


### PR DESCRIPTION
## Summary

So far there is no existing documentation of the `cwf-orc8r`, `feg-orc8r`, `lte-orc8r` helm charts. The services themselves appear in the docusaurus docs, but there is next to no explanation as to how to actually deploy the helm charts. For someone experienced with kubernetes not much explanation may actually be needed. However, for the average magma developer we should provide some detailed steps as to how to deploy the charts on a local minikube cluster for testing purposes.

I added some sentences in the `Deploy on Minikube` page about where to find the helm charts and how to deploy them. Crucially, an environment variable needs to be defined in the values files.

Along the way we also found some additional issues:
- [x] The fluentd secrets need to be applied in a single command with the other secrets
- [x] A missing `/orc8r` in the a directory name
- [x] Some issues with the NMS setup

## Test Plan

Following the steps described in the `Deploy on Minikube` page I was able to deploy the charts for `orc8r`, `cwf-orc8r`, `feg-orc8r`, and `lte-orc8r`.


Still to do:
- [x] Deploy elasticsearch/kibana and make sure they connect with fluentd .
- [x] Screenshot needs updating with the following deployments
  - [x] `dp-orc8r` (Deploy by running `make` in the `magma/dp` directory
  - [x] `fluentd`
  - [x] `nms`

![Screenshot from 2023-02-27 16-19-25](https://user-images.githubusercontent.com/8889531/221480622-33cc29fd-8e6b-414c-a916-70db70a3307b.png)

![Screenshot from 2023-02-27 14-13-17](https://user-images.githubusercontent.com/8889531/221464629-56737a64-3126-4019-b38d-daeff86218f4.png)
