### PR TITLE
fix(nms): nginx ssl issue

### DIFF
--- a/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
+++ b/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
@@ -318,6 +318,8 @@ describe('<TrafficDashboard APNs/>', () => {
   const networkId = 'test';
 
   beforeEach((): void => {
+    // @ts-ignore
+    delete window.location;
     window.location = {
       pathname: '/nms/test/traffic/apn',
     } as Location;

--- a/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
+++ b/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
@@ -318,8 +318,6 @@ describe('<TrafficDashboard APNs/>', () => {
   const networkId = 'test';
 
   beforeEach((): void => {
-    // @ts-ignore
-    delete window.location;
     window.location = {
       pathname: '/nms/test/traffic/apn',
     } as Location;

--- a/nms/docker/docker_ssl_proxy/proxy_ssl.conf
+++ b/nms/docker/docker_ssl_proxy/proxy_ssl.conf
@@ -1,6 +1,5 @@
 server {
-  listen 443;
-  ssl on;
+  listen 443 ssl;
   ssl_certificate /etc/nginx/conf.d/cert.pem;
   ssl_certificate_key /etc/nginx/conf.d/key.pem;
   location / {


### PR DESCRIPTION
Below error is observed when creating orc8r pods:
2023/06/15 13:34:36 [emerg] 1#1: unknown directive "ssl" in /etc/nginx/conf.d/nginx_proxy_ssl.conf:3
nginx: [emerg] unknown directive "ssl" in /etc/nginx/conf.d/nginx_proxy_ssl.conf:3

orc8r            nms-nginx-proxy-7454448447-xzc8l                 0/1     CrashLoopBackOff   7 (119s ago)   16m