### PR TITLE
fix: script does not try to publish removed agw meta data

### DIFF
--- a/ci-scripts/firebase_publish.py
+++ b/ci-scripts/firebase_publish.py
@@ -56,7 +56,7 @@ def main():
         print(f"Decoding build_metadata_env JSON failed: {build_metadata_env}")
     build_info = {"metadata": build_metadata}
 
-    builds = ["AGW", "FEG", "ORC8R", "CWAG", "NMS"]
+    builds = ["FEG", "ORC8R", "CWAG", "NMS"]
     for build in builds:
         artifact_env = os.environ[f"{build}_ARTIFACTS"]
         artifacts = {}
@@ -68,8 +68,6 @@ def main():
                 f"has failed: {artifact_env}",
             )
             artifacts = {"packages": [], "valid": False}
-        if build == "AGW":
-            artifacts = _set_download_uri(artifacts)
         build_info[f"{build.lower()}"] = artifacts
 
     # Prepare workload


### PR DESCRIPTION
## Summary

In #15144 the agw build make step was removed from the build_all workflow. The publish to firebase step still uses a script that references the now non-existing `AGW_ARTIFACT` environment variable. See failure pattern in e.g. https://github.com/magma/magma/actions/runs/4475878599/jobs/7866028423#logs.

## Test Plan

CI - but only on master runs.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

