### PR TITLE
fix(pipelined): Meaningful naming of function

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement.py
@@ -359,7 +359,7 @@ class EnforcementController(PolicyMixin, RestartMixin, MagmaController):
             for rule_id in rule_ids:
                 self._deactivate_flow_for_rule(imsi, ip_addr, rule_id)
 
-    def _skip_extra_flows_removal(self):
+    def _skip_extra_flows_removal_stateless(self):
         """
         Returns redis_enabled flag value
         Traffic is not getting resumed on service restart in case of stateless.

--- a/lte/gateway/python/magma/pipelined/app/restart_mixin.py
+++ b/lte/gateway/python/magma/pipelined/app/restart_mixin.py
@@ -128,7 +128,7 @@ class RestartMixin(metaclass=ABCMeta):
                 [flow.match for flow in startup_flows_map[tbl]],
             )
 
-        if self._skip_extra_flows_removal():
+        if self._skip_extra_flows_removal_stateless():
             logging.info("skipping removal of enforcement flows since it is in stateless mode")
         else:
             self._remove_extra_flows(startup_flows_map)
@@ -157,7 +157,7 @@ class RestartMixin(metaclass=ABCMeta):
             chan = self._msg_hub.send(msg_list, self._datapath)
             self._wait_for_responses(chan, len(msg_list))
 
-    def _skip_extra_flows_removal(self):
+    def _skip_extra_flows_removal_stateless(self):
         """
         This method can be overridden by controllers.
         Skips removal of extra flows in case of stateless mode.


### PR DESCRIPTION
## Summary

For skip the extra flows removal for stateless case only.
If redis flag is enabled then will not remove the flows from enforcement table.
The naming of function was not coming clear, so changed the name of the function.

Minor cleanup.