### PR TITLE
chore: Build the Python services with Bazel for CWF Docker images

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - name: Maximize build space
+        uses: ./.github/workflows/composite/maximize-build-space
       - name: Run docker compose
         run: |
           cd cwf/gateway/docker
@@ -46,6 +48,11 @@ jobs:
         with:
           name: docker-images
           path: images
+      - name: Build space left after run
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
       - name: Notify failure to slack
         if: failure() && github.event_name == 'push'
         env:

--- a/bazel/runfiles.bzl
+++ b/bazel/runfiles.bzl
@@ -35,6 +35,7 @@ load("@rules_pkg//:providers.bzl", "PackageFilesInfo")
 STRIP_PATHS = [
     "lte/gateway/python/",
     "orc8r/gateway/python/",
+    "cwf/swagger/specs_root/",
     "feg/swagger/specs_root/",
     "lte/swagger/specs_root/",
     "orc8r/swagger/specs_root/",
@@ -42,6 +43,7 @@ STRIP_PATHS = [
 
 # beware: order matters here, e.g., "lte/protos/oai/" needs to be before "lte/protos/"
 STRIP_PATHS_PROTOS = [
+    "cwf/protos/",
     "dp/protos/",
     "feg/protos/",
     "lte/protos/oai/",

--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -10,43 +10,59 @@
 # limitations under the License.
 
 # -----------------------------------------------------------------------------
-# Builder image for Magma proto files
+# Builder image
 # -----------------------------------------------------------------------------
 FROM ubuntu:focal AS builder
 
+ARG DEB_PORT=amd64
 # workaround to avoid interactive tzdata configurtaion
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install the runtime deps from apt.
-RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
-  apt-utils software-properties-common apt-transport-https
-
-# Install protobuf compiler.
-RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
-  unzip protoc3.zip -d protoc3 && \
-  mv protoc3/bin/protoc /usr/bin/protoc && \
-  chmod a+rx /usr/bin/protoc && \
-  cp -r protoc3/include/google /usr/include/ && \
-  chmod -R a+Xr /usr/include/google && \
-  rm -rf protoc3.zip protoc3
-
-RUN apt-get -y update && apt-get -y install python3.8
+# Install the build deps with apt.
+RUN apt-get -y update && apt-get -y install \
+    apt-transport-https \
+    apt-utils \
+    git \
+    libsystemd-dev \
+    python3.8 \
+    python3-distutils \
+    python3-pip \
+    pkg-config \
+    systemd \
+    wget
 
 ENV MAGMA_ROOT /magma
-ENV PYTHON_BUILD /build/python
 ENV PIP_CACHE_HOME ~/.pipcache
+
+# Download Bazel
+RUN  wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-"${DEB_PORT}" && \
+  chmod +x /usr/sbin/bazelisk-linux-"${DEB_PORT}" && \
+  ln -s /usr/sbin/bazelisk-linux-"${DEB_PORT}" /usr/sbin/bazel
 
 # Generate python proto bindings.
 COPY cwf/protos $MAGMA_ROOT/cwf/protos
+COPY cwf/swagger $MAGMA_ROOT/cwf/swagger
 COPY feg/protos $MAGMA_ROOT/feg/protos
-COPY lte/gateway/python/defs.mk $MAGMA_ROOT/lte/gateway/python/defs.mk
-COPY lte/gateway/python/Makefile $MAGMA_ROOT/lte/gateway/python/Makefile
+COPY feg/swagger $MAGMA_ROOT/feg/swagger
+COPY lte/gateway/configs $MAGMA_ROOT/lte/gateway/configs
+COPY lte/gateway/python $MAGMA_ROOT/lte/gateway/python
+COPY lte/gateway/deploy/roles/magma/files/patches $MAGMA_ROOT/lte/gateway/deploy/roles/magma/files/patches
 COPY lte/protos $MAGMA_ROOT/lte/protos
+COPY lte/swagger $MAGMA_ROOT/lte/swagger
+COPY orc8r/gateway/configs $MAGMA_ROOT/orc8r/gateway/configs
 COPY orc8r/gateway/python $MAGMA_ROOT/orc8r/gateway/python
 COPY orc8r/protos $MAGMA_ROOT/orc8r/protos
+COPY orc8r/swagger $MAGMA_ROOT/orc8r/swagger
 COPY protos $MAGMA_ROOT/protos
-ENV PROTO_LIST orc8r_protos lte_protos feg_protos cwf_protos
-RUN make -C $MAGMA_ROOT/orc8r/gateway/python protos
+
+# Copy Bazel files
+COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion ${MAGMA_ROOT}/
+COPY bazel/ ${MAGMA_ROOT}/bazel
+COPY ./lte/gateway/release/BUILD.bazel ${MAGMA_ROOT}/lte/gateway/release/BUILD.bazel
+COPY ./lte/gateway/release/deb_dependencies.bzl ${MAGMA_ROOT}/lte/gateway/release/deb_dependencies.bzl
+
+WORKDIR /magma
+RUN bazel build //lte/gateway/release:cwf_python_executables_tar
 
 # -----------------------------------------------------------------------------
 # Dev/Production image
@@ -78,7 +94,6 @@ RUN apt-get -y update && apt-get -y install \
     pkg-config \
     python-cffi \
     python3-pip \
-    python3-ryu \
     python3.8 \
     python3.8-dev \
     redis-server \
@@ -93,37 +108,11 @@ RUN apt-get -y update && apt-get -y install \
     iputils-ping \
     bcc-tools
 
-RUN python3.8 -m pip install --no-cache-dir \
-    Cython \
-    fire \
-    envoy \
-    glob2 \
-    flask \
-    aiodns \
-    pymemoize \
-    wsgiserver \
-    pycryptodome \
-    six \
-    eventlet \
-    h2 \
-    hpack \
-    docker \
-    redis \
-    redis-collections \
-    aiohttp \
-    Jinja2 \
-    netifaces \
-    pylint \
-    PyYAML \
-    pytz \
-    snowflake \
-    systemd-python \
-    itsdangerous \
-    click \
-    pycares \
-    python-dateutil \
-    aioeventlet@git+https://github.com/magma/deb-python-aioeventlet@86130360db113430370ed6c64d42aee3b47cd619 \
-    jsonpickle
+# Copy the build artifacts.
+COPY --from=builder /magma/bazel-bin/lte/gateway/release/cwf_python_executables.tar.gz \
+                    /tmp/cwf_python_executables.tar.gz
+RUN tar -xf /tmp/cwf_python_executables.tar.gz --directory / && \
+    rm /tmp/cwf_python_executables.tar.gz
 
 # Temporary workaround to restore uplink bridge flows
 RUN mkdir -p /var/opt/magma/scripts
@@ -146,23 +135,9 @@ RUN ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc
 RUN make
 RUN make install
 
-# Install orc8r python (magma.common required for lte python)
-COPY orc8r/gateway/python /tmp/orc8r
-RUN python3.8 -m pip install --no-cache-dir /tmp/orc8r
-
-# Install lte python
-COPY lte/gateway/python /tmp/lte
-RUN python3.8 -m pip install --no-cache-dir /tmp/lte
-
 # Copy the configs.
 COPY lte/gateway/configs /etc/magma
 COPY orc8r/gateway/configs/templates /etc/magma/templates
 RUN mkdir -p /var/opt/magma/configs
 
 WORKDIR /
-
-# Copy the build artifacts.
-COPY --from=builder /build/python/gen /usr/local/lib/python3.8/dist-packages/
-
-# update aioh2 since there is no pushed package, but master is fixed
-RUN python3.8 -m pip install --force-reinstall git+https://github.com/URenko/aioh2.git

--- a/cwf/protos/BUILD.bazel
+++ b/cwf/protos/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2023 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_proto_grpc//python:defs.bzl", "python_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "mconfigs_proto",
+    srcs = ["mconfig/mconfigs.proto"],
+)
+
+python_proto_library(
+    name = "mconfigs_python_proto",
+    protos = [":mconfigs_proto"],
+)

--- a/cwf/swagger/BUILD.bazel
+++ b/cwf/swagger/BUILD.bazel
@@ -1,0 +1,17 @@
+# Copyright 2023 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:python_swagger_specs.bzl", "py_swagger_specs")
+
+py_swagger_specs(
+    name = "cwf_swagger_specs",
+    component = "cwf",
+)

--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -59,11 +59,13 @@ COPY ./lte/gateway/configs $MAGMA_ROOT/lte/gateway/configs
 COPY ./orc8r/gateway/configs/templates $MAGMA_ROOT/orc8r/gateway/configs/templates
 
 COPY ./protos $MAGMA_ROOT/protos
+COPY ./cwf/protos $MAGMA_ROOT/cwf/protos
 COPY ./lte/protos $MAGMA_ROOT/lte/protos
 COPY ./orc8r/protos $MAGMA_ROOT/orc8r/protos
 COPY ./feg/protos $MAGMA_ROOT/feg/protos
 COPY ./dp/protos $MAGMA_ROOT/dp/protos
 
+COPY ./cwf/swagger $MAGMA_ROOT/cwf/swagger
 COPY ./feg/swagger $MAGMA_ROOT/feg/swagger
 COPY ./lte/swagger $MAGMA_ROOT/lte/swagger
 COPY ./orc8r/swagger $MAGMA_ROOT/orc8r/swagger

--- a/lte/gateway/python/BUILD.bazel
+++ b/lte/gateway/python/BUILD.bazel
@@ -42,3 +42,16 @@ pkg_filegroup(
     tags = ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
 )
+
+# This target is only needed for the CWF integration tests.
+pkg_filegroup(
+    name = "cwf_lte_python_services",
+    srcs = ["{py_service}_expanded".format(py_service = py_service) for py_service in [
+        "monitord",
+        "pipelined",
+        "policydb",
+        "redirectd",
+    ]],
+    tags = ["no-cache"],
+    visibility = ["//lte/gateway/release:__pkg__"],
+)

--- a/lte/gateway/release/BUILD.bazel
+++ b/lte/gateway/release/BUILD.bazel
@@ -369,15 +369,15 @@ pkg_filegroup(
 
 pkg_filegroup(
     name = "feg_python_services",
-    srcs = ["//orc8r/gateway/python:feg_python_services"],
+    srcs = ["//orc8r/gateway/python:magma_python_orc8r_services"],
     prefix = PY_DEST,
     tags = ["no-cache"],
 )
 
 # This target is used to bundle the Python services and scripts,
 # including all runfiles and pip dependencies, used in the FEG
-# integration tests. The tar file can be copied between builder
-# and runtime Docker images.
+# (and CWF) integration tests. The tar file can be copied between
+# builder and runtime Docker images.
 pkg_tar(
     name = "feg_python_executables_tar",
     srcs = [
@@ -389,6 +389,31 @@ pkg_tar(
     package_file_name = "{fname}.{ext}".format(
         ext = TAR_EXTENSION,
         fname = "feg_python_executables",
+    ),
+    tags = ["no-cache"],
+)
+
+pkg_filegroup(
+    name = "cwf_python_services",
+    srcs = ["//lte/gateway/python:cwf_lte_python_services"],
+    prefix = PY_DEST,
+    tags = ["no-cache"],
+)
+
+# This target is used to bundle the Python services,
+# including all runfiles and pip dependencies, used only in the
+# CWF integration tests. The tar file can be copied between builder
+# and runtime Docker images.
+pkg_tar(
+    name = "cwf_python_executables_tar",
+    srcs = [
+        ":cwf_python_services",
+        ":magma_configs",
+    ],
+    extension = TAR_EXTENSION,
+    package_file_name = "{fname}.{ext}".format(
+        ext = TAR_EXTENSION,
+        fname = "cwf_python_executables",
     ),
     tags = ["no-cache"],
 )

--- a/orc8r/gateway/python/BUILD.bazel
+++ b/orc8r/gateway/python/BUILD.bazel
@@ -37,14 +37,3 @@ pkg_filegroup(
     tags = ["no-cache"],
     visibility = ["//lte/gateway/release:__pkg__"],
 )
-
-# This target is only needed for the FEG integration tests.
-pkg_filegroup(
-    name = "feg_python_services",
-    srcs = ["{py_service}_expanded".format(py_service = py_service) for py_service in [
-        "eventd",
-        "magmad",
-    ]],
-    tags = ["no-cache"],
-    visibility = ["//lte/gateway/release:__pkg__"],
-)

--- a/orc8r/gateway/python/magma/configuration/BUILD.bazel
+++ b/orc8r/gateway/python/magma/configuration/BUILD.bazel
@@ -22,6 +22,7 @@ py_library(
         "service_configs.py",
     ],
     deps = [
+        "//cwf/protos:mconfigs_python_proto",
         "//feg/protos:mconfigs_python_proto",
         "//lte/protos:mconfigs_python_proto",
         "//orc8r/protos:mconfigs_python_proto",

--- a/orc8r/gateway/python/magma/eventd/BUILD.bazel
+++ b/orc8r/gateway/python/magma/eventd/BUILD.bazel
@@ -50,6 +50,7 @@ py_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//cwf/swagger:cwf_swagger_specs",
         "//feg/swagger:feg_swagger_specs",
         "//lte/swagger:lte_swagger_specs",
         "//orc8r/gateway/python/magma/common:rpc_utils",


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Build the Python services with Bazel for CWF Docker images
  - :warning: The Orc8r AGW Python services for the CWF integ tests are taken from the Dockerfile from the FEG folder.
    - The FEG tar target was refactored to include all orc8r Python services, which then also works for the CWF integ tests. 
  - The CWF swagger and protos files also needed to be bazelified. 
- Resolves #15041
- Resolves #15034


## Test Plan


LTE integ: :heavy_check_mark: 
- https://github.com/magma/magma/actions/runs/4353371800
- https://github.com/magma/magma/actions/runs/4353372516
- https://github.com/magma/magma/actions/runs/4353373224

FEG integ: :heavy_check_mark: 
- https://github.com/magma/magma/actions/runs/4353369314
- https://github.com/magma/magma/actions/runs/4353370285

CWF integ: :heavy_check_mark: (Gx/Gy tests are failing - this was already the case before the recent refactoring, check green runs on https://magma-ci.web.app/.)
- https://github.com/magma/magma/actions/runs/4353366977
- https://github.com/magma/magma/actions/runs/4353367559
- https://github.com/magma/magma/actions/runs/4353366403

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
