### PR TITLE
fix(ci): results of FEG integ tests are published to CI dashboard again

### DIFF
--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -204,7 +204,7 @@ jobs:
           junit_files: lte/gateway/test_results/**/*.xml
           check_run_annotations: all tests
       - name: Publish results to Firebase
-        if: always() && github.event_name == 'push'
+        if: always() && github.event_name == 'repository_dispatch'
         env:
           FIREBASE_SERVICE_CONFIG: ${{ secrets.FIREBASE_SERVICE_CONFIG }}
           REPORT_FILENAME: "feg_integ_test_${{ github.sha }}.html"
@@ -215,7 +215,7 @@ jobs:
           [ -f "out_url.txt" ] && { URL=$(cat out_url.txt); }
           python ci-scripts/firebase_publish_report.py -id ${{ github.sha }} --verdict ${{ job.status }} --run_id ${{ github.run_id }} feg --url $URL
       - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
+        if: failure() && github.repository_owner == 'magma'
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: ${{ github.workflow }}


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The results of the FEG integ tests are not longer published to the firebase CI dashboard because we changed the workflow trigger and now the condition for the CI step is never valid. This PR fixes it. 
The code was adapted according to the "AGW Test LTE Integration With Bazel Debian Build" workflow.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
