### PR TITLE
chore(orc8r): Upgrade go to 1.20.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -81,7 +81,7 @@ RUN echo "Install general purpose packages" && \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.19.3"
+ARG GOLANG_VERSION="1.20.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
     && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
     && tar -xzf ${GO_TARBALL} \

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -119,7 +119,7 @@ jobs:
         if: always()
         id: gateway_test_init
         with:
-          go-version: '1.19.3'
+          go-version: '1.20.1'
       - name: Download dependencies
         if: always() && steps.gateway_test_init.outcome=='success'
         id: gateway_test_dep

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.19.3'
+          go-version: '1.20.1'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.19.3'
+          go-version: '1.20.1'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.19.3'
+          go-version: '1.20.1'
       - run: go version
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh

--- a/.github/workflows/magma-publish-go.yml
+++ b/.github/workflows/magma-publish-go.yml
@@ -20,7 +20,7 @@ on:
     inputs:
       version:
         description: Version to upload?
-        default: 1.19.3
+        default: 1.20.1
         required: true
 
 env:

--- a/.github/workflows/scripts/golang_check_version.sh
+++ b/.github/workflows/scripts/golang_check_version.sh
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-expected_version="1.19.3"
+expected_version="1.20.1"
 all_versions_good=true
 
 while IFS= read -r -d '' file

--- a/cwf/cloud/go/go.mod
+++ b/cwf/cloud/go/go.mod
@@ -105,4 +105,4 @@ require (
 	magma/gateway v0.0.0 // indirect
 )
 
-go 1.19
+go 1.20

--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -38,8 +38,8 @@
     - role: ovs
     - role: golang
       vars:
-        golang_tar: go1.19.3.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba'
+        golang_tar: go1.20.1.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
     - role: cwag
 
   tasks:

--- a/cwf/gateway/deploy/cwag_dev_centos7.yml
+++ b/cwf/gateway/deploy/cwag_dev_centos7.yml
@@ -33,8 +33,8 @@
     - role: ovs
     - role: golang
       vars:
-        golang_tar: go1.19.3.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba'
+        golang_tar: go1.20.1.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
 #    - role: cwag
 
   tasks:

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -29,8 +29,8 @@
         override_nameserver: 8.8.8.8
     - role: golang
       vars:
-        golang_tar: go1.19.3.linux-amd64.tar.gz
-        golang_tar_checksum: 'sha256:74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba'
+        golang_tar: go1.20.1.linux-amd64.tar.gz
+        golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
     - role: cwag_test
   tasks:
     - name: Set build environment variables

--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && apt-get install -y \
 
 # Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.19.3"
+ARG GOLANG_VERSION="1.20.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -132,4 +132,4 @@ require (
 	magma/feg/cloud/go v0.0.0 // indirect
 )
 
-go 1.19
+go 1.20

--- a/cwf/k8s/cwf_operator/docker/Dockerfile
+++ b/cwf/k8s/cwf_operator/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y bzr curl daemontools gcc
 
 # Install Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.19.3"
+ARG GOLANG_VERSION="1.20.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/cwf/k8s/cwf_operator/go.mod
+++ b/cwf/k8s/cwf_operator/go.mod
@@ -26,7 +26,7 @@
 //
 module magma/cwf/k8s/cwf_operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/glogr v0.1.0

--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -31,10 +31,10 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    4. [Vagrant](https://vagrantup.com)
 
    ```bash
-   brew install go@1.19 pyenv
+   brew install go@1.20 pyenv
    # NOTE: this assumes you're using zsh.
    # See the above pyenv install instructions if using alternative shells.
-   echo 'export PATH="/usr/local/opt/go@1.19/bin:$PATH"' >> ~/.zshrc
+   echo 'export PATH="/usr/local/opt/go@1.20/bin:$PATH"' >> ~/.zshrc
    echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
    echo 'eval "$(pyenv init -)"' >> ~/.zshrc
    exec $SHELL
@@ -61,7 +61,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    1. [Docker and Docker Compose](https://docs.docker.com/engine/install/ubuntu/)
    2. [VirtualBox](https://www.virtualbox.org/wiki/Linux_Downloads)
    3. [Vagrant](https://www.vagrantup.com/downloads)
-2. Install golang version 19.
+2. Install golang version 1.20.1.
 
    1. Download the tar file.
 

--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -66,13 +66,13 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    1. Download the tar file.
 
       ```bash
-      wget https://linuxfoundation.jfrog.io/artifactory/magma-blob/go1.19.3.linux-amd64.tar.gz
+      wget https://linuxfoundation.jfrog.io/artifactory/magma-blob/go1.20.1.linux-amd64.tar.gz
       ```
 
    2. Extract the archive you downloaded into `/usr/local`, creating a Go tree in `/usr/local/go`.
 
       ```bash
-      sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.19.3.linux-amd64.tar.gz
+      sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.1.linux-amd64.tar.gz
       ```
 
    3. Add `/usr/local/go/bin` to the PATH environment variable.
@@ -90,7 +90,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       You should expect something like this
 
       ```bash
-      go version go1.19.3 linux/amd64
+      go version go1.20.1 linux/amd64
       ```
 
 3. Install `pyenv`.

--- a/dp/cloud/go/go.mod
+++ b/dp/cloud/go/go.mod
@@ -11,7 +11,7 @@
 //
 module magma/dp/cloud/go
 
-go 1.19
+go 1.20
 
 replace (
 	magma/dp/cloud/go => ../../../dp/cloud/go

--- a/feg/cloud/go/go.mod
+++ b/feg/cloud/go/go.mod
@@ -104,4 +104,4 @@ require (
 	magma/gateway v0.0.0 // indirect
 )
 
-go 1.19
+go 1.20

--- a/feg/cloud/go/protos/go.mod
+++ b/feg/cloud/go/protos/go.mod
@@ -13,4 +13,4 @@ require (
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 )
 
-go 1.19
+go 1.20

--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -59,7 +59,7 @@ lint_tools:
 	else \
 		echo "-> installing golangci " && \
 			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-			| sudo sh -s -- -b /usr/sbin/ v1.50.1; \
+			| sudo sh -s -- -b /usr/sbin/ v1.51.2; \
 	fi
 
 build_only:

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install -y \
 
 # Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.19.3"
+ARG GOLANG_VERSION="1.20.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -153,4 +153,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-go 1.19
+go 1.20

--- a/feg/radius/lib/go/http/go.mod
+++ b/feg/radius/lib/go/http/go.mod
@@ -1,6 +1,6 @@
 module fbc/lib/go/http
 
-go 1.19
+go 1.20
 
 replace (
 	fbc/lib/go/log => ../log

--- a/feg/radius/lib/go/libgraphql/go.mod
+++ b/feg/radius/lib/go/libgraphql/go.mod
@@ -2,4 +2,4 @@ module libgraphql
 
 require github.com/google/uuid v1.1.1
 
-go 1.19
+go 1.20

--- a/feg/radius/lib/go/log/go.mod
+++ b/feg/radius/lib/go/log/go.mod
@@ -1,6 +1,6 @@
 module fbc/lib/go/log
 
-go 1.19
+go 1.20
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/feg/radius/lib/go/machine/go.mod
+++ b/feg/radius/lib/go/machine/go.mod
@@ -1,3 +1,3 @@
 module machine
 
-go 1.19
+go 1.20

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -1,6 +1,6 @@
 module fbc/lib/go/oc
 
-go 1.19
+go 1.20
 
 replace (
 	fbc/lib/go/http => ../http

--- a/feg/radius/lib/go/oc/helpers/go.mod
+++ b/feg/radius/lib/go/oc/helpers/go.mod
@@ -1,5 +1,5 @@
 module fbc/lib/go/oc/helpers
 
-go 1.19
+go 1.20
 
 require go.opencensus.io v0.21.0

--- a/feg/radius/src/go.mod
+++ b/feg/radius/src/go.mod
@@ -49,4 +49,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-go 1.19
+go 1.20

--- a/feg/radius/src/run.sh
+++ b/feg/radius/src/run.sh
@@ -17,7 +17,7 @@ function lint {
     if [ -z "$LINTER" ]; then
         echo "-> installing golangci " && \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-        | sudo sh -s -- -b /usr/sbin/ v1.50.1;
+        | sudo sh -s -- -b /usr/sbin/ v1.51.2;
     fi
 
     golangci-lint run -c "$MAGMA_ROOT"/.golangci.yml

--- a/lte/cloud/go/go.mod
+++ b/lte/cloud/go/go.mod
@@ -114,4 +114,4 @@ require (
 	magma/gateway v0.0.0 // indirect
 )
 
-go 1.19
+go 1.20

--- a/lte/gateway/deploy/roles/magma/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma/vars/all.yaml
@@ -1,2 +1,2 @@
 WORK_DIR: "~/"
-GO_VERSION: "1.19.3"
+GO_VERSION: "1.20.1"

--- a/lte/gateway/docker/ghz/Dockerfile
+++ b/lte/gateway/docker/ghz/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.19.3"
+ARG GOLANG_VERSION="1.20.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.19.3"
+ARG GOLANG_VERSION="1.20.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -143,7 +143,7 @@ $(TOOLS_LIST): %_tools:
 
 tools_lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-		| sh -s -- -b $$(go env GOPATH)/bin v1.50.1
+		| sh -s -- -b $$(go env GOPATH)/bin v1.51.2
 
 ######################
 ## Swagger/API docs ##

--- a/orc8r/cloud/api/v1/go/go.mod
+++ b/orc8r/cloud/api/v1/go/go.mod
@@ -11,7 +11,7 @@
 
 module magma/orc8r/cloud/api/v1/go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-openapi/errors v0.20.2

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform
     rm -rf /root/download/*
 
 # Install go if we are building testframework image
-ARG GOLANG_VERSION="1.19.3"
+ARG GOLANG_VERSION="1.20.1"
 RUN if [ "$ENV" = "testframework" ]; \
     then \
         GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \

--- a/orc8r/cloud/deploy/roles/golang/defaults/main.yml
+++ b/orc8r/cloud/deploy/roles/golang/defaults/main.yml
@@ -10,8 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-golang_tar: go1.19.3.linux-amd64.tar.gz
-golang_tar_checksum: 'sha256:74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba'
+golang_tar: go1.20.1.linux-amd64.tar.gz
+golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
 go_install_path: /usr/local
 gopath: '/home/{{ user }}/go'
 gobin: '/home/{{ user }}/go/bin'

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
 
 # Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.19.3"
+ARG GOLANG_VERSION="1.20.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -169,4 +169,4 @@ require (
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
 
-go 1.19
+go 1.20

--- a/orc8r/cloud/test/go.mod
+++ b/orc8r/cloud/test/go.mod
@@ -1,6 +1,6 @@
 module magma/orc8r/cloud/test
 
-go 1.19
+go 1.20
 
 replace (
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20191016111102-bec269661e48

--- a/orc8r/gateway/go/go.mod
+++ b/orc8r/gateway/go/go.mod
@@ -52,4 +52,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 
-go 1.19
+go 1.20

--- a/orc8r/lib/go/go.mod
+++ b/orc8r/lib/go/go.mod
@@ -1,6 +1,6 @@
 module magma/orc8r/lib/go
 
-go 1.19
+go 1.20
 
 replace magma/orc8r/lib/go/protos => ./protos
 

--- a/orc8r/lib/go/protos/go.mod
+++ b/orc8r/lib/go/protos/go.mod
@@ -1,6 +1,6 @@
 module magma/orc8r/lib/go/protos
 
-go 1.19
+go 1.20
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/orc8r/tools/ansible/roles/golang/defaults/main.yml
+++ b/orc8r/tools/ansible/roles/golang/defaults/main.yml
@@ -10,8 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-golang_tar: go1.19.3.linux-amd64.tar.gz
-golang_tar_checksum: 'sha256:74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba'
+golang_tar: go1.20.1.linux-amd64.tar.gz
+golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
 go_install_path: /usr/local
 gopath: '/home/{{ user }}/go'
 gobin: '/home/{{ user }}/go/bin'


### PR DESCRIPTION
## Summary
- [x] Upload new go version to LF artifactory
- [x] Upgrade golangci-lint (See https://github.com/golangci/golangci-lint/issues/3470)
- [x] Add this PR to the go upgrade wiki page: https://github.com/magma/magma/wiki/Golang-Version-Upgrades

## Test Plan
- [x] CWF Integ tests:https://github.com/magma/magma/actions/runs/4421543919
- [x] FeG Integ tests: https://github.com/magma/magma/actions/runs/4360375418
- [x] Local connect orc8r to AGW
- [x] Deploy on minikube
![image](https://user-images.githubusercontent.com/8889531/223331276-6b67bb55-90c6-4277-80cf-bfaf9076c848.png)

- [x] CI green