### PR TITLE
docs: Add packaging page to sidebars

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -120,7 +120,7 @@
       "howtos/network_probe": {
         "title": "Network Probe"
       },
-      "howtos/readme_package": {
+      "howtos/package": {
         "title": "Packaging"
       },
       "howtos/troubleshooting/agw_healthcheck": {
@@ -1649,7 +1649,7 @@
       "version-1.7.0/howtos/version-1.7.0-network_probe": {
         "title": "Network Probe"
       },
-      "version-1.7.0/howtos/version-1.7.0-readme_package": {
+      "version-1.7.0/howtos/version-1.7.0-package": {
         "title": "Packaging"
       },
       "version-1.7.0/howtos/troubleshooting/version-1.7.0-agw_healthcheck": {

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -20,7 +20,8 @@
           "howtos/he_api",
           "howtos/inbound_roaming",
           "howtos/l3_transport",
-          "howtos/network_probe"
+          "howtos/network_probe",
+          "howtos/package"
         ]
       },
       {

--- a/docs/docusaurus/versioned_docs/version-1.7.0/howtos/package.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/howtos/package.md
@@ -1,8 +1,8 @@
 ---
-id: version-1.7.0-readme_package
+id: version-1.7.0-package
 title: Packaging
 hide_title: true
-original_id: readme_package
+original_id: package
 ---
 
 # Packaging

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -18,7 +18,8 @@
           "version-1.7.0-howtos/ipv6_agw",
           "version-1.7.0-howtos/he_api",
           "version-1.7.0-howtos/inbound_roaming",
-          "version-1.7.0-howtos/l3_transport"
+          "version-1.7.0-howtos/l3_transport",
+          "version-1.7.0-howtos/package"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -19,7 +19,8 @@
           "version-1.8.0-howtos/he_api",
           "version-1.8.0-howtos/inbound_roaming",
           "version-1.8.0-howtos/l3_transport",
-          "version-1.8.0-howtos/network_probe"
+          "version-1.8.0-howtos/network_probe",
+          "version-1.8.0-howtos/package"
         ]
       },
       {

--- a/docs/readmes/howtos/package.md
+++ b/docs/readmes/howtos/package.md
@@ -1,5 +1,5 @@
 ---
-id: readme_package
+id: package
 title: Packaging
 hide_title: true
 ---


### PR DESCRIPTION
## Summary

Related to https://github.com/magma/magma/issues/14958. Adds the page on packaging to the sidebar. This fixes the problem for master and the supported releases (1.7, 1.8). This also makes the ID consistent with the file name in accordance with https://github.com/magma/magma/issues/14965.

## Test Plan

- Ran `cd $MAGMA_ROOT/docs && make dev` successfully locally
- Checked that for each of the modified versions (1.7, 1.8, master), the page appears in the sidebar as expected

