### PR TITLE
chore: remove libvirt specific settings from Vagrantfiles

### DIFF
--- a/cwf/gateway/Vagrantfile
+++ b/cwf/gateway/Vagrantfile
@@ -40,26 +40,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
     end
 
-    config.vm.provider :libvirt do |domain, override|
-      override.vm.synced_folder "../..", "/home/vagrant/magma", type: 'nfs', linux__nfs_options: ['rw','no_subtree_check','no_root_squash'], mount_options: ['nolock']
-      domain.uri = "qemu+unix:///system"
-      domain.memory = 4096
-      domain.cpus = 4
-      domain.driver = "kvm"
-      domain.host = "localhost"
-      domain.connect_via_ssh = false
-      domain.username = $user
-      domain.storage_pool_name = "default"
-      domain.nic_model_type = "e1000"
-      domain.management_network_name = "magma-mgmt-net"
-      domain.management_network_address = "172.17.2.0/24"
-      domain.nested = true
-      domain.cpu_mode = "host-passthrough"
-      domain.volume_cache = "unsafe"
-      domain.disk_bus = "virtio"
-      domain.graphics_ip = "0.0.0.0"
-    end
-
     cwag.vm.provision "ansible" do |ansible|
       ansible.host_key_checking = false
       ansible.playbook = "deploy/cwag_dev.yml"
@@ -124,26 +104,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--memory", "4096"]
       vb.customize ["modifyvm", :id, "--cpus", "4"]
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
-    end
-
-    cwag_test.vm.provider :libvirt do |domain, override|
-      override.vm.synced_folder "../..", "/home/vagrant/magma", type: 'nfs', linux__nfs_options: ['rw','no_subtree_check','no_root_squash'], mount_options: ['nolock']
-      domain.uri = "qemu+unix:///system"
-      domain.memory = 4096
-      domain.cpus = 4
-      domain.driver = "kvm"
-      domain.host = "localhost"
-      domain.connect_via_ssh = false
-      domain.username = $user
-      domain.storage_pool_name = "default"
-      domain.nic_model_type = "e1000"
-      domain.management_network_name = "magma-mgmt-net"
-      domain.management_network_address = "172.17.2.0/24"
-      domain.nested = true
-      domain.cpu_mode = "host-passthrough"
-      domain.volume_cache = "unsafe"
-      domain.disk_bus = "virtio"
-      domain.graphics_ip = "0.0.0.0"
     end
 
     cwag_test.vm.provision "ansible" do |ansible|

--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -93,26 +93,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
     end
 
-    config.vm.provider :libvirt do |domain, override|
-      override.vm.synced_folder "../..", "/home/vagrant/magma", type: 'nfs', linux__nfs_options: ['rw','no_subtree_check','no_root_squash'], mount_options: ['nolock']
-      domain.uri = "qemu+unix:///system"
-      domain.memory = 6144
-      domain.cpus = 4
-      domain.disk_driver :cache => "unsafe"
-      domain.driver = "kvm"
-      domain.host = "localhost"
-      domain.connect_via_ssh = false
-      domain.username = $user
-      domain.storage_pool_name = "default"
-      domain.nic_model_type = "virtio"
-      domain.management_network_name = "magma-mgmt-net"
-      domain.management_network_address = "172.17.2.0/24"
-      domain.nested = true
-      domain.cpu_mode = "host-passthrough"
-      domain.disk_bus = "virtio"
-      domain.graphics_ip = "0.0.0.0"
-    end
-
     magma_trfserver.vm.provision "ansible" do |ansible|
       ansible.host_key_checking = false
       ansible.playbook = "deploy/magma_trfserver.yml"
@@ -146,26 +126,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--memory", "1024"]
       vb.customize ["modifyvm", :id, "--cpus", "1"]
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
-    end
-
-    config.vm.provider :libvirt do |domain, override|
-      override.vm.synced_folder "../..", "/home/vagrant/magma", type: 'nfs', linux__nfs_options: ['rw','no_subtree_check','no_root_squash'], mount_options: ['nolock']
-      domain.uri = "qemu+unix:///system"
-      domain.memory = 1024
-      domain.cpus = 1
-      domain.disk_driver :cache => "unsafe"
-      domain.driver = "kvm"
-      domain.host = "localhost"
-      domain.connect_via_ssh = false
-      domain.username = $user
-      domain.storage_pool_name = "default"
-      domain.nic_model_type = "virtio"
-      domain.management_network_name = "magma-mgmt-net"
-      domain.management_network_address = "172.17.2.0/24"
-      domain.nested = true
-      domain.cpu_mode = "host-passthrough"
-      domain.disk_bus = "virtio"
-      domain.graphics_ip = "0.0.0.0"
     end
 
     magma_test.vm.provision "ansible" do |ansible|

--- a/orc8r/tools/packer/vagrant-box-upload.sh
+++ b/orc8r/tools/packer/vagrant-box-upload.sh
@@ -9,9 +9,6 @@ USER=magmacore
 BOX=$(basename $BOX_FILE | cut -d_ -f1-2 | cut -d. -f1)
 VERSION="1.3.$(date +"%Y%m%d")"
 BOX_PROVIDER=virtualbox
-if echo $BOX_FILE | grep -q libvirt; then
-  BOX_PROVIDER=libvirt
-fi
 
 #source vagrant-cloud-token
 if [ -z "$VAGRANT_CLOUD_TOKEN" ]; then


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

The magma VMs use VirtualBox as a provider, libvirt support was dropped already some time ago. This PR removes all libvirt-specific settings in Vagrantfiles.
Closes #15074. 

## Test Plan

- [x] [CWF integ test](https://github.com/mpfirrmann/magma/actions/runs/4263311881)
- [x] [LTE integ test](https://github.com/mpfirrmann/magma/actions/runs/4263332245)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
