### PR TITLE
fix(feg): s6a_proxy: Handle ULA Served-Party-IP-Address AVP

### DIFF
--- a/feg/gateway/services/s6a_proxy/servicers/s6a_definitions.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_definitions.go
@@ -173,6 +173,7 @@ type APNConfiguration struct {
 	EPSSubscribedQoSProfile     EPSSubscribedQoSProfile `avp:"EPS-Subscribed-QoS-Profile"`
 	AMBR                        AMBR                    `avp:"AMBR"`
 	TgppChargingCharacteristics string                  `avp:"TGPP-Charging-Characteristics"`
+	ServedPartyIpAddress        []string                `avp:"Served-Party-IP-Address"`
 }
 
 type APNConfigurationProfile struct {


### PR DESCRIPTION
## Summary

An Update Location Answer (ULA) may contain, inside the APN configuration, an IPv4 address and an IPv6 address assigned by the HSS (i.e., the Served-Party-IP-Address AVP, which is optional). The s6a_proxy at the FeG would receive the Served-Party-IP-Address AVP in the ULA from an HSS, as visible in the logs, but would not process it when sending the data in protobuffer (e.g., to the AGW).

This patch adds the missing lines to handle the Served-Party-IP-Address AVP in a ULA, and include it in the protobuffer representation of the APN it belongs to.

## Test Plan

Using the `s6a_cli` tool from #15277 , the `ulr` command receives the following `ULA` from an external HSS via the FeG. The `ULA` which contains three APNs (one with an IPv4, one with an IPv6, one with both). Before this patch, no IP address was returned inside the gRPC message by the FeG. Now, they are:
```
vagrant@intrepid-gs41-magma-v1p8pp-agw-cppx:~$ s6a_cli ulr -remote_s6a 001010000036480
Using IMSI: 1010000036480; MCC: 101; MNC: 000; PLMN ID: [1 1 0]
Using S6a_proxy through Orc8r
Start sending requests to 1
Sending ULR to localhost:9098:
{
 "userName": "001010000036480",
 "visitedPlmn": "AQEA",
 "skipSubscriberData": false,
 "initialAttach": true,
 "dualRegistration5gIndicator": true,
 "featureListId2": null,
 "featureListId1": null
}
&protos.UpdateLocationRequest{state:impl.MessageState{NoUnkeyedLiterals:pragma.NoUnkeyedLiterals{}, DoNotCompare:pragma.DoNotCompare{}, DoNotCopy:pragma.DoNotCopy{}, atomicMessageInfo:(*impl.MessageInfo)(0xc000346290)}, sizeCache:0, unknownFields:[]uint8(nil), UserName:"001010000036480", VisitedPlmn:[]uint8{0x1, 0x1, 0x0}, SkipSubscriberData:false, InitialAttach:true, DualRegistration_5GIndicator:true, FeatureListId_2:(*protos.FeatureListId2)(nil), FeatureListId_1:(*protos.FeatureListId1)(nil)}

Received ULR:
{
 "errorCode": "UNDEFINED",
 "defaultContextId": 1,
 "totalAmbr": {
  "maxBandwidthUl": 1073741824,
  "maxBandwidthDl": 1073741824,
  "unit": "BPS"
 },
 "allApnsIncluded": true,
 "apn": [
  {
   "contextId": 1,
   "serviceSelection": "internet",
   "qosProfile": {
    "classId": 5,
    "priorityLevel": 1,
    "preemptionCapability": true,
    "preemptionVulnerability": true
   },
   "ambr": {
    "maxBandwidthUl": 524288,
    "maxBandwidthDl": 2097152,
    "unit": "BPS"
   },
   "pdn": "IPV4V6",
   "chargingCharacteristics": "",
   "servedPartyIpAddress": [
    "65.97.142.254"
   ],
   "resource": null
  },
  {
   "contextId": 2,
   "serviceSelection": "volte",
   "qosProfile": {
    "classId": 65,
    "priorityLevel": 9,
    "preemptionCapability": true,
    "preemptionVulnerability": true
   },
   "ambr": {
    "maxBandwidthUl": 1048576,
    "maxBandwidthDl": 1048576,
    "unit": "BPS"
   },
   "pdn": "IPV4V6",
   "chargingCharacteristics": "",
   "servedPartyIpAddress": [
    "f016:cff9::b857"
   ],
   "resource": null
  },
  {
   "contextId": 3,
   "serviceSelection": "intranet",
   "qosProfile": {
    "classId": 5,
    "priorityLevel": 1,
    "preemptionCapability": false,
    "preemptionVulnerability": false
   },
   "ambr": {
    "maxBandwidthUl": 1073741824,
    "maxBandwidthDl": 1073741824,
    "unit": "BPS"
   },
   "pdn": "IPV4V6",
   "chargingCharacteristics": "",
   "servedPartyIpAddress": [
    "12.12.12.13",
    "1bac:79f7::6fa9:f3f2"
   ],
   "resource": null
  }
 ],
 "defaultChargingCharacteristics": "",
 "msisdn": null,
 "networkAccessMode": "PACKET_AND_CIRCUIT",
 "regionalSubscriptionZoneCode": [
 ],
 "featureListId2": null,
 "featureListId1": null
}
default_context_id:1  total_ambr:{max_bandwidth_ul:1073741824  max_bandwidth_dl:1073741824}  all_apns_included:true  apn:{context_id:1  service_selection:"internet"  qos_profile:{class_id:5  priority_level:1  preemption_capability:true  preemption_vulnerability:true}  ambr:{max_bandwidth_ul:524288  max_bandwidth_dl:2097152}  pdn:IPV4V6  served_party_ip_address:"65.97.142.254"}  apn:{context_id:2  service_selection:"volte"  qos_profile:{class_id:65  priority_level:9  preemption_capability:true  preemption_vulnerability:true}  ambr:{max_bandwidth_ul:1048576  max_bandwidth_dl:1048576}  pdn:IPV4V6  served_party_ip_address:"f016:cff9::b857"}  apn:{context_id:3  service_selection:"intranet"  qos_profile:{class_id:5  priority_level:1}  ambr:{max_bandwidth_ul:1073741824  max_bandwidth_dl:1073741824}  pdn:IPV4V6  served_party_ip_address:"12.12.12.13"  served_party_ip_address:"1bac:79f7::6fa9:f3f2"}
2023/08/03 15:18:55 
All request (1) got a response
```
## Additional Information

- [ ] This change is backwards-breaking
- [x] This change can be back ported to Magma `v1.8`.

## Security Considerations

N/A
