### PR TITLE
chore: configure dependency update tool

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+# This is configured to only require security updates and exclude version updates, you can set open-pull-requests-limit to 0.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0


### PR DESCRIPTION
chore: configure dependency update tool

See https://github.com/magma/security/issues/144

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Magma configures Dependabot using the Github UI instead of a dependabot.yml file. This prevents automated verification of secure configuration.

The change should have no developer-visible impacts.

Related issue: https://github.com/magma/security/issues/144

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
I pushed the identical change to my personal fork and left it for a week to be sure no unwanted PRs were being submitted. It worked.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->
A net improvement to security by enabling automated checking.

