### PR TITLE
feat(ci): GitHub workflows run on release branches

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -31,6 +31,7 @@ on:
   push:
     branches:
       - master
+      - 'v1.*'
 
 env:
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
@@ -588,7 +589,9 @@ jobs:
 
       - name: Upload services for sentry_release job
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: github.repository_owner == 'magma' && github.ref_name == 'master'
+        if: |
+          github.repository_owner == 'magma' &&
+          ( github.ref_name == 'master' || startsWith(github.ref_name, 'v1.') )
         with:
           name: sentry_services
           path: sentry_services
@@ -614,7 +617,9 @@ jobs:
         uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
 
       - name: Set dry run environment variable
-        if: ${{ github.event_name != 'push' || github.repository_owner != 'magma' || github.ref_name != 'master' }}
+        if: |
+          ${{ github.event_name != 'push' || github.repository_owner != 'magma' ||
+          ( github.ref_name != 'master' && ! startsWith(github.ref_name, 'v1.') ) }}
         run: |
           echo "IS_DRY=--dry-run" >> $GITHUB_ENV
 
@@ -637,7 +642,7 @@ jobs:
         if: |
           github.event_name == 'push' &&
           github.repository_owner == 'magma' &&
-          github.ref_name == 'master'
+          ( github.ref_name == 'master' || startsWith(github.ref_name, 'v1.') )
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: magma/magma
@@ -674,7 +679,9 @@ jobs:
   # Create Sentry.io release with the services connectiond, liagentd, mme, sctpd and sessiond.
   sentry_release:
     needs: [bazel_package]
-    if: github.repository_owner == 'magma' && github.ref_name == 'master'
+    if: |
+      github.repository_owner == 'magma' &&
+      ( github.ref_name == 'master' || startsWith(github.ref_name, 'v1.') )
     name: Sentry release
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+      - 'v1.*'
 
 jobs:
   sudo-python-tests:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Some workflows with `push` triggers run only on `master` and not on pushes to release branches (`v1.*`). This PR modifies the push trigger for these workflows.
Closes #15031.

## Test Plan

I pushed adapted versions of these two workflows to forked master and a (possible future release) v1.9 branch. The testing changes adapt the `github.repository_owner` to run on my fork.

- [x] [AGW Test Sudo Python - push on `master`](https://github.com/mpfirrmann/magma/actions/runs/4282458206)
- [x] [AGW Build, Format & Test Bazel - push on `master`](https://github.com/mpfirrmann/magma/actions/runs/4282458207)
- [x] [AGW Test Sudo Python - push on `v1.9`](https://github.com/mpfirrmann/magma/actions/runs/4282373347)
- [x] [AGW Build, Format & Test Bazel - push on `v1.9`](https://github.com/mpfirrmann/magma/actions/runs/4282373328)

Pushing on a branch that does not match the naming scheme does not trigger the workflows.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
