### PR TITLE
docs: Fix outdated links in docs

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.0.0/feg/legacy/FAQ.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/feg/legacy/FAQ.md
@@ -19,7 +19,7 @@ original_id: faq
 3. I'm seeing 200's, but streamed configs at `/var/opt/magma/configs` aren't being updated?
 
     - Ensure the directory at `/var/opt/magma/configs` exists
-    - Ensure the gateway configs in NMS are created (see [link](https://github.com/facebookincubator/magma/blob/master/docs/Magma_Network_Management_System.pdf) for more instructions)
+    - Ensure the gateway configs in NMS are created (see [link](https://github.com/magma/magma/blob/v1.1.0/docs/Magma_Network_Management_System.pdf) for more instructions)
     - Ensure one of the following configs exist:
         - [Federated Gateway Network Configs](https://127.0.0.1:9443/apidocs#/Networks/post_networks__network_id__configs_federation)
         - [Federated Gateway Configs](https://127.0.0.1:9443/apidocs#/Gateways/post_networks__network_id__gateways__gateway_id__configs_federation)

--- a/docs/docusaurus/versioned_docs/version-1.0.0/feg/legacy/README.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/feg/legacy/README.md
@@ -6,11 +6,11 @@ hide_title: true
 original_id: readme
 ---
 # Federated Gateway (FeG)
-The federated gateway provides remote procedure call (GRPC) based interfaces to standard 3GPP components, such as 
-HSS (S6a, SWx), OCS (Gy), and PCRF (Gx). The exposed RPC interface provides versioning & backward compatibility, 
-security (HTTP2 & TLS) as well as support for multiple programming languages. The Remote Procedures below provide 
-simple, extensible, multi-language interfaces based on GRPC which allow developers to avoid dealing with the 
-complexities of 3GPP protocols. Implementing these RPC interfaces allows networks running on Magma to integrate 
+The federated gateway provides remote procedure call (GRPC) based interfaces to standard 3GPP components, such as
+HSS (S6a, SWx), OCS (Gy), and PCRF (Gx). The exposed RPC interface provides versioning & backward compatibility,
+security (HTTP2 & TLS) as well as support for multiple programming languages. The Remote Procedures below provide
+simple, extensible, multi-language interfaces based on GRPC which allow developers to avoid dealing with the
+complexities of 3GPP protocols. Implementing these RPC interfaces allows networks running on Magma to integrate
 with traditional 3GPP core components.
 
 ![Federated Gateway architecture diagram](https://github.com/facebookincubator/magma/blob/master/docs/readmes/assets/federated_gateway_diagram.png?raw=true "FeG Architecture")
@@ -18,28 +18,28 @@ with traditional 3GPP core components.
 The Federated Gateway supports the following features and functionalities:
 
 1. Hosting centralized control plane interface towards HSS, PCRF, OCS and MSC/VLR on behalf of distributed AGW/EPCs.
-2. Establishing diameter connection with HSS, PCRF and OCS directly as 1:1 or via DRA. 
+2. Establishing diameter connection with HSS, PCRF and OCS directly as 1:1 or via DRA.
 3. Establishing SCTP/IP connection with MSC/VLR.
 4. Interfacing with AGW over GPRC interface by responding to remote calls from EPC (MME and Sessiond/PCEF) components,
-    converting these remote calls to 3GPP compliant messages and then sending these messages to the appropriate core network 
-    components such as HSS, PCRF, OCS and MSC.  Similarly the FeG receives 3GPP compliant messages from HSS, PCRF, OCS and MSC 
-    and converts these to the appropriate GPRC messages before sending them to the AGW. 
+    converting these remote calls to 3GPP compliant messages and then sending these messages to the appropriate core network
+    components such as HSS, PCRF, OCS and MSC.  Similarly the FeG receives 3GPP compliant messages from HSS, PCRF, OCS and MSC
+    and converts these to the appropriate GPRC messages before sending them to the AGW.
 
 
 
-Please see the **[Magma Product Spec](https://github.com/facebookincubator/magma/blob/master/docs/Magma_Specs_V1.1.pdf)** for more detailed information.
+Please see the **[Magma Product Spec](https://github.com/magma/magma/blob/v1.1.0/docs/Magma_Specs_V1.1.pdf)** for more detailed information.
 
 ## Federated Gateway Services & Tools
 
 The following services run on the federated gateway:
- - `s6a_proxy` - translates calls from GRPC to S6a protocol between AGW and HSS 
+ - `s6a_proxy` - translates calls from GRPC to S6a protocol between AGW and HSS
  - `session_proxy` - translates calls from GRPC to gx/gy protocol between AGW and PCRF/OCS
  - `csfb` - translates calls from GRPC interface to csfb protocol between AGW and VLR
  - `swx_proxy` - translates GRPC interface to SWx protocol between AGW and HSS
- - `gateway_health` - provides health updates to the orc8r to be used for 
- achieving highly available federated gateway clusters (see **[Magma Product Spec](https://github.com/facebookincubator/magma/blob/master/docs/Magma_Specs_V1.1.pdf)**
+ - `gateway_health` - provides health updates to the orc8r to be used for
+ achieving highly available federated gateway clusters (see **[Magma Product Spec](https://github.com/magma/magma/blob/v1.1.0/docs/Magma_Specs_V1.1.pdf)**
  for more details)
  - `radiusd` - fetches metrics from the running radius server and exports them
 
 Associated tools for sending requests and debugging issues can be found
-at `magma/feg/gateway/tools`. 
+at `magma/feg/gateway/tools`.

--- a/docs/docusaurus/versioned_docs/version-1.0.0/symphony/download_requirements.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/symphony/download_requirements.md
@@ -14,7 +14,7 @@ If you are going to run or build the Symphony Agent you will need to install Doc
 There are some known limitations to running Docker on MacOS, the biggest being that you are unable to run ping over IPv6 from inside these Docker containers. But if you don't need your agent to do these things, this should be fine.
 
 
-With MacOS you actually **don't want to install Docker via Homebrew**, but if you go to the docker website it will ask you to create an account to login before installing. To avoid having to create an account, though, you can use this [direct link](https://download.docker.com/mac/stable/Docker.dmg) to download a dmg image file instead. (You can read more background on this issue [here](https://github.com/docker/docker.github.io/issues/6910))
+With MacOS you actually **don't want to install Docker via Homebrew**, but if you go to the docker website it will ask you to create an account to login before installing. To avoid having to create an account, though, you can use this [link](https://docs.docker.com/desktop/install/mac-install/) to download a dmg image file instead. (You can read more background on this issue [here](https://github.com/docker/docker.github.io/issues/6910))
 
 Once you have installed Docker via the dmg file you will want to increase the Docker disk (~50GB) and memory (at least 5GB) in the Docker desktop UI. You can do this by going to the Disk and Advanced tabs in Docker's preferences window.
 

--- a/docs/docusaurus/versioned_docs/version-1.0.X/feg/legacy/FAQ.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.X/feg/legacy/FAQ.md
@@ -19,7 +19,7 @@ original_id: faq
 3. I'm seeing 200's, but streamed configs at `/var/opt/magma/configs` aren't being updated?
 
     - Ensure the directory at `/var/opt/magma/configs` exists
-    - Ensure the gateway configs in NMS are created (see [link](https://github.com/facebookincubator/magma/blob/master/docs/Magma_Network_Management_System.pdf) for more instructions)
+    - Ensure the gateway configs in NMS are created (see [link](https://github.com/magma/magma/blob/v1.1.0/docs/Magma_Network_Management_System.pdf) for more instructions)
     - Ensure one of the following configs exist:
         - [Federated Gateway Network Configs](https://127.0.0.1:9443/apidocs#/Networks/post_networks__network_id__configs_federation)
         - [Federated Gateway Configs](https://127.0.0.1:9443/apidocs#/Gateways/post_networks__network_id__gateways__gateway_id__configs_federation)

--- a/docs/docusaurus/versioned_docs/version-1.0.X/feg/legacy/README.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.X/feg/legacy/README.md
@@ -27,7 +27,7 @@ The Federated Gateway supports the following features and functionalities:
 
 
 
-Please see the **[Magma Product Spec](https://github.com/facebookincubator/magma/blob/master/docs/Magma_Specs_V1.1.pdf)** for more detailed information.
+Please see the **[Magma Product Spec](https://github.com/magma/magma/blob/v1.1.0/docs/Magma_Specs_V1.1.pdf)** for more detailed information.
 
 ## Federated Gateway Services & Tools
 
@@ -37,7 +37,7 @@ The following services run on the federated gateway:
  - `csfb` - translates calls from GRPC interface to csfb protocol between AGW and VLR
  - `swx_proxy` - translates GRPC interface to SWx protocol between AGW and HSS
  - `gateway_health` - provides health updates to the orc8r to be used for
- achieving highly available federated gateway clusters (see **[Magma Product Spec](https://github.com/facebookincubator/magma/blob/master/docs/Magma_Specs_V1.1.pdf)**
+ achieving highly available federated gateway clusters (see **[Magma Product Spec](https://github.com/magma/magma/blob/v1.1.0/docs/Magma_Specs_V1.1.pdf)**
  for more details)
  - `radiusd` - fetches metrics from the running radius server and exports them
 

--- a/docs/docusaurus/versioned_docs/version-1.1.X/feg/legacy/README.md
+++ b/docs/docusaurus/versioned_docs/version-1.1.X/feg/legacy/README.md
@@ -27,7 +27,7 @@ The Federated Gateway supports the following features and functionalities:
 
 
 
-Please see the **[Magma Product Spec](https://github.com/facebookincubator/magma/blob/master/docs/Magma_Specs_V1.1.pdf)** for more detailed information.
+Please see the **[Magma Product Spec](https://github.com/magma/magma/blob/v1.1.0/docs/Magma_Specs_V1.1.pdf)** for more detailed information.
 
 ## Federated Gateway Services & Tools
 
@@ -37,7 +37,7 @@ The following services run on the federated gateway:
  - `csfb` - translates calls from GRPC interface to csfb protocol between AGW and VLR
  - `swx_proxy` - translates GRPC interface to SWx protocol between AGW and HSS
  - `gateway_health` - provides health updates to the orc8r to be used for
- achieving highly available federated gateway clusters (see **[Magma Product Spec](https://github.com/facebookincubator/magma/blob/master/docs/Magma_Specs_V1.1.pdf)**
+ achieving highly available federated gateway clusters (see **[Magma Product Spec](https://github.com/magma/magma/blob/v1.1.0/docs/Magma_Specs_V1.1.pdf)**
  for more details)
  - `radiusd` - fetches metrics from the running radius server and exports them
 

--- a/docs/docusaurus/versioned_docs/version-1.2.X/proposals/p002_scaled_prometheus_pipeline.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.X/proposals/p002_scaled_prometheus_pipeline.md
@@ -105,7 +105,7 @@ We should make this as easy to configure as possible. Some goals include:
 
 ### Improving prometheus-edge-hub performance
 
-With the goal of handling 10 million datapoints per minute, the [prometheus-edge-hub](github.com/facebookincubator/prometheus-edge-hub) will probably need some improvements to handle that load. First we'll do benchmark tests on specific AWS hardware options. Then, profile the code to find the bottlenecks and improve them. It's not clear what exactly needs to be done, but I'm confident we can find significant improvements as this component hasn't gone through much optimization yet.
+With the goal of handling 10 million datapoints per minute, the [prometheus-edge-hub](https://github.com/facebookincubator/prometheus-edge-hub) will probably need some improvements to handle that load. First we'll do benchmark tests on specific AWS hardware options. Then, profile the code to find the bottlenecks and improve them. It's not clear what exactly needs to be done, but I'm confident we can find significant improvements as this component hasn't gone through much optimization yet.
 
 In the end if we can't get enough performance out of a single edge-hub, we will have to investigate scaling this horizontally.
 

--- a/docs/docusaurus/versioned_docs/version-1.2.X/proposals/p002_scaled_prometheus_pipeline.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.X/proposals/p002_scaled_prometheus_pipeline.md
@@ -14,7 +14,7 @@ original_id: p002_scaled_prometheus_pipeline
 **Requires Feedback From: Jacky Tian**
 
 Details:
-* I use the term pushgateway to reference [prometheus-edge-hub](https://github.com/facebookincubator/prometheus-edge-hub)
+* I use the term pushgateway to reference [prometheus-edge-hub](https://github.com/facebookarchive/prometheus-edge-hub)
 * "Prod" and "Staging" refer to FB-hosted deployments of Orchestrator which are currently our largest deployments and our source of performance data.
 
 ### Goal: Improve metrics query speed on large deployments

--- a/docs/docusaurus/versioned_docs/version-1.2.X/proposals/p002_scaled_prometheus_pipeline.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.X/proposals/p002_scaled_prometheus_pipeline.md
@@ -83,7 +83,7 @@ All metrics go through the controller (which is already scalable and placed behi
 
 All metrics are stored for 30 days in the Prometheus TSDB storage. This means that all queries have to go through the prometheus server itself, which is the main cause of slow queries.
 
-[Object storage](https://thanos.io/storage.md/) will allow us to only store a few hours of metrics on the server itself (potentially keeping everything in-memory) and then exporting older metrics to object storage elsewhere. For example on an AWS deployment metrics would be stored in S3.
+[Object storage](https://thanos.io/tip/thanos/storage.md/) will allow us to only store a few hours of metrics on the server itself (potentially keeping everything in-memory) and then exporting older metrics to object storage elsewhere. For example on an AWS deployment metrics would be stored in S3.
 
 *Options for Object Storage*
 * Deployed on AWS: S3

--- a/docs/docusaurus/versioned_docs/version-1.4.X/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.X/nms/metrics.md
@@ -174,7 +174,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 On the gateways, magmad service collects metrics from all the services and pushes them to Orc8r.
 In Orc8r, metricsd receives the metrics and pushes them to registered metric exporters. Prometheus
 is one the main metric exporters. Specifically, Orc8r pushes the metrics to the
-[edge-hub](https://github.com/facebookincubator/prometheus-edge-hub), which later scraped by prometheus instance.
+[edge-hub](https://github.com/facebookarchive/prometheus-edge-hub), which later scraped by prometheus instance.
 
 On the query side, When we make queries through NMS or swagger, the Orc8r queries the prometheus
 instance directly.

--- a/docs/docusaurus/versioned_docs/version-1.4.X/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.X/nms/metrics.md
@@ -35,8 +35,8 @@ With Grafana, you can create your own custom dashboards and populate them with a
 The simple way is to just click on the “+” icon on the left sidebar, then create a new dashboard. There is ample documentation about grafana dashboards online if you need help creating your dashboard.
 
 ![Grafana new dashboard](assets/nms/grafana_new_dashboard.png)
-- Grafana documentation on creating dashboards: [Grafana Dashboards](_https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/_)
-- Prometheus documentation on writing queries: [Prometheus Querying](_https://prometheus.io/docs/prometheus/latest/querying/basics/_)
+- Grafana documentation on creating dashboards: [Grafana Dashboards](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/)
+- Prometheus documentation on writing queries: [Prometheus Querying](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 
 If you want to replicate the networkID or gatewayID variables that you find in the preconfigured dashboards, we provide a “template” dashboard to make that easy. Simply open the Template dashboard, and click on the gear icon near the
 top right. From there, click “Save As” and enter the name you want. Your new dashboard will now have the gatewayID and networkID variables. An example of how to use these variables in your queries:

--- a/docs/docusaurus/versioned_docs/version-1.5.X/contributing/contribute_conventions.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/contributing/contribute_conventions.md
@@ -233,7 +233,7 @@ def foo(arg1: str) -> int:
 
 - For mandatory lint checks, we have a unit test that runs [Pylint](https://pypi.org/project/pylint/) on all gateway services
   - On CI, the check gets run as part of the `lte-test` job
-- Additionally, we have a [Reviewdog](https://github.com/reviewdog/reviewdog) linter using [wemake-python-styleguide](https://wemake-python-stylegui.de/en/latest/) enabled to aid the code review process
+- Additionally, we have a [Reviewdog](https://github.com/reviewdog/reviewdog) linter using [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) enabled to aid the code review process
   - To run the linter locally, use the [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py)
 
 **Formatters**

--- a/docs/docusaurus/versioned_docs/version-1.5.X/contributing/contribute_conventions.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/contributing/contribute_conventions.md
@@ -241,7 +241,7 @@ def foo(arg1: str) -> int:
 - We recommend [autopep8](https://pypi.org/project/autopep8/) as it conforms to [pep8](https://www.python.org/dev/peps/pep-0008/)
   - The above-mentioned [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py) also has an option to format your changes with
   [isort](https://pypi.org/project/isort/), [autopep8](https://pypi.org/project/autopep8/), and [add-trailing-comma](https://pypi.org/project/add-trailing-comma/)
-- We do *not* recommend other formatters such as [black](https://black.readthedocs.io/en/stable/installation_and_usage.html), as it diverges from pep8 on basic things like line length, etc.
+- We do *not* recommend other formatters such as [black](https://ichard26-testblackdocs.readthedocs.io/en/refactor_docs/installation_and_usage.html), as it diverges from pep8 on basic things like line length, etc.
 
 
 ### Shell

--- a/docs/docusaurus/versioned_docs/version-1.5.X/howtos/troubleshooting/user_unable_to_attach.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/howtos/troubleshooting/user_unable_to_attach.md
@@ -53,7 +53,7 @@ PROTOCOL_ERROR 111
 
 Suggested Solution:
 
-1. Identify which parameter the UE is sending in the Attach Request and compare with the ones Magma support. You can find which parameters magma is currently supported from the code. https://github.com/magma/magma/blob/master/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c
+1. Identify which parameter the UE is sending in the Attach Request and compare with the ones Magma support. You can find which parameters magma is currently supported from the code. https://github.com/magma/magma/blob/master/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.cpp
 
     Note: Make sure to select the branch you are currently have in your network(v1.1, v1.2, v1.3 , etc)
 

--- a/docs/docusaurus/versioned_docs/version-1.5.X/lte/configure_sentry.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/lte/configure_sentry.md
@@ -17,7 +17,7 @@ The first step to setting up your account is to request access to Linux Foundati
 
 ## Configuration
 
-To configure Sentry, you will need to create a pull request to update the config.yml on the Magma Github page. If you skip this step, all C/C++ will be unreadable for your Sentry instance. This file is located [here](https://github.com/magma/magma/blob/master/.circleci/config.yml). You will need to navigate to the "sentry-create-and-upload-artifacts" section of the file and create a new a new sentry upload in the following format:
+To configure Sentry, you will need to create a pull request to update the config.yml on the Magma Github page. If you skip this step, all C/C++ will be unreadable for your Sentry instance. This file is located [here](https://github.com/magma/magma/blob/v1.5.3/.circleci/config.yml). You will need to navigate to the "sentry-create-and-upload-artifacts" section of the file and create a new a new sentry upload in the following format:
 
 ```bash
 sentry-upload:

--- a/docs/docusaurus/versioned_docs/version-1.5.X/lte/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/lte/deploy_install.md
@@ -42,7 +42,7 @@ installation process to get an IP using DHCP.
 
 ```bash
 su
-wget https://raw.githubusercontent.com/magma/magma/master/lte/gateway/deploy/agw_install.sh
+wget https://raw.githubusercontent.com/magma/magma/v1.5.3/lte/gateway/deploy/agw_install.sh
 bash agw_install.sh
 ```
 

--- a/docs/docusaurus/versioned_docs/version-1.5.X/lte/upgrade_1_5.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/lte/upgrade_1_5.md
@@ -12,7 +12,7 @@ original_id: upgrade_1_5
 ### Repo Change
 
 In Magma Fuji (v1.5), Magma artifacts are now hosted on the new Magmacore repositories at
-[artifactory.magmacore.org](https://artifactory.magmacore.org/).
+[https://linuxfoundation.jfrog.io/](https://linuxfoundation.jfrog.io/).
 Gateways migrating from older Magma releases can run the migration script to update the sources accordingly.
 
 The repository currently supports both Debian and Ubuntu OS flavors.

--- a/docs/docusaurus/versioned_docs/version-1.5.X/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/nms/metrics.md
@@ -174,7 +174,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 On the gateways, magmad service collects metrics from all the services and pushes them to Orc8r.
 In Orc8r, metricsd receives the metrics and pushes them to registered metric exporters. Prometheus
 is one the main metric exporters. Specifically, Orc8r pushes the metrics to the
-[edge-hub](https://github.com/facebookincubator/prometheus-edge-hub), which later scraped by prometheus instance.
+[edge-hub](https://github.com/facebookarchive/prometheus-edge-hub), which later scraped by prometheus instance.
 
 On the query side, When we make queries through NMS or swagger, the Orc8r queries the prometheus
 instance directly.

--- a/docs/docusaurus/versioned_docs/version-1.5.X/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/nms/metrics.md
@@ -35,8 +35,8 @@ With Grafana, you can create your own custom dashboards and populate them with a
 The simple way is to just click on the “+” icon on the left sidebar, then create a new dashboard. There is ample documentation about grafana dashboards online if you need help creating your dashboard.
 
 ![Grafana new dashboard](assets/nms/grafana_new_dashboard.png)
-- Grafana documentation on creating dashboards: [Grafana Dashboards](_https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/_)
-- Prometheus documentation on writing queries: [Prometheus Querying](_https://prometheus.io/docs/prometheus/latest/querying/basics/_)
+- Grafana documentation on creating dashboards: [Grafana Dashboards](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/)
+- Prometheus documentation on writing queries: [Prometheus Querying](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 
 If you want to replicate the networkID or gatewayID variables that you find in the preconfigured dashboards, we provide a “template” dashboard to make that easy. Simply open the Template dashboard, and click on the gear icon near the
 top right. From there, click “Save As” and enter the name you want. Your new dashboard will now have the gatewayID and networkID variables. An example of how to use these variables in your queries:

--- a/docs/docusaurus/versioned_docs/version-1.5.X/proposals/p011_victoriametrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/proposals/p011_victoriametrics.md
@@ -21,7 +21,7 @@ Magma is getting to the point where scaling is a primary concern. One of the
 areas that could be most impacted by larger scale is metrics, since there is a
 direct correlation with the number of subscribers/gateways and the amount of
 data coming through the system. We’ve been relying on a single Prometheus
-server coupled to our [prometheus-edge-hub](github.com/facebookincubator/prometheus-edge-hub)
+server coupled to our [prometheus-edge-hub](https://github.com/facebookincubator/prometheus-edge-hub)
 which has worked for all of the small and medium deployments so far, but we’re
 getting pretty close to the limit where this setup would not be able to ingest
 more data. In addition to this, partners have been wanting to run magma at a

--- a/docs/docusaurus/versioned_docs/version-1.5.X/proposals/p011_victoriametrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/proposals/p011_victoriametrics.md
@@ -94,11 +94,11 @@ This is actually something we looked into way back when this all started but it
 wasn’t open sourced back then. Now it is fully [open source](https://blog.usejournal.com/open-sourcing-victoriametrics-f31e34485c2b)
 with some [insane](https://valyala.medium.com/high-cardinality-tsdb-benchmarks-victoriametrics-vs-timescaledb-vs-influxdb-13e6ee64dd6b)
 [benchmarks](https://valyala.medium.com/prometheus-vs-victoriametrics-benchmark-on-node-exporter-metrics-4ca29c75590f)
-and [significant](https://victoriametrics.github.io/CaseStudies.html) community
+and [significant](https://docs.victoriametrics.com/CaseStudies.html) community
 usage.
 
-The biggest benefit of VM is that it supports both [push](https://victoriametrics.github.io/Single-server-VictoriaMetrics#how-to-import-data-in-prometheus-exposition-format)
-and [pull](https://victoriametrics.github.io/Single-server-VictoriaMetrics#how-to-scrape-prometheus-exporters-such-as-node-exporter)
+The biggest benefit of VM is that it supports both [push](https://docs.victoriametrics.com/Single-server-VictoriaMetrics#how-to-import-data-in-prometheus-exposition-format)
+and [pull](https://docs.victoriametrics.com/Single-server-VictoriaMetrics#how-to-scrape-prometheus-exporters-such-as-node-exporter)
 natively.
 
 This means we can completely get rid of prometheus-edge-hub and just push
@@ -116,14 +116,14 @@ only using <200% CPU.
 Based on VM’s data this capacity should scale nearly linearly for quite a
 while with more/faster CPUs.
 
-VM also offers a [cluster](https://victoriametrics.github.io/Cluster-VictoriaMetrics)
+VM also offers a [cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics)
 version which is very simply scaled horizontally behind a load balancer. Given
 how well it scales vertically I don’t think this is something we’ll likely have
 to look into for quite a while. Even then if we do I don’t think the
 engineering work would be significant.
 
 VictoriaMetrics integrates seamlessly with configmanager and the
-[alerting setup](https://victoriametrics.github.io/vmalert.html)
+[alerting setup](https://docs.victoriametrics.com/vmalert.html)
 is nearly identical to how Thanos does alerting, which I’ve already validated
 so there’s not much risk on that end.
 
@@ -181,7 +181,7 @@ require more engineering work for a likely worse product.
 
 The implementation for this is very straightforward.
 * Deploy VictoriaMetrics in a single node configuration and then use the
-existing [remote exporter](https://github.com/magma/magma/blob/master/orc8r/cloud/go/services/orchestrator/servicers/exporter_servicer.go)
+existing [remote exporter](https://github.com/magma/magma/tree/v1.5.3/orc8r/cloud/go/services/orchestrator/servicers/exporter_servicer.go)
 to push metrics directly to VM.
 * Configure metricsd to direct queries to the VM query endpoint rather than
 Prometheus

--- a/docs/docusaurus/versioned_docs/version-1.6.X/contributing/contribute_conventions.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/contributing/contribute_conventions.md
@@ -233,7 +233,7 @@ def foo(arg1: str) -> int:
 
 - For mandatory lint checks, we have a unit test that runs [Pylint](https://pypi.org/project/pylint/) on all gateway services
   - On CI, the check gets run as part of the `lte-test` job
-- Additionally, we have a [Reviewdog](https://github.com/reviewdog/reviewdog) linter using [wemake-python-styleguide](https://wemake-python-stylegui.de/en/latest/) enabled to aid the code review process
+- Additionally, we have a [Reviewdog](https://github.com/reviewdog/reviewdog) linter using [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) enabled to aid the code review process
   - To run the linter locally, use the [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py)
 
 **Formatters**

--- a/docs/docusaurus/versioned_docs/version-1.6.X/contributing/contribute_conventions.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/contributing/contribute_conventions.md
@@ -241,7 +241,7 @@ def foo(arg1: str) -> int:
 - We recommend [autopep8](https://pypi.org/project/autopep8/) as it conforms to [pep8](https://www.python.org/dev/peps/pep-0008/)
   - The above-mentioned [precommit script](https://github.com/magma/magma/blob/master/lte/gateway/python/precommit.py) also has an option to format your changes with
   [isort](https://pypi.org/project/isort/), [autopep8](https://pypi.org/project/autopep8/), and [add-trailing-comma](https://pypi.org/project/add-trailing-comma/)
-- We do *not* recommend other formatters such as [black](https://black.readthedocs.io/en/stable/installation_and_usage.html), as it diverges from pep8 on basic things like line length, etc.
+- We do *not* recommend other formatters such as [black](https://ichard26-testblackdocs.readthedocs.io/en/refactor_docs/installation_and_usage.html), as it diverges from pep8 on basic things like line length, etc.
 
 
 ### C++

--- a/docs/docusaurus/versioned_docs/version-1.6.X/lte/configure_sentry.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/lte/configure_sentry.md
@@ -15,7 +15,7 @@ The first step to setting up your account is to request access to Linux Foundati
 
 ## Configuration
 
-To configure Sentry, you will need to create a pull request to update the config.yml on the Magma Github page. If you skip this step, all C/C++ will be unreadable for your Sentry instance. This file is located [here](https://github.com/magma/magma/blob/master/.circleci/config.yml). You will need to navigate to the "sentry-create-and-upload-artifacts" section of the file and create a new a new sentry upload in the following format:
+To configure Sentry, you will need to create a pull request to update the config.yml on the Magma Github page. If you skip this step, all C/C++ will be unreadable for your Sentry instance. This file is located [here](https://github.com/magma/magma/blob/v1.6.0/.circleci/config.yml). You will need to navigate to the "sentry-create-and-upload-artifacts" section of the file and create a new a new sentry upload in the following format:
 
 ```bash
 sentry-upload:

--- a/docs/docusaurus/versioned_docs/version-1.6.X/lte/upgrade_1_5.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/lte/upgrade_1_5.md
@@ -12,7 +12,7 @@ original_id: upgrade_1_5
 ### Repo Change
 
 In Magma Fuji (v1.5), Magma artifacts are now hosted on the new Magmacore repositories at
-[artifactory.magmacore.org](https://artifactory.magmacore.org/).
+[https://linuxfoundation.jfrog.io/](https://linuxfoundation.jfrog.io/).
 Gateways migrating from older Magma releases can run the migration script to update the sources accordingly.
 
 The repository currently supports both Debian and Ubuntu OS flavors.

--- a/docs/docusaurus/versioned_docs/version-1.6.X/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/nms/metrics.md
@@ -174,7 +174,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 On the gateways, magmad service collects metrics from all the services and pushes them to Orc8r.
 In Orc8r, metricsd receives the metrics and pushes them to registered metric exporters. Prometheus
 is one the main metric exporters. Specifically, Orc8r pushes the metrics to the
-[edge-hub](https://github.com/facebookincubator/prometheus-edge-hub), which later scraped by prometheus instance.
+[edge-hub](https://github.com/facebookarchive/prometheus-edge-hub), which later scraped by prometheus instance.
 
 On the query side, When we make queries through NMS or swagger, the Orc8r queries the prometheus
 instance directly.

--- a/docs/docusaurus/versioned_docs/version-1.6.X/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/nms/metrics.md
@@ -35,8 +35,8 @@ With Grafana, you can create your own custom dashboards and populate them with a
 The simple way is to just click on the “+” icon on the left sidebar, then create a new dashboard. There is ample documentation about grafana dashboards online if you need help creating your dashboard.
 
 ![Grafana new dashboard](assets/nms/grafana_new_dashboard.png)
-- Grafana documentation on creating dashboards: [Grafana Dashboards](_https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/_)
-- Prometheus documentation on writing queries: [Prometheus Querying](_https://prometheus.io/docs/prometheus/latest/querying/basics/_)
+- Grafana documentation on creating dashboards: [Grafana Dashboards](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/)
+- Prometheus documentation on writing queries: [Prometheus Querying](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 
 If you want to replicate the networkID or gatewayID variables that you find in the preconfigured dashboards, we provide a “template” dashboard to make that easy. Simply open the Template dashboard, and click on the gear icon near the
 top right. From there, click “Save As” and enter the name you want. Your new dashboard will now have the gatewayID and networkID variables. An example of how to use these variables in your queries:

--- a/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/deploy_intro.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/deploy_intro.md
@@ -9,7 +9,7 @@ original_id: deploy_intro
 
 This section walks through installing a production Orchestrator deployment.
 
-We assume you will use the versioned artifacts provided by the project's official artifactory at [artifactory.magmacore.org](https://artifactory.magmacore.org/). If you would like to build and host your own artifacts, see the [Build Orchestrator](./dev_build.md) page.
+We assume you will use the versioned artifacts provided by the project's official artifactory at [https://linuxfoundation.jfrog.io/](https://linuxfoundation.jfrog.io/). If you would like to build and host your own artifacts, see the [Build Orchestrator](./dev_build.md) page.
 
 There are two principal ways to deploy an Orc8r instance
 

--- a/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/dev_minikube.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/dev_minikube.md
@@ -19,7 +19,7 @@ significant differences and many things in there you don't need to worry about.
 
 ### Build and publish images
 
-> NOTE: you can skip this step if you want to use the official container images at [https://linuxfoundation.jfrog.io/](hhttps://linuxfoundation.jfrog.io/).
+> NOTE: you can skip this step if you want to use the official container images at [https://linuxfoundation.jfrog.io/](https://linuxfoundation.jfrog.io/).
 
 Follow the instructions at [Building Orchestrator](./dev_build.md#build-and-publish-container-images).
 

--- a/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/dev_minikube.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/orc8r/dev_minikube.md
@@ -19,7 +19,7 @@ significant differences and many things in there you don't need to worry about.
 
 ### Build and publish images
 
-> NOTE: you can skip this step if you want to use the official container images at [artifactory.magmacore.org](https://artifactory.magmacore.org/).
+> NOTE: you can skip this step if you want to use the official container images at [https://linuxfoundation.jfrog.io/](hhttps://linuxfoundation.jfrog.io/).
 
 Follow the instructions at [Building Orchestrator](./dev_build.md#build-and-publish-container-images).
 

--- a/docs/docusaurus/versioned_docs/version-1.6.X/proposals/p017_apn_refactoring.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/proposals/p017_apn_refactoring.md
@@ -154,4 +154,4 @@ We have two options to implement this, we will choose it depending on time in 1.
 ## **References**
 
 * https://gist.github.com/karthiksubraveti/0daee7f5446cc72460497e247d427ee6
-* _https://raw.githubusercontent.com/magma/magma/d691319dd40e0a7d2822a993f819beca7490e65d/docs/readmes/lte/Attach_call_flow_in_Magma.txt_
+* [_https://raw.githubusercontent.com/magma/magma/d691319dd40e0a7d2822a993f819beca7490e65d/docs/readmes/lte/Attach_call_flow_in_Magma.txt_](https://raw.githubusercontent.com/magma/magma/d691319dd40e0a7d2822a993f819beca7490e65d/docs/readmes/lte/Attach_call_flow_in_Magma.txt)

--- a/docs/docusaurus/versioned_docs/version-1.7.0/cwf/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/cwf/deploy_install.md
@@ -83,7 +83,7 @@ DOCKER_PASSWORD=<password>
 IMAGE_VERSION=latest
 GIT_HASH=master
 
-BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master
+BUILD_CONTEXT=https://github.com/magma/magma.git#master
 
 ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem
 CONTROL_PROXY_PATH=/etc/magma/control_proxy.yml

--- a/docs/docusaurus/versioned_docs/version-1.7.0/feg/architecture_overview.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/feg/architecture_overview.md
@@ -16,7 +16,7 @@ simple, extensible, multi-language interfaces based on GRPC which allow develope
 complexities of 3GPP protocols. Implementing these RPC interfaces allows networks running on Magma to integrate
 with traditional 3GPP core components.
 
-![Federated Gateway architecture diagram](https://github.com/facebookincubator/magma/blob/master/docs/readmes/assets/federated_gateway_diagram.png?raw=true "FeG Architecture")
+![Federated Gateway architecture diagram](https://github.com/magma/magma/blob/master/docs/readmes/assets/federated_gateway_diagram.png?raw=true "FeG Architecture")
 
 The Federated Gateway supports the following features and functionalities:
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/howtos/troubleshooting/user_unable_to_attach.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/howtos/troubleshooting/user_unable_to_attach.md
@@ -51,7 +51,7 @@ PROTOCOL_ERROR 111
 
 Suggested Solution:
 
-1. Identify which parameter the UE is sending in the Attach Request and compare with the ones Magma support. You can find which parameters magma is currently supported from the code. <https://github.com/magma/magma/blob/master/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c>
+1. Identify which parameter the UE is sending in the Attach Request and compare with the ones Magma support. You can find which parameters magma is currently supported from the code. <https://github.com/magma/magma/blob/master/lte/gateway/c/core/oai/tasks/nas/emm/msg/AttachRequest.cpp>
 
     Note: Make sure to select the branch you are currently have in your network(v1.1, v1.2, v1.3 , etc)
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/README_AGW.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/README_AGW.md
@@ -75,7 +75,7 @@ Sessiond implements the control plane for the PCEF functionality in Magma. Sessi
 
 ## Pipelined
 
-Pipelined is the control application that programs the OVS openflow rules. In implementation pipelined is a set of services that are chained together. These services can be chained and enabled/disabled through the REST API.  The README (<https://github.com/facebookincubator/magma/blob/master/README.md>) describes the contract in greater detail.
+Pipelined is the control application that programs the OVS openflow rules. In implementation pipelined is a set of services that are chained together. These services can be chained and enabled/disabled through the REST API.  The README (<https://github.com/magma/magma/blob/master/README.md>) describes the contract in greater detail.
 
 ## PolicyDB
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/datapath.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/datapath.md
@@ -10,7 +10,7 @@ original_id: openvswitch
 
 Magma gateway is a software appliance. Magma Gateway uses linux networking stack and OVS to program packet pipeline on the gateway. OVS gives us tremendous programmability to classify and process packets on the gateway
 
-![datapath components](https://github.com/facebookincubator/magma/blob/master/docs/readmes/assets/AGW-OVS.png?raw=true)
+![datapath components](https://github.com/magma/magma/blob/master/docs/readmes/assets/AGW-OVS.png?raw=true)
 
 OVS configuration has two major component.
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5g_sa.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5g_sa.md
@@ -27,8 +27,8 @@ Following diagram gives an overview of the 5G SA components.
 
 Before starting to configure 5G SA setup, first you need to bring up a setup to handle your own/local subscribers. So before configuring Inbound Roaming you need:
 
-- Install [Or8cr](https:///magma.github.io/magma/docs/orc8r/architecture_overview),
-- Install [Federation Gateway](https:///magma.github.io/magma/docs/feg/deploy_intro) and,
+- Install [Or8cr](https://magma.github.io/magma/docs/orc8r/architecture_overview),
+- Install [Federation Gateway](https://magma.github.io/magma/docs/feg/deploy_intro) and,
 - Install [Access Gateway](https://magma.github.io/magma/docs/lte/setup_deb).
 - Make sure your setup is able to serve calls with your local subscribers
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/pipelined.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/pipelined.md
@@ -19,7 +19,7 @@ The OpenFlow pipeline of OVS contains 255 flow tables. Pipelined splits the tabl
 - Main table (Table 1 - 20)
 - Scratch table (Table 21 - 254)
 
-![OpenFlow Pipeline](https://github.com/facebookincubator/magma/blob/master/docs/readmes/assets/openflow-pipeline.png?raw=true)
+![OpenFlow Pipeline](https://github.com/magma/magma/blob/master/docs/readmes/assets/openflow-pipeline.png?raw=true)
 
 [*Source: OpenFlow Specification*](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-spec-v1.4.0.pdf)
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/tr069.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/tr069.md
@@ -61,7 +61,7 @@ differences between devices. Some devices require rebooting for parameter
 changes to take effect, for example. You can add/remove behavior through this
 map, and also add custom states.
 
-[An example pull request for adding an eNB](https://github.com/facebookincubator/magma/commit/e1d4564f7daa7a4c1be135e8dbffe7a10bfa4e34)
+[An example pull request for adding an eNB](https://github.com/magma/magma/commit/e1d4564f7daa7a4c1be135e8dbffe7a10bfa4e34)
 
 ## Testing
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/upgrade_1_5.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/upgrade_1_5.md
@@ -12,7 +12,7 @@ original_id: upgrade_1_5
 ## Repo Change
 
 In Magma Fuji (v1.5), Magma artifacts are now hosted on the new Magmacore repositories at
-[artifactory.magmacore.org](https://artifactory.magmacore.org/).
+[https://linuxfoundation.jfrog.io/](https://linuxfoundation.jfrog.io/).
 Gateways migrating from older Magma releases can run the migration script to update the sources accordingly.
 
 The repository currently supports both Debian and Ubuntu OS flavors.

--- a/docs/docusaurus/versioned_docs/version-1.7.0/nms/alert.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/nms/alert.md
@@ -228,8 +228,8 @@ Duration:
 In case we are having issues with alerts. Logs from the following services will give more information on debugging this further.
 
 ```bash
-kubectl --namespace orc8r logs -l [app.kubernetes.io/component=alertmanager](http://app.kubernetes.io/component=alertmanager)
-kubectl --namespace orc8r logs -l [app.kubernetes.io/component=alertmanager-configurer](http://app.kubernetes.io/component=alertmanager-configurer)
+kubectl --namespace orc8r logs -l app.kubernetes.io/component=alertmanager
+kubectl --namespace orc8r logs -l app.kubernetes.io/component=alertmanager-configurer
 kubectl --namespace orc8r logs -l app.kubernetes.io/component=prometheus-configurer -c prometheus-configurer
 kubectl --namespace orc8r logs -l app.kubernetes.io/component=prometheus -c prometheus
 kubectl --namespace orc8r logs -l app.kubernetes.io/component=metricsd

--- a/docs/docusaurus/versioned_docs/version-1.7.0/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/nms/metrics.md
@@ -36,8 +36,8 @@ The simple way is to just click on the “+” icon on the left sidebar, then cr
 
 ![Grafana new dashboard](assets/nms/grafana_new_dashboard.png)
 
-- Grafana documentation on creating dashboards: [Grafana Dashboards](_https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/_)
-- Prometheus documentation on writing queries: [Prometheus Querying](_https://prometheus.io/docs/prometheus/latest/querying/basics/_)
+- Grafana documentation on creating dashboards: [Grafana Dashboards](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/)
+- Prometheus documentation on writing queries: [Prometheus Querying](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 
 If you want to replicate the networkID or gatewayID variables that you find in the preconfigured dashboards, we provide a “template” dashboard to make that easy. Simply open the Template dashboard, and click on the gear icon near the
 top right. From there, click “Save As” and enter the name you want. Your new dashboard will now have the gatewayID and networkID variables. An example of how to use these variables in your queries:

--- a/docs/docusaurus/versioned_docs/version-1.7.0/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/nms/metrics.md
@@ -176,7 +176,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 On the gateways, magmad service collects metrics from all the services and pushes them to Orc8r.
 In Orc8r, metricsd receives the metrics and pushes them to registered metric exporters. Prometheus
 is one the main metric exporters. Specifically, Orc8r pushes the metrics to the
-[edge-hub](<https://github.com/facebookincubator/prometheus-edge-hub>), which later scraped by prometheus instance.
+[edge-hub](<https://github.com/facebookarchive/prometheus-edge-hub>), which later scraped by prometheus instance.
 
 On the query side, When we make queries through NMS or swagger, the Orc8r queries the prometheus
 instance directly.

--- a/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/deploy_intro.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/deploy_intro.md
@@ -9,7 +9,7 @@ original_id: deploy_intro
 
 This section walks through installing a production Orchestrator deployment.
 
-We assume you will use the versioned artifacts provided by the project's official artifactory at [artifactory.magmacore.org](https://artifactory.magmacore.org/). If you would like to build and host your own artifacts, see the [Build Orchestrator](./dev_build.md) page.
+We assume you will use the versioned artifacts provided by the project's official artifactory at [https://linuxfoundation.jfrog.io/](https://linuxfoundation.jfrog.io/). If you would like to build and host your own artifacts, see the [Build Orchestrator](./dev_build.md) page.
 
 To deploy orc8r, see the [Manual installation](./deploy_install.md) page.
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/dev_minikube.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/dev_minikube.md
@@ -35,7 +35,7 @@ helm upgrade --install \
 
 ### Build and publish images
 
-> NOTE: skip this step if you want to use the official container images at [artifactory.magmacore.org](https://artifactory.magmacore.org/).
+> NOTE: skip this step if you want to use the official container images at [https://linuxfoundation.jfrog.io/](https://linuxfoundation.jfrog.io/).
 
 There are 2 ways you can publish your own images: to a private registry, or to a localhost registry. Choose an option, then complete the relevant prerequisites:
 
@@ -104,8 +104,8 @@ A minimal values file is at `${MAGMA_ROOT}/orc8r/cloud/helm/orc8r/examples/minik
 
 This section describes how to install based on local charts. However, you can also install charts from the official chart repositories
 
-- Stable: <https://artifactory.magmacore.org/artifactory/helm/>
-- Test: <https://artifactory.magmacore.org/artifactory/helm-test/>
+- Stable: <https://linuxfoundation.jfrog.io/ui/repos/tree/General/magma-helm>
+- Test: <https://linuxfoundation.jfrog.io/ui/repos/tree/General/magma-helm-test>
 
 Install base `orc8r` chart
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/upgrade_1_1.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/orc8r/upgrade_1_1.md
@@ -22,7 +22,7 @@ including developer tooling, a Helm chart repository, and a container registry.
 ## Create a New Root Module
 
 First, create a new directory somewhere to store your new root Terraform module
-for the 1.1.x deployment. We have an example root module at <https://github.com/facebookincubator/magma/tree/v1.1/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade>
+for the 1.1.x deployment. We have an example root module at <https://github.com/magma/magma/tree/v1.1/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade>
 that we recommend you use for the upgrade. Copy all the files to your new
 directory and change the `source` attribute of both modules in `main.tf` to
 `github.com/facebookincubator/magma//orc8r/cloud/deploy/terraform/orc8r-aws` and

--- a/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p002_scaled_prometheus_pipeline.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p002_scaled_prometheus_pipeline.md
@@ -82,7 +82,7 @@ All metrics go through the controller (which is already scalable and placed behi
 
 All metrics are stored for 30 days in the Prometheus TSDB storage. This means that all queries have to go through the prometheus server itself, which is the main cause of slow queries.
 
-[Object storage](https://thanos.io/storage.md/) will allow us to only store a few hours of metrics on the server itself (potentially keeping everything in-memory) and then exporting older metrics to object storage elsewhere. For example on an AWS deployment metrics would be stored in S3.
+[Object storage](https://thanos.io/tip/thanos/storage.md/) will allow us to only store a few hours of metrics on the server itself (potentially keeping everything in-memory) and then exporting older metrics to object storage elsewhere. For example on an AWS deployment metrics would be stored in S3.
 
 Options for Object Storage
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p002_scaled_prometheus_pipeline.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p002_scaled_prometheus_pipeline.md
@@ -105,7 +105,7 @@ We should make this as easy to configure as possible. Some goals include:
 
 ### Improving prometheus-edge-hub performance
 
-With the goal of handling 10 million datapoints per minute, the [prometheus-edge-hub](github.com/facebookincubator/prometheus-edge-hub) will probably need some improvements to handle that load. First we'll do benchmark tests on specific AWS hardware options. Then, profile the code to find the bottlenecks and improve them. It's not clear what exactly needs to be done, but I'm confident we can find significant improvements as this component hasn't gone through much optimization yet.
+With the goal of handling 10 million datapoints per minute, the [prometheus-edge-hub](https://github.com/facebookincubator/prometheus-edge-hub) will probably need some improvements to handle that load. First we'll do benchmark tests on specific AWS hardware options. Then, profile the code to find the bottlenecks and improve them. It's not clear what exactly needs to be done, but I'm confident we can find significant improvements as this component hasn't gone through much optimization yet.
 
 In the end if we can't get enough performance out of a single edge-hub, we will have to investigate scaling this horizontally.
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p002_scaled_prometheus_pipeline.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p002_scaled_prometheus_pipeline.md
@@ -13,7 +13,7 @@ original_id: p002_scaled_prometheus_pipeline
 
 Details:
 
-- I use the term pushgateway to reference [prometheus-edge-hub](https://github.com/facebookincubator/prometheus-edge-hub)
+- I use the term pushgateway to reference [prometheus-edge-hub](https://github.com/facebookarchive/prometheus-edge-hub)
 - "Prod" and "Staging" refer to FB-hosted deployments of Orchestrator which are currently our largest deployments and our source of performance data.
 
 ## Goal: Improve metrics query speed on large deployments

--- a/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p011_victoriametrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p011_victoriametrics.md
@@ -22,7 +22,7 @@ Magma is getting to the point where scaling is a primary concern. One of the
 areas that could be most impacted by larger scale is metrics, since there is a
 direct correlation with the number of subscribers/gateways and the amount of
 data coming through the system. We’ve been relying on a single Prometheus
-server coupled to our [prometheus-edge-hub](github.com/facebookincubator/prometheus-edge-hub)
+server coupled to our [prometheus-edge-hub](github.com/facebookarchive/prometheus-edge-hub)
 which has worked for all of the small and medium deployments so far, but we’re
 getting pretty close to the limit where this setup would not be able to ingest
 more data. In addition to this, partners have been wanting to run magma at a

--- a/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p011_victoriametrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p011_victoriametrics.md
@@ -95,11 +95,11 @@ This is actually something we looked into way back when this all started but it
 wasn’t open sourced back then. Now it is fully [open source](https://blog.usejournal.com/open-sourcing-victoriametrics-f31e34485c2b)
 with some [insane](https://valyala.medium.com/high-cardinality-tsdb-benchmarks-victoriametrics-vs-timescaledb-vs-influxdb-13e6ee64dd6b)
 [benchmarks](https://valyala.medium.com/prometheus-vs-victoriametrics-benchmark-on-node-exporter-metrics-4ca29c75590f)
-and [significant](https://victoriametrics.github.io/CaseStudies.html) community
+and [significant](https://docs.victoriametrics.com/CaseStudies.html) community
 usage.
 
-The biggest benefit of VM is that it supports both [push](https://victoriametrics.github.io/Single-server-VictoriaMetrics#how-to-import-data-in-prometheus-exposition-format)
-and [pull](https://victoriametrics.github.io/Single-server-VictoriaMetrics#how-to-scrape-prometheus-exporters-such-as-node-exporter)
+The biggest benefit of VM is that it supports both [push](https://docs.victoriametrics.com/Single-server-VictoriaMetrics#how-to-import-data-in-prometheus-exposition-format)
+and [pull](https://docs.victoriametrics.com/Single-server-VictoriaMetrics#how-to-scrape-prometheus-exporters-such-as-node-exporter)
 natively.
 
 This means we can completely get rid of prometheus-edge-hub and just push
@@ -117,14 +117,14 @@ only using <200% CPU.
 Based on VM’s data this capacity should scale nearly linearly for quite a
 while with more/faster CPUs.
 
-VM also offers a [cluster](https://victoriametrics.github.io/Cluster-VictoriaMetrics)
+VM also offers a [cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics)
 version which is very simply scaled horizontally behind a load balancer. Given
 how well it scales vertically I don’t think this is something we’ll likely have
 to look into for quite a while. Even then if we do I don’t think the
 engineering work would be significant.
 
 VictoriaMetrics integrates seamlessly with configmanager and the
-[alerting setup](https://victoriametrics.github.io/vmalert.html)
+[alerting setup](https://docs.victoriametrics.com/vmalert.html)
 is nearly identical to how Thanos does alerting, which I’ve already validated
 so there’s not much risk on that end.
 
@@ -183,7 +183,7 @@ require more engineering work for a likely worse product.
 The implementation for this is very straightforward.
 
 - Deploy VictoriaMetrics in a single node configuration and then use the
-existing [remote exporter](https://github.com/magma/magma/blob/master/orc8r/cloud/go/services/orchestrator/servicers/exporter_servicer.go)
+existing [remote exporter](https://github.com/magma/magma/blob/v1.7.0/orc8r/cloud/go/services/orchestrator/servicers/protected/exporter_servicer.go)
 to push metrics directly to VM.
 - Configure metricsd to direct queries to the VM query endpoint rather than
 Prometheus

--- a/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p011_victoriametrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p011_victoriametrics.md
@@ -22,7 +22,7 @@ Magma is getting to the point where scaling is a primary concern. One of the
 areas that could be most impacted by larger scale is metrics, since there is a
 direct correlation with the number of subscribers/gateways and the amount of
 data coming through the system. We’ve been relying on a single Prometheus
-server coupled to our [prometheus-edge-hub](github.com/facebookarchive/prometheus-edge-hub)
+server coupled to our [prometheus-edge-hub](https://github.com/facebookarchive/prometheus-edge-hub)
 which has worked for all of the small and medium deployments so far, but we’re
 getting pretty close to the limit where this setup would not be able to ingest
 more data. In addition to this, partners have been wanting to run magma at a

--- a/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p020_sgi_tunnel_transport.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p020_sgi_tunnel_transport.md
@@ -148,5 +148,5 @@ This is the scope for version 1.
    skb-mark.
 6. IPSec would be only supported on ubuntu and kernel (> 4.14).
 
-[1] <https://www>.`wireguard`.com/performance/
+[1] <https://www.wireguard.com/performance/>
     <https://core.ac.uk/download/pdf/322886318.pdf>

--- a/docs/docusaurus/versioned_docs/version-1.7.0/resources/ref_magma_metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/resources/ref_magma_metrics.md
@@ -119,7 +119,7 @@ func (s *GRPCPushExporterServicer) pushFamilies(families []*io_prometheus_client
 }
 ```
 
-[Prometheus Edge Hub](https://github.com/facebookincubator/prometheus-edge-hub) is a Facebook project that replaces the Prometheus Pushgateway. Orc8r's Prometheus service [scrapes](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml#L160-L168) and drains the Edge Hub so metrics finally arrive at their home in the Prometheus server. [On a dev environment](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/docker/docker-compose.metrics.yml?L14-24), the Prometheus server runs at [localhost:9090](https://localhost:9090).
+[Prometheus Edge Hub](https://github.com/facebookarchive/prometheus-edge-hub) is a Facebook project that replaces the Prometheus Pushgateway. Orc8r's Prometheus service [scrapes](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml#L160-L168) and drains the Edge Hub so metrics finally arrive at their home in the Prometheus server. [On a dev environment](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/docker/docker-compose.metrics.yml?L14-24), the Prometheus server runs at [localhost:9090](https://localhost:9090).
 
 ## Phase 3: NMS and Grafana
 

--- a/docs/docusaurus/versioned_docs/version-1.8.0/lte/pipelined.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/lte/pipelined.md
@@ -19,7 +19,7 @@ The OpenFlow pipeline of OVS contains 255 flow tables. Pipelined splits the tabl
 - Main table (Table 1 - 20)
 - Scratch table (Table 21 - 254)
 
-![OpenFlow Pipeline](https://github.com/facebookincubator/magma/blob/master/docs/readmes/assets/openflow-pipeline.png?raw=true)
+![OpenFlow Pipeline](https://github.com/magma/magma/blob/master/docs/readmes/assets/openflow-pipeline.png?raw=true)
 
 [*Source: OpenFlow Specification*](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-spec-v1.4.0.pdf)
 

--- a/docs/docusaurus/versioned_docs/version-1.8.0/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/nms/metrics.md
@@ -36,8 +36,8 @@ The simple way is to just click on the “+” icon on the left sidebar, then cr
 
 ![Grafana new dashboard](assets/nms/grafana_new_dashboard.png)
 
-- Grafana documentation on creating dashboards: [Grafana Dashboards](_https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/_)
-- Prometheus documentation on writing queries: [Prometheus Querying](_https://prometheus.io/docs/prometheus/latest/querying/basics/_)
+- Grafana documentation on creating dashboards: [Grafana Dashboards](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/)
+- Prometheus documentation on writing queries: [Prometheus Querying](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 
 If you want to replicate the networkID or gatewayID variables that you find in the preconfigured dashboards, we provide a “template” dashboard to make that easy. Simply open the Template dashboard, and click on the gear icon near the
 top right. From there, click “Save As” and enter the name you want. Your new dashboard will now have the gatewayID and networkID variables. An example of how to use these variables in your queries:

--- a/docs/docusaurus/versioned_docs/version-1.8.0/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/nms/metrics.md
@@ -176,7 +176,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 On the gateways, magmad service collects metrics from all the services and pushes them to Orc8r.
 In Orc8r, metricsd receives the metrics and pushes them to registered metric exporters. Prometheus
 is one the main metric exporters. Specifically, Orc8r pushes the metrics to the
-[edge-hub](<https://github.com/facebookincubator/prometheus-edge-hub>), which later scraped by prometheus instance.
+[edge-hub](<https://github.com/facebookarchive/prometheus-edge-hub>), which later scraped by prometheus instance.
 
 On the query side, When we make queries through NMS or swagger, the Orc8r queries the prometheus
 instance directly.

--- a/docs/readmes/lte/upgrade_1_5.md
+++ b/docs/readmes/lte/upgrade_1_5.md
@@ -11,7 +11,7 @@ hide_title: true
 ## Repo Change
 
 In Magma Fuji (v1.5), Magma artifacts are now hosted on the new Magmacore repositories at
-[artifactory.magmacore.org](https://artifactory.magmacore.org/).
+[https://linuxfoundation.jfrog.io/](https://linuxfoundation.jfrog.io/).
 Gateways migrating from older Magma releases can run the migration script to update the sources accordingly.
 
 The repository currently supports both Debian and Ubuntu OS flavors.

--- a/docs/readmes/nms/metrics.md
+++ b/docs/readmes/nms/metrics.md
@@ -175,7 +175,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 On the gateways, magmad service collects metrics from all the services and pushes them to Orc8r.
 In Orc8r, metricsd receives the metrics and pushes them to registered metric exporters. Prometheus
 is one the main metric exporters. Specifically, Orc8r pushes the metrics to the
-[edge-hub](<https://github.com/facebookincubator/prometheus-edge-hub>), which later scraped by prometheus instance.
+[edge-hub](<https://github.com/facebookarchive/prometheus-edge-hub>), which later scraped by prometheus instance.
 
 On the query side, When we make queries through NMS or swagger, the Orc8r queries the prometheus
 instance directly.

--- a/docs/readmes/proposals/p002_scaled_prometheus_pipeline.md
+++ b/docs/readmes/proposals/p002_scaled_prometheus_pipeline.md
@@ -12,7 +12,7 @@ hide_title: true
 
 Details:
 
-- I use the term pushgateway to reference [prometheus-edge-hub](https://github.com/facebookincubator/prometheus-edge-hub)
+- I use the term pushgateway to reference [prometheus-edge-hub](https://github.com/facebookarchive/prometheus-edge-hub)
 - "Prod" and "Staging" refer to FB-hosted deployments of Orchestrator which are currently our largest deployments and our source of performance data.
 
 ## Goal: Improve metrics query speed on large deployments

--- a/docs/readmes/proposals/p002_scaled_prometheus_pipeline.md
+++ b/docs/readmes/proposals/p002_scaled_prometheus_pipeline.md
@@ -81,7 +81,7 @@ All metrics go through the controller (which is already scalable and placed behi
 
 All metrics are stored for 30 days in the Prometheus TSDB storage. This means that all queries have to go through the prometheus server itself, which is the main cause of slow queries.
 
-[Object storage](https://thanos.io/storage.md/) will allow us to only store a few hours of metrics on the server itself (potentially keeping everything in-memory) and then exporting older metrics to object storage elsewhere. For example on an AWS deployment metrics would be stored in S3.
+[Object storage](https://thanos.io/tip/thanos/storage.md/) will allow us to only store a few hours of metrics on the server itself (potentially keeping everything in-memory) and then exporting older metrics to object storage elsewhere. For example on an AWS deployment metrics would be stored in S3.
 
 Options for Object Storage
 

--- a/docs/readmes/proposals/p002_scaled_prometheus_pipeline.md
+++ b/docs/readmes/proposals/p002_scaled_prometheus_pipeline.md
@@ -104,7 +104,7 @@ We should make this as easy to configure as possible. Some goals include:
 
 ### Improving prometheus-edge-hub performance
 
-With the goal of handling 10 million datapoints per minute, the [prometheus-edge-hub](github.com/facebookincubator/prometheus-edge-hub) will probably need some improvements to handle that load. First we'll do benchmark tests on specific AWS hardware options. Then, profile the code to find the bottlenecks and improve them. It's not clear what exactly needs to be done, but I'm confident we can find significant improvements as this component hasn't gone through much optimization yet.
+With the goal of handling 10 million datapoints per minute, the [prometheus-edge-hub](https://github.com/facebookincubator/prometheus-edge-hub) will probably need some improvements to handle that load. First we'll do benchmark tests on specific AWS hardware options. Then, profile the code to find the bottlenecks and improve them. It's not clear what exactly needs to be done, but I'm confident we can find significant improvements as this component hasn't gone through much optimization yet.
 
 In the end if we can't get enough performance out of a single edge-hub, we will have to investigate scaling this horizontally.
 

--- a/docs/readmes/proposals/p011_victoriametrics.md
+++ b/docs/readmes/proposals/p011_victoriametrics.md
@@ -21,7 +21,7 @@ Magma is getting to the point where scaling is a primary concern. One of the
 areas that could be most impacted by larger scale is metrics, since there is a
 direct correlation with the number of subscribers/gateways and the amount of
 data coming through the system. We’ve been relying on a single Prometheus
-server coupled to our [prometheus-edge-hub](github.com/facebookincubator/prometheus-edge-hub)
+server coupled to our [prometheus-edge-hub](https://github.com/facebookincubator/prometheus-edge-hub)
 which has worked for all of the small and medium deployments so far, but we’re
 getting pretty close to the limit where this setup would not be able to ingest
 more data. In addition to this, partners have been wanting to run magma at a

--- a/docs/readmes/proposals/p011_victoriametrics.md
+++ b/docs/readmes/proposals/p011_victoriametrics.md
@@ -94,11 +94,11 @@ This is actually something we looked into way back when this all started but it
 wasn’t open sourced back then. Now it is fully [open source](https://blog.usejournal.com/open-sourcing-victoriametrics-f31e34485c2b)
 with some [insane](https://valyala.medium.com/high-cardinality-tsdb-benchmarks-victoriametrics-vs-timescaledb-vs-influxdb-13e6ee64dd6b)
 [benchmarks](https://valyala.medium.com/prometheus-vs-victoriametrics-benchmark-on-node-exporter-metrics-4ca29c75590f)
-and [significant](https://victoriametrics.github.io/CaseStudies.html) community
+and [significant](https://docs.victoriametrics.com/CaseStudies.html) community
 usage.
 
-The biggest benefit of VM is that it supports both [push](https://victoriametrics.github.io/Single-server-VictoriaMetrics#how-to-import-data-in-prometheus-exposition-format)
-and [pull](https://victoriametrics.github.io/Single-server-VictoriaMetrics#how-to-scrape-prometheus-exporters-such-as-node-exporter)
+The biggest benefit of VM is that it supports both [push](https://docs.victoriametrics.com/Single-server-VictoriaMetrics#how-to-import-data-in-prometheus-exposition-format)
+and [pull](https://docs.victoriametrics.com/Single-server-VictoriaMetrics#how-to-scrape-prometheus-exporters-such-as-node-exporter)
 natively.
 
 This means we can completely get rid of prometheus-edge-hub and just push
@@ -116,14 +116,14 @@ only using <200% CPU.
 Based on VM’s data this capacity should scale nearly linearly for quite a
 while with more/faster CPUs.
 
-VM also offers a [cluster](https://victoriametrics.github.io/Cluster-VictoriaMetrics)
+VM also offers a [cluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics)
 version which is very simply scaled horizontally behind a load balancer. Given
 how well it scales vertically I don’t think this is something we’ll likely have
 to look into for quite a while. Even then if we do I don’t think the
 engineering work would be significant.
 
 VictoriaMetrics integrates seamlessly with configmanager and the
-[alerting setup](https://victoriametrics.github.io/vmalert.html)
+[alerting setup](https://docs.victoriametrics.com/vmalert.html)
 is nearly identical to how Thanos does alerting, which I’ve already validated
 so there’s not much risk on that end.
 
@@ -182,7 +182,7 @@ require more engineering work for a likely worse product.
 The implementation for this is very straightforward.
 
 - Deploy VictoriaMetrics in a single node configuration and then use the
-existing [remote exporter](https://github.com/magma/magma/blob/master/orc8r/cloud/go/services/orchestrator/servicers/exporter_servicer.go)
+existing [remote exporter](https://github.com/magma/magma/blob/master/orc8r/cloud/go/services/orchestrator/servicers/protected/exporter_servicer.go)
 to push metrics directly to VM.
 - Configure metricsd to direct queries to the VM query endpoint rather than
 Prometheus

--- a/docs/readmes/proposals/p020_sgi_tunnel_transport.md
+++ b/docs/readmes/proposals/p020_sgi_tunnel_transport.md
@@ -147,5 +147,5 @@ This is the scope for version 1.
    skb-mark.
 6. IPSec would be only supported on ubuntu and kernel (> 4.14).
 
-[1] <https://www>.`wireguard`.com/performance/
+[1] <https://www.wireguard.com/performance/>
     <https://core.ac.uk/download/pdf/322886318.pdf>

--- a/docs/readmes/resources/ref_magma_metrics.md
+++ b/docs/readmes/resources/ref_magma_metrics.md
@@ -118,7 +118,7 @@ func (s *GRPCPushExporterServicer) pushFamilies(families []*io_prometheus_client
 }
 ```
 
-[Prometheus Edge Hub](https://github.com/facebookincubator/prometheus-edge-hub) is a Facebook project that replaces the Prometheus Pushgateway. Orc8r's Prometheus service [scrapes](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml#L160-L168) and drains the Edge Hub so metrics finally arrive at their home in the Prometheus server. [On a dev environment](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/docker/docker-compose.metrics.yml?L14-24), the Prometheus server runs at [localhost:9090](https://localhost:9090).
+[Prometheus Edge Hub](https://github.com/facebookarchive/prometheus-edge-hub) is a Facebook project that replaces the Prometheus Pushgateway. Orc8r's Prometheus service [scrapes](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml#L160-L168) and drains the Edge Hub so metrics finally arrive at their home in the Prometheus server. [On a dev environment](https://sourcegraph.com/github.com/magma/magma@v1.6.0/-/blob/orc8r/cloud/docker/docker-compose.metrics.yml?L14-24), the Prometheus server runs at [localhost:9090](https://localhost:9090).
 
 ## Phase 3: NMS and Grafana
 


### PR DESCRIPTION
## Summary

Fixes a number of dead links in the docs.

Remaining dead links:
- [x] ~https://github.com/magma/ci-infra/blob/master/bazel/remote_caching/Readme.md~ -> Would need CI codeowner access to check and I have no reason to believe this link is dead for anyone holding the right permissions.
- [x] https://github.com/magma/magma/tree/v1.7.0/orc8r/cloud/go/services/orchestrator/servicers/exporter_servicer.go
- [x] https://magma.github.io/magma/docs/orc8r/rds_upgrade#logs-and-validation Follow up in #15139
- [x] http://automation.fbmagma.ninja/ Follow up in #15138
- [x] https://github.com/fbcinternal/ens_magma/tree/master/spirent_automation #15138
- [x] https://fb.quip.com/4tmUAtlox4Oy -> Follow up in #15140

I'm ignoring all markdown issues highlighted by reviewdog as they are out of scope and would lead to inconsistent formatting.

## Test Plan

Using this simple script to check existing links. Dead links are listed by the script. Results need to be checked manually because links are sometimes cut off at the wrong character.

