### PR TITLE
fix(ci): evaluate dry run condition correctly

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -618,8 +618,8 @@ jobs:
 
       - name: Set dry run environment variable
         if: |
-          ${{ github.event_name != 'push' || github.repository_owner != 'magma' ||
-          ( github.ref_name != 'master' && ! startsWith(github.ref_name, 'v1.') ) }}
+          github.event_name != 'push' || github.repository_owner != 'magma' ||
+          ( github.ref_name != 'master' && ! startsWith(github.ref_name, 'v1.') )
         run: |
           echo "IS_DRY=--dry-run" >> $GITHUB_ENV
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

#15098 introduced a bug, where the dry run condition in the Bazel workflow was evaluated incorrectly. This fixes it.

## Test Plan

Tested on my fork with adapted `github.repository_owner == 'mpfirrmann'`.

- [x] [with existing bug - dry run condition is true](https://github.com/mpfirrmann/magma/actions/runs/4343004990/jobs/7584527979) (although it shouldn't be)
- [x] [with fix - dry run condition is false](https://github.com/mpfirrmann/magma/actions/runs/4342932318/jobs/7584368883)

See also the tests on the mentioned PR, linked in [this conversation](https://github.com/magma/magma/pull/15098#discussion_r1120697497).

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
