### PR TITLE
fix(ci): td-agent-bit version pinning (#15164)

### DIFF
--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -143,7 +143,7 @@ RUN apt-get update && apt-get install -y \
   openvswitch-datapath-dkms \
   openvswitch-common \
   openvswitch-switch \
-  td-agent-bit \
+  td-agent-bit=1.7.8 \
   wireguard \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Changes:
  1. Pinned the version of td-agent-bit

Testing:
  1. Deployed the docker agw and verified the version
  2. Using netstat verified the connection is established
  3. Events are getting posted to orc8r

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

