### PR TITLE
chore(ci): docker images are published with release tags

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -52,7 +52,7 @@ jobs:
 
   build-containers:
     outputs:
-      image_tag: ${{ steps.get-short-git-sha.outputs.commit_hash }}
+      image_tag: ${{ steps.set-agwc-tags.outputs.image_tag }}
       registry: ${{ steps.set-registry.outputs.registry }}
     runs-on: ubuntu-20.04
     steps:
@@ -77,10 +77,16 @@ jobs:
         name: Set short git sha output
         run: |
           echo ${GITHUB_SHA:0:8}
-          echo commit_hash=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT
+          echo commit_hash=${GITHUB_SHA:0:8} >> $GITHUB_ENV
 
       - name: verify git sha output
-        run: echo "Git SHA is ${{ steps.get-short-git-sha.outputs.commit_hash }}"
+        run: echo "Git SHA is ${commit_hash}"
+
+      - name: Create possible release Tag
+        if: github.event_name == 'push' && github.ref_name != 'master'
+        run: |
+          GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
+          echo commit_hash="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
 
       - name: Set agwc tags
         id: set-agwc-tags
@@ -89,7 +95,7 @@ jobs:
           python_image=${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_python
           go_image=${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}gateway_go
 
-          commit_hash=${{ steps.get-short-git-sha.outputs.commit_hash }}
+          echo image_tag=${commit_hash} >> $GITHUB_OUTPUT
           if [[ ${{ github.ref_name }} = master ]]
           then
             echo c_image_tags=${c_image}:${commit_hash},${c_image}:latest >> $GITHUB_OUTPUT
@@ -161,15 +167,12 @@ jobs:
           echo "Registry is ${{ steps.set-registry.outputs.registry }}"
           echo "Image prefix is ${{ steps.set-registry.outputs.image_prefix }}"
 
-      - id: get-short-git-sha
-        run: echo commit_hash=${GITHUB_SHA:0:8} >> $GITHUB_OUTPUT
-
       - uses: ./.github/workflows/composite/docker-builder-agw
         with:
           REGISTRY_USERNAME: ${{ secrets.LF_JFROG_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
           REGISTRY: ${{ env.registry }}
-          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_c:${{ steps.get-short-git-sha.outputs.commit_hash }}
+          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_c:${{ needs.build-containers.outputs.image_tag }}
           TARGET: agw_c_ghz
           CONTEXT: lte/gateway/docker/ghz
 
@@ -178,7 +181,7 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.LF_JFROG_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.LF_JFROG_PASSWORD }}
           REGISTRY: ${{ env.registry }}
-          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_python:${{ steps.get-short-git-sha.outputs.commit_hash }}
+          TAGS: ${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}ghz_gateway_python:${{ needs.build-containers.outputs.image_tag }}
           TARGET: agw_python_ghz
           CONTEXT: lte/gateway/docker/ghz
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Magma debian packages are released for every merge to master and release branches. They are tagged with `latest` plus either commit hash (master branch) or release version number (release branch). This behavior is mimicked here for magma containers. At the moment, they are only published with the `latest` tag and commit hash.
Closes #15040.

## Test Plan
The GitHub action was adapted to only perform the tag handling and executed on my fork (see the adapted test via the commit hash on the links)

- [x] [Push on master](https://github.com/mpfirrmann/magma/actions/runs/4281248352)
- [x] [Push on a `v1.9` branch created on my fork specifically for this test](https://github.com/mpfirrmann/magma/actions/runs/4281252335)

## Additional Information

The final output tag is written into $GITHUB_OUTPUT in a different step now.
