### PR TITLE
fix(ci): failure slack message will display commit message

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -647,7 +647,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: magma/magma
           event-type: magma-debian-artifact
-          client-payload: '{ "magma_version": "${{ env.MAGMA_VERSION }}", "trigger_sha": "${{ github.sha }}" }'
+          client-payload: '{ "magma_version": "${{ env.MAGMA_VERSION }}", "trigger_sha": "${{ github.sha }}", "commit_message": ${{ github.event.head_commit.message }} }'
 
       - name: Publish bazel profile
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -746,4 +746,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: magma/magma
           event-type: build-all-artifact
-          client-payload: '{ "artifact": "${{ needs.agw-build.outputs.magma_package }}", "trigger_sha": "${{ github.sha }}" }'
+          client-payload: '{ "artifact": "${{ needs.agw-build.outputs.magma_package }}", "trigger_sha": "${{ github.sha }}", "commit_message": ${{ github.event.head_commit.message }} }'

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -222,4 +222,4 @@ jobs:
           SLACK_AVATAR: ":boom:"
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
         with:
-          args: "Federated integration tests failed in run <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}> from commit ${{ github.sha }}: ${{ github.event.head_commit.message || github.event.pull_request.title }}"
+          args: "Federated integration tests failed in run <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}> from commit ${{ github.sha }}: ${{ github.event.client_payload.commit_message }}"

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -129,4 +129,4 @@ jobs:
           SLACK_USERNAME: ${{ github.workflow }}
           SLACK_AVATAR: ":boom:"
         with:
-          args: "Bazel Debian LTE integration tests failed in run <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}> from commit ${{ github.event.client_payload.trigger_sha }}: ${{ github.event.head_commit.message || github.event.pull_request.title }}"
+          args: "Bazel Debian LTE integration tests failed in run <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}> from commit ${{ github.event.client_payload.trigger_sha }}: ${{ github.event.client_payload.commit_message }}"

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -99,4 +99,4 @@ jobs:
           SLACK_USERNAME: ${{ github.workflow }}
           SLACK_AVATAR: ":boom:"
         with:
-          args: "LTE Debian integration tests failed in run <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}> from commit ${{ github.event.client_payload.trigger_sha }}: ${{ github.event.head_commit.message || github.event.pull_request.title }}"
+          args: "LTE Debian integration tests failed in run <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}> from commit ${{ github.event.client_payload.trigger_sha }}: ${{ github.event.client_payload.commit_message }}"


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Failing CI jobs send a message to the `#ci` Slack channel. This message is structured as:
"`$TEST_NAME` failed in run `$RUN_ID` from commit `$COMMIT_HASH`: `$COMMIT_MESSAGE`"

Workflows which are triggered via a repository_dispatch trigger, `Magma Build, Publish & Test Federated Integration`, `AGW Test LTE Integration With Bazel Debian Build`, and `AGW Test LTE Integration With Make Debian Build` miss the `$COMMIT_MESSAGE` information. This results in their slack messages ending after the colon.

In order to fix this, the `$COMMIT_MESSAGE` information is parsed to these workflows via `client_payload`.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
