### PR TITLE
docs: improve external links

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/feg/s1ap_federated_test.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/feg/s1ap_federated_test.md
@@ -70,7 +70,7 @@ fab federated_integ_test
 You can access Orc8r adding to your keychain the `admin_operator.pfx` cert
 you will find at `/magma/.cache/test_certs`. Then you can check your
 provisioned gateways using
-[swagger interface](https://127.0.0.1:9443/apidocs/v1/?docExpansion=none)
+[swagger interface](https://localhost:9443/apidocs/v1/?docExpansion=none)
 that will be running on your Orc8r
 
 Please, for more detail, check the following sections which provide more

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/configure_sentry.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/configure_sentry.md
@@ -13,7 +13,7 @@ As part of v1.5, we have integrated Sentry's [Native](https://docs.sentry.io/pla
 
 ## Connect to the Linux Foundation Sentry Account
 
-The first step to setting up your account is to request access to Linux Foundation [Sentry.io](http://Sentry.io) instance by submitting your email address and company through the [community form](https://docs.google.com/forms/d/e/1FAIpQLSeJMWecw9An5-aYv0US8Fc_PDO7kUMx4Pky13S_3LhFJkge_g/viewform). You should also create a team for your company on the Sentry site. This team name should match your company and will be used to enable group access to your project. Once you are granted access, you will need to login and navigate to the “Projects” tab and locate your team’s project name. You will need this information to update a CI job in the next section.
+The first step to setting up your account is to request access to Linux Foundation [Sentry.io](https://sentry.io) instance by submitting your email address and company through the [community form](https://docs.google.com/forms/d/e/1FAIpQLSeJMWecw9An5-aYv0US8Fc_PDO7kUMx4Pky13S_3LhFJkge_g/viewform). You should also create a team for your company on the Sentry site. This team name should match your company and will be used to enable group access to your project. Once you are granted access, you will need to login and navigate to the “Projects” tab and locate your team’s project name. You will need this information to update a CI job in the next section.
 
 ## Configuration
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/pipelined.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/pipelined.md
@@ -12,7 +12,7 @@ Pipelined is the control application that programs rules in the Open vSwitch (OV
 
 ### Open vSwitch & OpenFlow
 
-[Open vSwitch (OVS)](http://docs.openvswitch.org/en/latest/intro/what-is-ovs/) is a virtual switch that implements the [OpenFlow](https://en.wikipedia.org/wiki/OpenFlow) protocol. Pipelined services program rules in OVS to implement basic PCEF functionality for user plane traffic.
+[Open vSwitch (OVS)](https://docs.openvswitch.org/en/latest/intro/what-is-ovs/) is a virtual switch that implements the [OpenFlow](https://en.wikipedia.org/wiki/OpenFlow) protocol. Pipelined services program rules in OVS to implement basic PCEF functionality for user plane traffic.
 
 The OpenFlow pipeline of OVS contains 255 flow tables. Pipelined splits the tables into two categories:
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/nms/dev_themes.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/nms/dev_themes.md
@@ -15,7 +15,7 @@ At the moment the `default.js` file exports 3 core design types, though more wil
 
 Colors are broken into subgroups (primary, secondary, state, data, and code), and then defined based off of the hex color code. Generally speaking, they should match closely with those found in the design file.
 
-In the case you need to add a color, I used [this site](http://chir.ag/projects/name-that-color/) to generate names based off of the color hex.
+In the case you need to add a color, I used [this site](https://chir.ag/projects/name-that-color/) to generate names based off of the color hex.
 
 ## Typography
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/dev_aws_stack.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/dev_aws_stack.md
@@ -37,7 +37,7 @@ Magma provides a set of configuration parameters to control these resources, fol
 The values for these configurations can be defined/overwritten in your `main.tf` `orc8r` module.
 Some configurations do not have default values and are mandatory to be present in your `main.tf`.
 Other already have predefined values and can be overwritten.
-See the [complete list of available configurations](http://github.com/magma/magma/blob/master/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf).
+See the [complete list of available configurations](https://github.com/magma/magma/blob/master/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf).
 
 ## What Magma deploys in my AWS-hosted Kubernetes?
 
@@ -65,7 +65,7 @@ Magma provides a set of configuration parameters to control these resources, fol
 |deploy_openvpn |Optional |Flag to deploy OpenVPN server into cluster. This is useful if you want to remotely access AGWs. |FALSE |
 
 The values of these configurations can be defined or overwritten in your `main.tf` files's `orc8r-app` module.
-See the [complete list of configurations available for these resource](http://github.com/magma/magma/blob/master/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf).
+See the [complete list of configurations available for these resource](https://github.com/magma/magma/blob/master/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf).
 
 ## What does the Orc8r Helm chart contain?
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/dev_sub_digests.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/dev_sub_digests.md
@@ -15,7 +15,7 @@ Previously, Orc8r followed a basic data sync pattern that sent all subscriber co
 
 This introduces a number of issues at scale, namely significant network pressure. For example, to support 20k subscribers over 500 active gateways, subscriber config sync alone would generate at least [**20TB of network pressure per month per network**](../proposals/p010_subscriber_scaling.md#context).
 
-Therefore, starting with Magma v1.6, Orc8r uses deterministic protobuf digests to only sync subscriber configs when they're updated. This pattern utilizes the assumption `#reads >> #writes` to retain a [level-triggered architecture](http://haobaozhong.github.io/design/2019/08/28/level-edge-triggered.html), providing two major improvements
+Therefore, starting with Magma v1.6, Orc8r uses deterministic protobuf digests to only sync subscriber configs when they're updated. This pattern utilizes the assumption `#reads >> #writes` to retain a [level-triggered architecture](https://haobaozhong.github.io/design/2019/08/28/level-edge-triggered.html), providing two major improvements
 
 1. Instead of syncing at every interval, only sync when AGW is out of sync
 2. Instead of syncing all data, only transmit updates

--- a/docs/docusaurus/versioned_docs/version-1.7.0/resources/ref_magma_metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/resources/ref_magma_metrics.md
@@ -123,7 +123,7 @@ func (s *GRPCPushExporterServicer) pushFamilies(families []*io_prometheus_client
 
 ## Phase 3: NMS and Grafana
 
-The NMS initially reads metric names, descriptions and their corresponding PromQL from [`LteMetrics.json`](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/nms/packages/magmalte/data/LteMetrics.json). Then, in [`Explorer.js`](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/nms/packages/magmalte/app/views/metrics/Explorer.js), it filters relevant metrics for the network in question using the `/networks/{network_id}/prometheus/series` Orc8r endpoint.
+The NMS initially reads metric names, descriptions and their corresponding PromQL from [`LteMetrics.json`](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/nms/app/packages/magmalte/data/LteMetrics.json). Then, in [`Explorer.js`](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/nms/app/packages/magmalte/app/views/metrics/Explorer.js), it filters relevant metrics for the network in question using the `/networks/{network_id}/prometheus/series` Orc8r endpoint.
 
 ```javascript
 // Explorer.js

--- a/docs/docusaurus/versioned_docs/version-1.7.0/resources/ref_magma_metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/resources/ref_magma_metrics.md
@@ -119,7 +119,7 @@ func (s *GRPCPushExporterServicer) pushFamilies(families []*io_prometheus_client
 }
 ```
 
-[Prometheus Edge Hub](https://github.com/facebookincubator/prometheus-edge-hub) is a Facebook project that replaces the Prometheus Pushgateway. Orc8r's Prometheus service [scrapes](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml#L160-L168) and drains the Edge Hub so metrics finally arrive at their home in the Prometheus server. [On a dev environment](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/docker/docker-compose.metrics.yml?L14-24), the Prometheus server runs at [localhost:9090](http://localhost:9090).
+[Prometheus Edge Hub](https://github.com/facebookincubator/prometheus-edge-hub) is a Facebook project that replaces the Prometheus Pushgateway. Orc8r's Prometheus service [scrapes](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml#L160-L168) and drains the Edge Hub so metrics finally arrive at their home in the Prometheus server. [On a dev environment](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/docker/docker-compose.metrics.yml?L14-24), the Prometheus server runs at [localhost:9090](https://localhost:9090).
 
 ## Phase 3: NMS and Grafana
 

--- a/docs/docusaurus/versioned_docs/version-1.8.0/feg/s1ap_federated_tests.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/feg/s1ap_federated_tests.md
@@ -74,7 +74,7 @@ fab federated_integ_test
 You can access Orc8r adding to your keychain the `admin_operator.pfx` cert
 you will find at `/magma/.cache/test_certs`. Then you can check your
 provisioned gateways using
-[swagger interface](https://127.0.0.1:9443/apidocs/v1/?docExpansion=none)
+[swagger interface](https://localhost:9443/apidocs/v1/?docExpansion=none)
 that will be running on your Orc8r
 
 Please, for more detail, check the following sections which provide more

--- a/docs/docusaurus/versioned_docs/version-1.8.0/lte/pipelined.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/lte/pipelined.md
@@ -12,7 +12,7 @@ Pipelined is the control application that programs rules in the Open vSwitch (OV
 
 ### Open vSwitch & OpenFlow
 
-[Open vSwitch (OVS)](http://docs.openvswitch.org/en/latest/intro/what-is-ovs/) is a virtual switch that implements the [OpenFlow](https://en.wikipedia.org/wiki/OpenFlow) protocol. Pipelined services program rules in OVS to implement basic PCEF functionality for user plane traffic.
+[Open vSwitch (OVS)](https://docs.openvswitch.org/en/latest/intro/what-is-ovs/) is a virtual switch that implements the [OpenFlow](https://en.wikipedia.org/wiki/OpenFlow) protocol. Pipelined services program rules in OVS to implement basic PCEF functionality for user plane traffic.
 
 The OpenFlow pipeline of OVS contains 255 flow tables. Pipelined splits the tables into two categories:
 

--- a/docs/readmes/feg/s1ap_federated_tests.md
+++ b/docs/readmes/feg/s1ap_federated_tests.md
@@ -73,7 +73,7 @@ fab federated-integ-test
 You can access Orc8r adding to your keychain the `admin_operator.pfx` cert
 you will find at `/magma/.cache/test_certs`. Then you can check your
 provisioned gateways using
-[swagger interface](https://127.0.0.1:9443/apidocs/v1/?docExpansion=none)
+[swagger interface](https://localhost:9443/apidocs/v1/?docExpansion=none)
 that will be running on your Orc8r
 
 Please, for more detail, check the following sections which provide more

--- a/docs/readmes/lte/configure_sentry.md
+++ b/docs/readmes/lte/configure_sentry.md
@@ -12,7 +12,7 @@ As part of v1.5, we have integrated Sentry's [Native](https://docs.sentry.io/pla
 
 ## Connect to the Linux Foundation Sentry Account
 
-The first step to setting up your account is to request access to Linux Foundation [Sentry.io](http://Sentry.io) instance by submitting your email address and company through the [community form](https://docs.google.com/forms/d/e/1FAIpQLSeJMWecw9An5-aYv0US8Fc_PDO7kUMx4Pky13S_3LhFJkge_g/viewform). You should also create a team for your company on the Sentry site. This team name should match your company and will be used to enable group access to your project. Once you are granted access, you will need to login and navigate to the “Projects” tab and locate your team’s project name. You will need this information to update a CI job in the next section.
+The first step to setting up your account is to request access to Linux Foundation [Sentry.io](https://sentry.io) instance by submitting your email address and company through the [community form](https://docs.google.com/forms/d/e/1FAIpQLSeJMWecw9An5-aYv0US8Fc_PDO7kUMx4Pky13S_3LhFJkge_g/viewform). You should also create a team for your company on the Sentry site. This team name should match your company and will be used to enable group access to your project. Once you are granted access, you will need to login and navigate to the “Projects” tab and locate your team’s project name. You will need this information to update a CI job in the next section.
 
 ## Configuration
 

--- a/docs/readmes/lte/pipelined.md
+++ b/docs/readmes/lte/pipelined.md
@@ -11,7 +11,7 @@ Pipelined is the control application that programs rules in the Open vSwitch (OV
 
 ### Open vSwitch & OpenFlow
 
-[Open vSwitch (OVS)](http://docs.openvswitch.org/en/latest/intro/what-is-ovs/) is a virtual switch that implements the [OpenFlow](https://en.wikipedia.org/wiki/OpenFlow) protocol. Pipelined services program rules in OVS to implement basic PCEF functionality for user plane traffic.
+[Open vSwitch (OVS)](https://docs.openvswitch.org/en/latest/intro/what-is-ovs/) is a virtual switch that implements the [OpenFlow](https://en.wikipedia.org/wiki/OpenFlow) protocol. Pipelined services program rules in OVS to implement basic PCEF functionality for user plane traffic.
 
 The OpenFlow pipeline of OVS contains 255 flow tables. Pipelined splits the tables into two categories:
 

--- a/docs/readmes/nms/dev_themes.md
+++ b/docs/readmes/nms/dev_themes.md
@@ -14,7 +14,7 @@ At the moment the `default.js` file exports 3 core design types, though more wil
 
 Colors are broken into subgroups (primary, secondary, state, data, and code), and then defined based off of the hex color code. Generally speaking, they should match closely with those found in the design file.
 
-In the case you need to add a color, I used [this site](http://chir.ag/projects/name-that-color/) to generate names based off of the color hex.
+In the case you need to add a color, I used [this site](https://chir.ag/projects/name-that-color/) to generate names based off of the color hex.
 
 ## Typography
 

--- a/docs/readmes/orc8r/dev_aws_stack.md
+++ b/docs/readmes/orc8r/dev_aws_stack.md
@@ -36,7 +36,7 @@ Magma provides a set of configuration parameters to control these resources, fol
 The values for these configurations can be defined/overwritten in your `main.tf` `orc8r` module.
 Some configurations do not have default values and are mandatory to be present in your `main.tf`.
 Other already have predefined values and can be overwritten.
-See the [complete list of available configurations](http://github.com/magma/magma/blob/master/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf).
+See the [complete list of available configurations](https://github.com/magma/magma/blob/master/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf).
 
 ## What Magma deploys in my AWS-hosted Kubernetes?
 
@@ -64,7 +64,7 @@ Magma provides a set of configuration parameters to control these resources, fol
 |deploy_openvpn |Optional |Flag to deploy OpenVPN server into cluster. This is useful if you want to remotely access AGWs. |FALSE |
 
 The values of these configurations can be defined or overwritten in your `main.tf` files's `orc8r-app` module.
-See the [complete list of configurations available for these resource](http://github.com/magma/magma/blob/master/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf).
+See the [complete list of configurations available for these resource](https://github.com/magma/magma/blob/master/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf).
 
 ## What does the Orc8r Helm chart contain?
 

--- a/docs/readmes/orc8r/dev_sub_digests.md
+++ b/docs/readmes/orc8r/dev_sub_digests.md
@@ -14,7 +14,7 @@ Previously, Orc8r followed a basic data sync pattern that sent all subscriber co
 
 This introduces a number of issues at scale, namely significant network pressure. For example, to support 20k subscribers over 500 active gateways, subscriber config sync alone would generate at least [**20TB of network pressure per month per network**](../proposals/p010_subscriber_scaling.md#context).
 
-Therefore, starting with Magma v1.6, Orc8r uses deterministic protobuf digests to only sync subscriber configs when they're updated. This pattern utilizes the assumption `#reads >> #writes` to retain a [level-triggered architecture](http://haobaozhong.github.io/design/2019/08/28/level-edge-triggered.html), providing two major improvements
+Therefore, starting with Magma v1.6, Orc8r uses deterministic protobuf digests to only sync subscriber configs when they're updated. This pattern utilizes the assumption `#reads >> #writes` to retain a [level-triggered architecture](https://haobaozhong.github.io/design/2019/08/28/level-edge-triggered.html), providing two major improvements
 
 1. Instead of syncing at every interval, only sync when AGW is out of sync
 2. Instead of syncing all data, only transmit updates

--- a/docs/readmes/resources/ref_magma_metrics.md
+++ b/docs/readmes/resources/ref_magma_metrics.md
@@ -118,7 +118,7 @@ func (s *GRPCPushExporterServicer) pushFamilies(families []*io_prometheus_client
 }
 ```
 
-[Prometheus Edge Hub](https://github.com/facebookincubator/prometheus-edge-hub) is a Facebook project that replaces the Prometheus Pushgateway. Orc8r's Prometheus service [scrapes](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml#L160-L168) and drains the Edge Hub so metrics finally arrive at their home in the Prometheus server. [On a dev environment](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/docker/docker-compose.metrics.yml?L14-24), the Prometheus server runs at [localhost:9090](http://localhost:9090).
+[Prometheus Edge Hub](https://github.com/facebookincubator/prometheus-edge-hub) is a Facebook project that replaces the Prometheus Pushgateway. Orc8r's Prometheus service [scrapes](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml#L160-L168) and drains the Edge Hub so metrics finally arrive at their home in the Prometheus server. [On a dev environment](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/docker/docker-compose.metrics.yml?L14-24), the Prometheus server runs at [localhost:9090](https://localhost:9090).
 
 ## Phase 3: NMS and Grafana
 

--- a/docs/readmes/resources/ref_magma_metrics.md
+++ b/docs/readmes/resources/ref_magma_metrics.md
@@ -122,7 +122,7 @@ func (s *GRPCPushExporterServicer) pushFamilies(families []*io_prometheus_client
 
 ## Phase 3: NMS and Grafana
 
-The NMS initially reads metric names, descriptions and their corresponding PromQL from [`LteMetrics.json`](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/nms/packages/magmalte/data/LteMetrics.json). Then, in [`Explorer.js`](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/nms/packages/magmalte/app/views/metrics/Explorer.js), it filters relevant metrics for the network in question using the `/networks/{network_id}/prometheus/series` Orc8r endpoint.
+The NMS initially reads metric names, descriptions and their corresponding PromQL from [`LteMetrics.json`](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/nms/app/packages/magmalte/data/LteMetrics.json). Then, in [`Explorer.js`](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/nms/app/packages/magmalte/app/views/metrics/Explorer.js), it filters relevant metrics for the network in question using the `/networks/{network_id}/prometheus/series` Orc8r endpoint.
 
 ```javascript
 // Explorer.js


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

While looking into a CI job detecting 404 errors in docusaurus links, [several improvements were recommended](https://github.com/mpfirrmann/magma/actions/runs/4313426920#summary-11713488430). This PR 

- fixes two broken links to sourcegraph
- unifies calls to localhost
- links via https protocol

These changes are implemented in docs starting with v1.7 and leaves out the proposal pages.

## Test Plan

- [ ] Click the links.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
