### PR TITLE
fix(mme): Tuning response timers for Moblityd

### DIFF
--- a/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/core/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -133,8 +133,9 @@ static void handle_allocate_ipv4_address_status(
                         "result", "failure");
       OAILOG_ERROR(LOG_UTIL,
                    "Failed to allocate IPv4 PAA for PDN type IPv4 for "
-                   "imsi <%s> and apn <%s>\n",
-                   imsi, apn);
+                   "imsi <%s> and apn <%s>, error_code=%d\n",
+                   imsi, apn, status.error_code());
+
       ip_allocation_response_p->status =
           SGI_STATUS_ERROR_ALL_DYNAMIC_ADDRESSES_OCCUPIED;
     }

--- a/lte/gateway/c/core/oai/lib/mobility_client/MobilityServiceClient.hpp
+++ b/lte/gateway/c/core/oai/lib/mobility_client/MobilityServiceClient.hpp
@@ -159,7 +159,7 @@ class MobilityServiceClient : public GRPCReceiver {
 
  private:
   MobilityServiceClient();
-  static const uint32_t RESPONSE_TIMEOUT = 10;  // seconds
+  static const uint32_t RESPONSE_TIMEOUT = 60;  // seconds
   std::unique_ptr<MobilityService::Stub> stub_{};
 
   /**

--- a/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py
+++ b/lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py
@@ -75,7 +75,7 @@ class MacAddress:
 class DhcpHelperCli:
     _SNIFFER_FILTER = "udp and (port 67 or 68)"
     _SNIFFER_STARTUP_WAIT = 0.5
-    _TIMEOUT = 10
+    _TIMEOUT = 50
     _state = DHCPState.DISCOVER
     _vlan = None
 
@@ -199,7 +199,7 @@ class DhcpHelperCli:
             else:
                 self._pkt_queue.task_done()
 
-        raise TimeoutError(f"Timed out while waiting for {handler}.")
+        raise TimeoutError(f"Timed out while waiting for {handler} after {start_time}.")
 
     def receive_dhcp_offer(
             self, dhcp_state_code: int, pkt: scapy.packet.Packet,

--- a/lte/gateway/python/magma/pipelined/gw_mac_address.py
+++ b/lte/gateway/python/magma/pipelined/gw_mac_address.py
@@ -182,7 +182,7 @@ def _send_packet_and_receive_response(pkt: dpkt.arp.ARP, vlan: str, non_nat_arp_
     packet_aux_data = 8
     with socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(0x0003)) as s:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, buffsize)
-        s.settimeout(10)
+        s.settimeout(50)
         if vlan.isdigit():
             s.setsockopt(sol_packet, packet_aux_data, 1)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, 1)


### PR DESCRIPTION
Issue:
  1. With higher attach rates mobilityd taking slightly more timer then expected
  2. Call flow starts faling

Fix:
  Increase the wait timer for response from mobilityd

Test:
  With increase loads Flows are getting connected

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
