### PR TITLE
chore(ci): Disable Make AGW Debian build and integ tests

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -107,127 +107,6 @@ jobs:
         run: |
           pip install artifactory
           python ci-scripts/helm_repo_rotation.py
-  agw-build:
-    if: github.event_name == 'push' && github.repository_owner == 'magma'
-    runs-on: macos-12
-    outputs:
-      artifacts: ${{ steps.publish_packages.outputs.artifacts }}
-      magma_package: ${{ steps.publish_packages.outputs.magma_package }}
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-        with:
-          fetch-depth: 0
-      - name: Cache magma-dev-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
-        with:
-          path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
-          key: vagrant-box-magma-dev-v1.3.20221230
-      - name: Log in to vagrant cloud
-        run: |
-          if [[ -n "${{ secrets.VAGRANT_TOKEN }}" ]]
-          then
-            echo "Logging in to vagrant cloud to mitigate rate limiting."
-            vagrant cloud auth login --token "${{ secrets.VAGRANT_TOKEN }}"
-          else
-            echo "Vagrant cloud token is not configured. Skipping login."
-          fi
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
-        with:
-          python-version: '3.8.10'
-      - name: Install pre requisites
-        run: |
-          pip3 install --upgrade pip
-          pip3 install ansible fabric jsonpickle requests PyYAML
-          vagrant plugin install vagrant-disksize vagrant-vbguest vagrant-mutate vagrant-reload
-      - name: Open up network interfaces for VM
-        run: |
-          sudo mkdir -p /etc/vbox/
-          sudo touch /etc/vbox/networks.conf
-          sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
-          sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
-      - name: Build AGW
-        run: |
-          export MAGMA_DEV_MEMORY_MB=4096
-          cd lte/gateway
-          fab release package --destroy-vm
-          mkdir magma-packages
-          vagrant ssh -c "cp -r magma-packages /vagrant"
-      - name: Setup JFROG CLI
-        uses: jfrog/setup-jfrog-cli@d0a59b1cdaeeb16e65b5039fc92b8507337f1559 # pin@v3
-      - name: Publish debian packages
-        id: publish_packages
-        if: github.event_name == 'push'
-        env:
-          DEBIAN_META_INFO: deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64
-        run: |
-          # Default firebase output before anything can fail
-          ARTIFACTS='{"packages":[],"valid":false}'
-          echo "artifacts=$(echo $ARTIFACTS)" >> $GITHUB_OUTPUT
-
-          set -euo pipefail
-
-          cd lte/gateway/magma-packages
-
-          # Extract magma debian package version
-          version_pattern="magma_([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-[a-z0-9]+)_amd64.deb"
-          magma_version=""
-          for i in *.deb; do
-              if [[ $i =~ $version_pattern ]]; then
-                  magma_version=${BASH_REMATCH[1]}
-              fi
-          done
-          if [[ -z "$magma_version" ]]; then
-              echo "No file found with a matching version pattern \"${version_pattern}\". Files in folder:"
-              ls -la
-              exit 1
-          else
-              echo "Exporting magma version \"${magma_version}\""
-              echo "magma_package=magma=${magma_version}" >> $GITHUB_OUTPUT
-          fi
-
-          # Uploading packages to the registry
-          RESPONSE=$(jf rt upload \
-            --recursive=false \
-            --detailed-summary \
-            --url https://linuxfoundation.jfrog.io/artifactory/ \
-            --user ${{ secrets.LF_JFROG_USERNAME }} \
-            --password ${{ secrets.LF_JFROG_PASSWORD }} \
-            --target-props="${DEBIAN_META_INFO}" \
-            "(*).deb" magma-packages-test/pool/focal-ci/{1}.deb)
-
-          # Mapping response to output (for firebase)
-          echo "Response:"
-          echo $RESPONSE | jq
-          echo "Output (for firebase):"
-          ARTIFACTS=$(echo $RESPONSE | jq '{"valid": (.status=="success"), "packages": [.files[] | .target]}')
-          echo $ARTIFACTS | jq
-          echo "artifacts=$(echo $ARTIFACTS)" >> $GITHUB_OUTPUT
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
-        if: github.event_name == 'pull_request'
-        with:
-          name: magma-packages
-          path: lte/gateway/magma-packages/*.deb
-      - name: Notify failure to slack
-        if: failure() && github.event_name == 'push'
-        env:
-          SLACK_TITLE: "Github action agw build failed"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_USERNAME: ${{ github.workflow }}
-          SLACK_AVATAR: ":boom:"
-        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
-        with:
-          args: "AGW  build failed in run <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}> from commit ${{ github.sha }}: ${{ github.event.head_commit.message || github.event.pull_request.title }}"
-      # Notify ci channel when push succeeds
-      - name: Notify success to Slack
-        if: success() && github.event_name == 'push'
-        env:
-          SLACK_TITLE: "Github action agw build got published"
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ARTIFACTS }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS }}
-          SLACK_USERNAME: ${{ github.workflow }}
-        uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # pin@2.1.0
-        with:
-          args: "AGW build succeeded in run <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}> from commit ${{ github.sha }}: ${{ github.event.head_commit.message || github.event.pull_request.title }}"
 
   orc8r-build:
     if: github.repository_owner == 'magma'
@@ -648,7 +527,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
       [
-        agw-build,
         feg-build,
         orc8r-build,
         cwag-deploy,
@@ -667,7 +545,6 @@ jobs:
           BUILD_METADATA: '{"github:workflow": "${{ github.workflow }}", "github:run_id": "${{ github.run_id }}", "github:actor": "${{ github.actor }}", "github:repository": "${{ github.repository }}",
             "github:event_name": "${{ github.event_name }}", "github:sha": "${{ github.sha }}", "github:sha:url": "${{github.event.repository.owner.html_url}}/magma/commit/${{github.sha}}",
             "github:ref": "${{ github.ref }}"}'
-          AGW_ARTIFACTS: ${{ needs.agw-build.outputs.artifacts }}
           FEG_ARTIFACTS: ${{ needs.feg-build.outputs.artifacts }}
           ORC8R_ARTIFACTS: ${{ needs.orc8r-build.outputs.artifacts }}
           CWAG_ARTIFACTS: ${{ needs.cwag-deploy.outputs.artifacts }}
@@ -735,17 +612,3 @@ jobs:
           SLACK_ICON_EMOJI: ":heavy_check_mark:"
           SLACK_COLOR: "#00FF00"
           SLACK_FOOTER: ' '
-  trigger-debian-integ-test:
-    if: always() && github.event_name == 'push' && github.repository_owner == 'magma' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-20.04
-    needs: agw-build
-    steps:
-      - name: Trigger debian integ test workflow
-        uses: peter-evans/repository-dispatch@f2696244ec00ed5c659a5cc77f7138ad0302dffb # pin@v2.1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: magma/magma
-          event-type: build-all-artifact
-          client-payload: '{ "artifact": "${{ needs.agw-build.outputs.magma_package }}", "trigger_sha": "${{ github.sha }}", "commit_message": "$COMMIT_MESSAGE" }'
-        env:
-          COMMIT_MESSAGE: ${{ toJSON(github.event.head_commit.message) }}

--- a/.github/workflows/lte-integ-test-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-magma-deb.yml
@@ -15,10 +15,11 @@
 
 name: AGW Test LTE Integration With Make Debian Build
 
+# WARNING: This workflow is deprecated and has been replaced by the
+# "AGW Test LTE Integration With Bazel Debian Build" workflow,
+# see .github/workflows/lte-integ-test-bazel-magma-deb.yml
 on:
   workflow_dispatch: null
-  repository_dispatch:
-    types: [build-all-artifact]
 
 jobs:
   lte-integ-test-magma-deb:

--- a/.github/workflows/lte-integ-test.yml
+++ b/.github/workflows/lte-integ-test.yml
@@ -15,6 +15,9 @@
 
 name: AGW Build & Test LTE Integration With Make Dev Build
 
+# WARNING: This workflow is deprecated and has been replaced by the
+# "AGW Test LTE Integration With Bazel Debian Build" workflow,
+# see .github/workflows/lte-integ-test-bazel-magma-deb.yml
 on:
   workflow_dispatch: null
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

- Add deprecation statements to the Make AGW Debian and LTE dev build integ test workflows and remove automatic triggers.
- Remove the Make AGW Debian artifact build. This job is difficult to keep deactivated but still functional because it integrates with follow up jobs.

## Test Plan

- [Manual run](https://github.com/LKreutzer/magma/actions/runs/4353965867/jobs/7608681022) with `workflow_dispatch` on the Make Debian integ tests.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
