### PR TITLE
fix(nms): Fixing metrics fetching

### DIFF
--- a/nms/app/views/metrics/Explorer.tsx
+++ b/nms/app/views/metrics/Explorer.tsx
@@ -96,7 +96,7 @@ export default function MetricsExplorer() {
   } = useMagmaAPI(MagmaAPI.metrics.tenantsTargetsMetadataGet, {});
 
   useEffect(() => {
-    fetch('/data/LteMetrics')
+    fetch('/api/data/LteMetrics')
       .then(res => res.json())
       .then(
         (result: Array<MetricsDetail>) => {

--- a/nms/server/app.ts
+++ b/nms/server/app.ts
@@ -107,8 +107,8 @@ const alertLinksJsonData = fs.readFileSync(
   path.join(__dirname, '..', 'api/data/AlertLinks.json'),
   'utf-8',
 );
-app.get('api/data/LteMetrics', (req, res) => res.send(lteMetricsJsonData));
-app.get('api/data/AlertLinks', (req, res) => res.send(alertLinksJsonData));
+app.get('/api/data/LteMetrics', (req, res) => res.send(lteMetricsJsonData));
+app.get('/api/data/AlertLinks', (req, res) => res.send(alertLinksJsonData));
 
 // Trigger syncing of automatically generated alerts
 app.use('/sync_alerts', access(AccessRoles.USER), alertRoutes);


### PR DESCRIPTION
## Summary

Fixes error message popping up in the `Explorer` tab when trying to fetch metrics.
![error](https://user-images.githubusercontent.com/42570669/223420838-5d53fa7c-b85e-4a30-bf25-b30dcd1b5da3.png)

## Test Plan

- Deploy Orc8r and see the red popup in the Metrics/Explorer tab
- Fix the code and build custom `nms-magmalte` image
- Update image for `nms-magmalte` pod
- See the red popup in the Metrics/Explorer tab is gone and metrics are fatched

## Additional Information

This should be backported to v1.8 as well.
- [ ] This change is backwards-breaking
