### PR TITLE
chore: Build the Python services with Bazel for the Dockerized AGW

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,7 @@
 !lte/gateway/docker/
 !lte/gateway/deploy/roles/magma/files/
 !lte/gateway/python/
+!lte/gateway/release/
 !lte/gateway/Makefile
 !lte/gateway/c
 !lte/protos/
@@ -55,9 +56,8 @@
 !protos/
 
 !bazel/
-!*.bzl
-!*.bazel
-!*.BUILD
+!**/*.bzl
+!**/*.bazel
 !.bazelrc
 !.bazelignore
 !.bazelversion

--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -18,23 +18,17 @@ ARG CPU_ARCH=x86_64
 ARG DEB_PORT=amd64
 ARG OS_DIST=ubuntu
 ARG OS_RELEASE=focal
-ARG EXTRA_REPO=https://linuxfoundation.jfrog.io/artifactory/magma-packages-test
 
 FROM $OS_DIST:$OS_RELEASE AS builder
 ARG CPU_ARCH
 ARG DEB_PORT
 ARG OS_DIST
 ARG OS_RELEASE
-ARG EXTRA_REPO
 
 ENV MAGMA_DEV_MODE 0
 ENV TZ=Europe/Paris
 ENV MAGMA_ROOT=/magma
-ENV PYTHON_BUILD=/build
 ENV PIP_CACHE_HOME="~/.pipcache"
-ENV SWAGGER_CODEGEN_DIR /var/tmp/codegen/modules/swagger-codegen-cli/target
-ENV SWAGGER_CODEGEN_JAR ${SWAGGER_CODEGEN_DIR}/swagger-codegen-cli.jar
-ARG CODEGEN_VERSION=2.2.3
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
@@ -42,43 +36,27 @@ RUN apt-get update && apt-get install -y \
   git \
   lsb-release \
   libsystemd-dev \
-  libprotobuf-dev \
   pkg-config \
   python3-dev \
-  python3-eventlet \
   python3-pip \
-  python3-protobuf \
-  python3-pystemd \
-  ruby \
-  ruby-dev \
   sudo \
-  openjdk-8-jdk \
-  openjdk-8-jre-headless \
-  virtualenv \
   wget \
   && rm -rf /var/lib/apt/lists/*
 
-RUN gem install fpm
+# Download Bazel
+RUN  wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-"${DEB_PORT}" && \
+  chmod +x /usr/sbin/bazelisk-linux-"${DEB_PORT}" && \
+  ln -s /usr/sbin/bazelisk-linux-"${DEB_PORT}" /usr/sbin/bazel
 
-COPY ./third_party/build/bin/aioeventlet_build.sh $MAGMA_ROOT/third_party/build/bin/aioeventlet_build.sh
-COPY ./third_party/build/lib/util.sh $MAGMA_ROOT/third_party/build/lib/util.sh
-WORKDIR /var/tmp/
-RUN /magma/third_party/build/bin/aioeventlet_build.sh && \
-  dpkg -i python3-aioeventlet*
-
-RUN mkdir -p ${SWAGGER_CODEGEN_DIR}; \
-  wget --no-verbose https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/${CODEGEN_VERSION}/swagger-codegen-cli-${CODEGEN_VERSION}.jar -O ${SWAGGER_CODEGEN_JAR}
-
-COPY \
-    ./lte/gateway/python/Makefile \
-    ./lte/gateway/python/defs.mk \
-    ./lte/gateway/python/setup.py \
-    $MAGMA_ROOT/lte/gateway/python/
+COPY ./lte/gateway/python/integ_tests/s1aptests/ovs $MAGMA_ROOT/lte/gateway/python/integ_tests/s1aptests/ovs
 COPY ./lte/gateway/python/load_tests $MAGMA_ROOT/lte/gateway/python/load_tests
 COPY ./lte/gateway/python/scripts $MAGMA_ROOT/lte/gateway/python/scripts
 COPY ./lte/gateway/python/dhcp_helper_cli $MAGMA_ROOT/lte/gateway/python/dhcp_helper_cli
 COPY ./lte/gateway/python/magma $MAGMA_ROOT/lte/gateway/python/magma
 COPY ./orc8r/gateway/python $MAGMA_ROOT/orc8r/gateway/python
+
+COPY ./lte/gateway/configs $MAGMA_ROOT/lte/gateway/configs
+COPY ./orc8r/gateway/configs/templates $MAGMA_ROOT/orc8r/gateway/configs/templates
 
 COPY ./protos $MAGMA_ROOT/protos
 COPY ./lte/protos $MAGMA_ROOT/lte/protos
@@ -91,8 +69,15 @@ COPY ./orc8r/swagger $MAGMA_ROOT/orc8r/swagger
 
 COPY ./lte/gateway/deploy/roles/magma/files/patches $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/patches
 
-WORKDIR /magma/lte/gateway/python
-RUN make buildenv
+# Copy Bazel files
+COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion ${MAGMA_ROOT}/
+COPY bazel/ ${MAGMA_ROOT}/bazel
+COPY ./lte/gateway/python/BUILD.bazel $MAGMA_ROOT/lte/gateway/python/BUILD.bazel
+COPY ./lte/gateway/release/BUILD.bazel $MAGMA_ROOT/lte/gateway/release/BUILD.bazel
+COPY ./lte/gateway/release/deb_dependencies.bzl $MAGMA_ROOT/lte/gateway/release/deb_dependencies.bzl
+
+WORKDIR /magma
+RUN bazel build //lte/gateway/release:python_executables_tar //lte/gateway/release:dhcp_helper_cli_tar
 
 # -----------------------------------------------------------------------------
 # Dev/Production image
@@ -124,19 +109,12 @@ RUN apt-get update && apt-get install -y \
   nghttp2-proxy \
   python3-pip \
   python3-venv \
-  python3-eventlet \
-  python3-pystemd \
-  python3-jinja2 \
-  python3-scapy \
   redis-server \
   sudo \
-  virtualenv \
   wget \
   && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m venv $VIRTUAL_ENV
-
-ENV PATH="/magma/orc8r/gateway/python/scripts/:/magma/lte/gateway/python/scripts/:$VIRTUAL_ENV/bin:$PATH"
+ENV PATH="/magma/orc8r/gateway/python/scripts/:/magma/lte/gateway/python/scripts/:$PATH"
 
 # Add the magma apt repo
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
@@ -155,26 +133,18 @@ RUN apt-get update && apt-get install -y \
   wireguard \
   && rm -rf /var/lib/apt/lists/*
 
-COPY \
-    ./orc8r/gateway/python/scripts/ \
-    ./lte/gateway/python/scripts/ \
-    ./lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py \
-    /usr/local/bin/
-COPY ./lte/gateway/configs/templates /etc/magma/templates/
-COPY ./lte/gateway/deploy/roles/magma/files/set_irq_affinity /usr/local/bin/set_irq_affinity
-COPY ./lte/gateway/python/magma /magma/lte/gateway/python/magma
-COPY ./orc8r/gateway/configs/templates/nghttpx.conf.template /etc/magma/templates/nghttpx.conf.template
-COPY ./orc8r/gateway/python/magma /magma/orc8r/gateway/python/magma
+COPY ./lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py /usr/local/bin/
+RUN mkdir -p /var/opt/magma/
 
-COPY --from=builder /build /build
-COPY --from=builder /var/tmp/python3-aioeventlet*.deb /var/tmp/
+# Copy the build artifacts.
+COPY --from=builder /magma/bazel-bin/lte/gateway/release/magma_python_executables.tar.gz \
+                    /tmp/magma_python_executables.tar.gz
+RUN tar -xf /tmp/magma_python_executables.tar.gz --directory / && \
+    rm /tmp/magma_python_executables.tar.gz
 
-# The Python scripts in /build/bin are broken inside the container
-# Remove all Python scripts already exist in /usr/local/bin
+COPY --from=builder /magma/bazel-bin/lte/gateway/release/magma-dhcp-cli_1.9.0-VERSION-SUFFIX_amd64.tar.gz \
+                    /tmp/magma-dhcp-cli_1.9.0-VERSION-SUFFIX_amd64.tar.gz
+RUN tar -xf /tmp/magma-dhcp-cli_1.9.0-VERSION-SUFFIX_amd64.tar.gz --directory / && \
+    rm /tmp/magma-dhcp-cli_1.9.0-VERSION-SUFFIX_amd64.tar.gz
+
 WORKDIR /usr/local/bin
-RUN find ./*.py -exec rm -rf /build/bin/{} \;
-
-RUN chmod -R +x /usr/local/bin/generate* /usr/local/bin/set_irq_affinity /usr/local/bin/checkin_cli.py && \
-  dpkg -i /var/tmp/python3-aioeventlet* && \
-  pip install jsonpointer>$JSONPOINTER_VERSION && \
-  mkdir -p /var/opt/magma/

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -338,3 +338,23 @@ sh_binary(
         "no-cache",
     ],
 )
+
+# CONTAINERIZED ACCESS GATEWAY
+# This target is used to bundle the Python services and scripts,
+# including all runfiles and pip dependencies. The tar file can
+# be copied between builder and runtime Docker images.
+pkg_tar(
+    name = "python_executables_tar",
+    srcs = [
+        ":magma_configs",
+        ":magma_ebpf",
+        ":magma_python_scripts",
+        ":magma_python_services",
+    ],
+    extension = TAR_EXTENSION,
+    package_file_name = "{fname}.{ext}".format(
+        ext = TAR_EXTENSION,
+        fname = "magma_python_executables",
+    ),
+    tags = ["no-cache"],
+)


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Remove the buildenv steps from Python Docker build.
- Build Python services/scripts with Bazel.
  - The `tar.gz` is needed to transfer the services with all dependencies (pip etc.) to the runner image.
  - This also uses the same logic as the `.deb` build in production.
  - See also https://github.com/magma/magma/issues/15034#issuecomment-1441909179
- The steps in `_start_gateway_containerized` (fabric) are adapted to what is already documented for local execution in the `lte/gateway/docker/README.md` file. 
- Resolves https://github.com/magma/magma/issues/15073
  - Part of https://github.com/magma/magma/issues/15034
  

## Test Plan

- [Containerized integ test run with dhcp 1](https://github.com/magma/magma/actions/runs/4292251268)
- [Containerized integ test run with dhcp 2](https://github.com/magma/magma/actions/runs/4292252451) 
- [Containerized integ test run with dhcp 3](https://github.com/magma/magma/actions/runs/4293144107) 
- [Containerized integ test run with dhcp 4](https://github.com/magma/magma/actions/runs/4293145134) 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
