### PR TITLE
docs: Add missing AGW technical reference pages to sidebars

### DIFF
--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -290,11 +290,13 @@
         "type": "subcategory",
         "label": "Access Gateway",
         "ids": [
+          "lte/readme_agw",
           "lte/dev_notes",
           "lte/openvswitch",
           "lte/pipelined",
           "lte/ebpf_datapath",
           "lte/ipfix",
+          "lte/pipelined_tests",
           "lte/dev_unit_testing",
           "lte/tr069",
           "lte/s1ap_tests",
@@ -304,7 +306,8 @@
           "lte/dev_teid_allocation",
           "lte/integrated_5g_sa",
           "lte/extended_5g_sa_features",
-          "lte/suci_extensions"
+          "lte/suci_extensions",
+          "lte/redirectd"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -303,18 +303,21 @@
         "type": "subcategory",
         "label": "Access Gateway",
         "ids": [
+          "version-1.7.0-lte/readme_agw",
           "version-1.7.0-lte/dev_notes",
           "version-1.7.0-lte/openvswitch",
           "version-1.7.0-lte/pipelined",
           "version-1.7.0-lte/ebpf_datapath",
           "version-1.7.0-lte/ipfix",
+          "version-1.7.0-lte/pipelined_tests",
           "version-1.7.0-lte/dev_unit_testing",
           "version-1.7.0-lte/tr069",
           "version-1.7.0-lte/s1ap_tests",
           "version-1.7.0-lte/eventd",
           "version-1.7.0-lte/access_service_restrictions",
           "version-1.7.0-lte/dev_teid_allocation",
-          "version-1.7.0-lte/integrated_5g_sa"
+          "version-1.7.0-lte/integrated_5g_sa",
+          "version-1.7.0-lte/redirectd"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -305,11 +305,13 @@
         "type": "subcategory",
         "label": "Access Gateway",
         "ids": [
+          "version-1.8.0-lte/readme_agw",
           "version-1.8.0-lte/dev_notes",
           "version-1.8.0-lte/openvswitch",
           "version-1.8.0-lte/pipelined",
           "version-1.8.0-lte/ebpf_datapath",
           "version-1.8.0-lte/ipfix",
+          "version-1.8.0-lte/pipelined_tests",
           "version-1.8.0-lte/dev_unit_testing",
           "version-1.8.0-lte/tr069",
           "version-1.8.0-lte/s1ap_tests",
@@ -318,7 +320,8 @@
           "version-1.8.0-lte/dev_teid_allocation",
           "version-1.8.0-lte/integrated_5g_sa",
           "version-1.8.0-lte/extended_5g_sa_features",
-          "version-1.8.0-lte/suci_extensions"
+          "version-1.8.0-lte/suci_extensions",
+          "version-1.8.0-lte/redirectd"
         ]
       },
       {


### PR DESCRIPTION
## Summary

Related to https://github.com/magma/magma/issues/14958. Adds three AGW pages that were not being displayed properly to the sidebars. This fixes the problem for master and the supported releases (1.7, 1.8).

## Test Plan

- Ran `cd $MAGMA_ROOT/docs && make dev` successfully locally
- Checked that for each of the modified versions (1.7, 1.8, master), the pages appear in the sidebar as expected

