### PR TITLE
fix(amf): Registration request of Mobility updating registration type

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/Registration.cpp
@@ -228,7 +228,10 @@ status_code_e amf_proc_registration_request(
   /* Implicit deregistartion of existing context should be triggered if
    * same TMSI used and trigger fresh registration request*/
   if (ies->guti) {
-    if (ies->m5gsregistrationtype != AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) {
+    if ((ies->m5gsregistrationtype !=
+         AMF_REGISTRATION_TYPE_PERIODIC_UPDATING) &&
+        (ies->m5gsregistrationtype !=
+         AMF_REGISTRATION_TYPE_MOBILITY_UPDATING)) {
       amf_app_desc_t* amf_app_desc_p = get_amf_nas_state(false);
       if (amf_app_desc_p == NULL) {
         OAILOG_WARNING(LOG_NAS_AMF, " amf_app_desc_p null, from %s\n",


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Issue: AGW is not sending a response back to REG_REQ of type MOBILITY UPDATING REGISTRATION TYPE when UE is in active state. 

Steps to reproduce:
1. Perform registration + pdu session
2. Do not deregister or release (Let the ue be in active state)
3. Send registration of type mobility registration updating.

Fix:
- Added the flow which allows AGW to accept or reject the mobility updating registration request.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
1. Tested with Spirent tool.
![image](https://user-images.githubusercontent.com/89975652/231355858-9507f3ef-a8c7-4e2f-80cc-eb645b1ac386.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

