### PR TITLE
docs: add missing 5G SA feature page link to sidebars

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5g_sa.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5g_sa.md
@@ -2,7 +2,7 @@
 id: version-1.7.0-integrated_5g_sa
 title: Integrated 5G SA
 hide_title: true
-original_id: integrated_5G_sa
+original_id: integrated_5g_sa
 ---
 
 # Integrated 5G SA FWA


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Related to #14958 and #14923. Adds pages that were not being linked in the sidebars. This fixes the problem for the supported releases (1.7, 1.8).

## Test Plan

- [ ] - `cd $MAGMA_ROOT/docs && make dev` successfully locally
- [ ] - Check that for each of the modified versions (1.7, 1.8), the pages appear in the sidebar as expected

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
