### PR TITLE
feat(agw): set up containerized agw with fabric

### DIFF
--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -37,14 +37,14 @@ On an Arm architecture with the 5.4 kernel, the images can be built with `cd $MA
 The magma VM defined in [../Vagrantfile](../Vagrantfile) can be used to run the
 containerized AGW by either using a fabric command on the host machine:
 
-```
+```bash
 cd ${MAGMA_ROOT}/lte/gateway
 fab start-gateway-containerized
 ```
 
 or by running the following steps inside the VM:
 
-```
+```bash
 sudo rm -rf /etc/snowflake && sudo touch /etc/snowflake
 cd $MAGMA_ROOT && bazel/scripts/link_scripts_for_bazel_integ_tests.sh
 bazel build `bazel query "attr(tags, util_script, kind(.*_binary, //orc8r/... union //lte/... union //feg/... except //lte/gateway/c/core:mme_oai))"`

--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -35,7 +35,14 @@ On an Arm architecture with the 5.4 kernel, the images can be built with `cd $MA
 ## Running the containerized AGW locally on the magma VM
 
 The magma VM defined in [../Vagrantfile](../Vagrantfile) can be used to run the
-containerized AGW by running the following steps inside the VM:
+containerized AGW by either using a fabric command on the host machine:
+
+```
+cd ${MAGMA_ROOT}/lte/gateway
+fab start-gateway-containerized
+```
+
+or by running the following steps inside the VM:
 
 ```
 sudo rm -rf /etc/snowflake && sudo touch /etc/snowflake

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -456,6 +456,10 @@ def integ_test_containerized(
 def start_gateway_containerized(c, docker_registry=None):
     """
     Start the containerized AGW.
+
+    Args:
+        c: Fabric connection.
+        docker_registry: The docker registry to pull the images from.
     """
     with vagrant_connection(c, "magma") as c_gw:
         c_gw.run("sudo systemctl stop magma@*")
@@ -463,7 +467,13 @@ def start_gateway_containerized(c, docker_registry=None):
 
 
 def _start_gateway_containerized(c_gw, docker_registry=None):
-    """ Starts the containerized AGW """
+    """
+    Start the containerized AGW
+
+    Args:
+        c_gw: Fabric connection to the gateway VM.
+        docker_registry: The docker registry to pull the images from.
+    """
 
     c_gw.run('sudo rm -rf /etc/snowflake && sudo touch /etc/snowflake')
     with c_gw.cd("${MAGMA_ROOT}"):
@@ -484,8 +494,6 @@ def _start_gateway_containerized(c_gw, docker_registry=None):
         if docker_registry:
             docker_cmd = f'DOCKER_REGISTRY={docker_registry} {docker_cmd}'
         else:
-            # build the containers locally if no registry to pull the images is
-            # given
             c_gw.run('docker compose --compatibility build')
         # The `docker-compose up` times are machine dependent, such that a
         # retry is needed here for resilience.


### PR DESCRIPTION
Part of #14909 .

## Summary

Introduces a fabric command to setup the dockerized AGW for convenience.

## Test Plan

Setup the dockerized AGW with the fabric command `fab start-gateway-containerized` and check the containers functionality.

## Additional Information

- [ ] This change is backwards-breaking


