### PR TITLE
docs: Add callflow page to sidebars

### DIFF
--- a/docs/docusaurus/i18n/en.json
+++ b/docs/docusaurus/i18n/en.json
@@ -224,7 +224,7 @@
         "sidebar_label": "Services/Sub-Components"
       },
       "lte/readme_callflow": {
-        "title": "Building the callflow"
+        "title": "Building the Callflow"
       },
       "lte/redirectd": {
         "title": "Redirection"
@@ -1743,7 +1743,7 @@
         "sidebar_label": "Services/Sub-Components"
       },
       "version-1.7.0/lte/version-1.7.0-readme_callflow": {
-        "title": "Building the callflow"
+        "title": "Building the Callflow"
       },
       "version-1.7.0/lte/version-1.7.0-redirectd": {
         "title": "Redirection"

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -308,7 +308,8 @@
           "lte/integrated_5g_sa",
           "lte/extended_5g_sa_features",
           "lte/suci_extensions",
-          "lte/redirectd"
+          "lte/redirectd",
+          "lte/readme_callflow"
         ]
       },
       {

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/README_callflow.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/README_callflow.md
@@ -1,10 +1,10 @@
 ---
 id: version-1.7.0-readme_callflow
-title: Building the callflow
+title: Building the Callflow
 hide_title: true
 original_id: readme_callflow
 ---
-# Building the callflow
+# Building the Callflow
 
 In order to visualize the attach call flow in Magma, this change adds a sequence
 flow diagram. The file **Attach_call_flow_in_Magma.txt** can be uploaded to

--- a/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.7.0-sidebars.json
@@ -319,7 +319,8 @@
           "version-1.7.0-lte/access_service_restrictions",
           "version-1.7.0-lte/dev_teid_allocation",
           "version-1.7.0-lte/integrated_5g_sa",
-          "version-1.7.0-lte/redirectd"
+          "version-1.7.0-lte/redirectd",
+          "version-1.7.0-lte/readme_callflow"
         ]
       },
       {

--- a/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/docs/docusaurus/versioned_sidebars/version-1.8.0-sidebars.json
@@ -322,7 +322,8 @@
           "version-1.8.0-lte/integrated_5g_sa",
           "version-1.8.0-lte/extended_5g_sa_features",
           "version-1.8.0-lte/suci_extensions",
-          "version-1.8.0-lte/redirectd"
+          "version-1.8.0-lte/redirectd",
+          "version-1.8.0-lte/readme_callflow"
         ]
       },
       {

--- a/docs/readmes/lte/readme_callflow.md
+++ b/docs/readmes/lte/readme_callflow.md
@@ -1,9 +1,9 @@
 ---
 id: readme_callflow
-title: Building the callflow 
+title: Building the Callflow
 hide_title: true
 ---
-# Building the callflow
+# Building the Callflow
 
 In order to visualize the attach call flow in Magma, this change adds a sequence
 flow diagram. The file **Attach_call_flow_in_Magma.txt** can be uploaded to


### PR DESCRIPTION
## Summary

Related to https://github.com/magma/magma/issues/14958.

Adds the final missing page to the sidebars (excluding proposals) for master and supported versions (v1.7, v1.8). Also fixes the capitalisation of the page's title for these versions.

## Test Plan

- Successfully ran `cd $MAGMA_ROOT/docs && make dev` locally
- Checked that the page appears in the sidebar for master, v1.7 and v1.8
