### PR TITLE
chore(ci): Unblock CI by skipping broken NMS tests

### DIFF
--- a/nms/app/components/cwf/__tests__/CWFGateways-test.tsx
+++ b/nms/app/components/cwf/__tests__/CWFGateways-test.tsx
@@ -126,7 +126,9 @@ const Wrapper = () => (
   </MemoryRouter>
 );
 
-describe('<CWFGateways />', () => {
+// This test is being skipped. Test failures needs to be investigated
+// and fixed, see https://github.com/magma/magma/issues/15122 for details.
+describe.skip('<CWFGateways />', () => {
   beforeEach(() => {
     (axiosMock as jest.Mocked<typeof axiosMock>).get.mockResolvedValueOnce({
       data: [CWF_HA_GATEWAY_1, CWF_HA_GATEWAY_2],

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailStatusTest.tsx
@@ -115,7 +115,9 @@ const mockCPUUsage: PromqlReturnObject = {
   },
 };
 
-describe('<FEGGatewayDetailStatus />', () => {
+// This test is being skipped. Test failures needs to be investigated
+// and fixed, see https://github.com/magma/magma/issues/15122 for details.
+describe.skip('<FEGGatewayDetailStatus />', () => {
   beforeEach(() => {
     // called when getting the CPU Usage
     mockAPI(

--- a/nms/app/views/equipment/__tests__/GatewayLogsTest.tsx
+++ b/nms/app/views/equipment/__tests__/GatewayLogsTest.tsx
@@ -45,7 +45,9 @@ const LogTableWrapper = () => (
   </MemoryRouter>
 );
 
-describe('<GatewayLogs />', () => {
+// This test is being skipped. Test failures needs to be investigated
+// and fixed, see https://github.com/magma/magma/issues/15122 for details.
+describe.skip('<GatewayLogs />', () => {
   const mockLogCount = 100;
   const mockLogs = [
     {

--- a/nms/app/views/events/__tests__/EventsTableTest.tsx
+++ b/nms/app/views/events/__tests__/EventsTableTest.tsx
@@ -103,7 +103,9 @@ const mockEvents = [
   },
 ];
 
-describe('<EventsTable />', () => {
+// This test is being skipped. Test failures needs to be investigated
+// and fixed, see https://github.com/magma/magma/issues/15122 for details.
+describe.skip('<EventsTable />', () => {
   beforeEach(() => {
     mockAPI(MagmaAPI.events, 'eventsNetworkIdAboutCountGet', mockEvents.length);
     mockAPI(MagmaAPI.events, 'eventsNetworkIdGet', mockEvents);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Skip the following tests to unblock CI (see e.g. this [test run](https://github.com/magma/magma/actions/runs/4314762549/jobs/7542366398)):
```
app/views/events/__tests__/EventsTableTest.tsx
app/views/equipment/__tests__/GatewayLogsTest.tsx
app/components/cwf/__tests__/CWFGateways-test.tsx
app/views/equipment/__tests__/FEGGatewayDetailStatusTest.tsx
```
- Related to https://github.com/magma/magma/issues/15122

## Test Plan

- Run `yarn run test` locally:
```
Test Suites: 4 skipped, 53 passed, 53 of 57 total
Tests:       4 skipped, 351 passed, 355 total
Snapshots:   0 total
Time:        25.129 s
Ran all test suites in 2 projects.
Done in 25.77s.
```
- [CI run](https://github.com/magma/magma/actions/runs/4341400168/jobs/7580959740):
```
Test Suites: 4 skipped, 53 passed, 53 of 57 total
Tests:       4 skipped, 351 passed, 355 total
Snapshots:   0 total
Time:        187.614 s
Ran all test suites in 2 projects.
Done in 189.13s.
``` 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
