### PR TITLE
fix(nms): nms yarn test filed

### DIFF
--- a/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
+++ b/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
@@ -318,6 +318,7 @@ describe('<TrafficDashboard APNs/>', () => {
   const networkId = 'test';
 
   beforeEach((): void => {
+    // @ts-ignore
     delete window.location;
     window.location = {
       pathname: '/nms/test/traffic/apn',

--- a/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
+++ b/nms/app/views/traffic/__tests__/TrafficOverviewTest.tsx
@@ -318,6 +318,7 @@ describe('<TrafficDashboard APNs/>', () => {
   const networkId = 'test';
 
   beforeEach((): void => {
+    delete window.location;
     window.location = {
       pathname: '/nms/test/traffic/apn',
     } as Location;


### PR DESCRIPTION
## Summary

It's failing on latest CI/CD check and getting below errors:
```
Summary of all failing tests
FAIL app/views/traffic/__tests__/TrafficOverviewTest.tsx (8.891 s)
  ● <TrafficDashboard APNs/> › renders

    TypeError: Cannot redefine property: location

      319 |
      320 |   beforeEach((): void => {
    > 321 |     window.location = {
          |     ^
      322 |       pathname: '/nms/test/traffic/apn',
      323 |     } as Location;
      324 |

      at Object.<anonymous> (app/views/traffic/__tests__/TrafficOverviewTest.tsx:321:5)
```
## Test Plan

CI/CD run

