### PR TITLE
fix(pipelined): QOS test cases pertaining to bitrate units

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
@@ -63,7 +63,7 @@ class MeterManager(object):
 
     # pylint:disable=unused-argument
     def add_qos(
-        self, _, qos_info: QosInfo, cleanup_rule,
+        self, _, qos_info: QosInfo, cleanup_rule, units='',
         parent=None, skip_filter=False,
     ) -> int:
         if self._qos_impl_broken:

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops_pyroute2.py
@@ -49,6 +49,7 @@ class TcOpsPyRoute2(TcOpsBase):
             qid: qid number.
             max_bw: ceiling in bits per sec.
             rate: rate limiting.
+            units: bit/kbit
             parent_qid: HTB parent queue.
 
         Returns:
@@ -139,10 +140,10 @@ class TcOpsPyRoute2(TcOpsBase):
         return 0
 
     def create(
-        self, iface: str, qid: str, max_bw: int, rate=None,
+        self, iface: str, qid: str, max_bw: int, units: str, rate=None,
         parent_qid: Optional[str] = None, proto=PROTOCOL,
     ) -> int:
-        err = self.create_htb(iface, qid, max_bw, rate, parent_qid)
+        err = self.create_htb(iface, qid, max_bw, rate, units, parent_qid)
         if err:
             return err
         err = self.create_filter(iface, qid, qid, proto)

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -198,8 +198,8 @@ get_action_instruction",
         imsi, ip_addr, rule_num, qos_info = "1234", '1.1.1.1', 0, QosInfo(100000, 100000)
 
         # add new subscriber qos queue
-        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.UPLINK, qos_info)
-        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.DOWNLINK, qos_info)
+        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, 'bit', rule_num, FlowMatch.UPLINK, qos_info)
+        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, 'bit', rule_num, FlowMatch.DOWNLINK, qos_info)
 
         k1 = get_key_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.UPLINK))
         k2 = get_key_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.DOWNLINK))
@@ -215,8 +215,9 @@ get_action_instruction",
 
         # add the same subscriber and ensure that we didn't create another
         # qos config for the subscriber
-        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.UPLINK, qos_info)
-        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.DOWNLINK, qos_info)
+
+        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, 'bit', rule_num, FlowMatch.UPLINK, qos_info)
+        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, 'bit', rule_num, FlowMatch.DOWNLINK, qos_info)
 
         self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, ul_qid_info))
         self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, dl_qid_info))
@@ -324,7 +325,7 @@ get_action_instruction",
 
         # add new subscriber qos queues
         for i, (imsi, rule_num, d) in enumerate(rule_list1):
-            qos_mgr.add_subscriber_qos(imsi, '', 0, rule_num, d, qos_info)
+            qos_mgr.add_subscriber_qos(imsi, '', 0, 'bit', rule_num, d, qos_info)
 
             exp_id = id_list[i]
             k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
@@ -409,7 +410,7 @@ get_action_instruction",
 
         # add new subscriber qos queues
         for i, (imsi, rule_num, d) in enumerate(rule_list2):
-            qos_mgr.add_subscriber_qos(imsi, '', 0, rule_num, d, qos_info)
+            qos_mgr.add_subscriber_qos(imsi, '', 0, 'bit', rule_num, d, qos_info)
             exp_id = id_list[i]
             qid_info = get_data_json(get_subscriber_data(exp_id, 0, 0))
 
@@ -516,7 +517,7 @@ get_action_instruction",
         # add a new rule to the qos_mgr and check if it is assigned right id
         imsi, rule_num, d, qos_info = "3", 0, 0, QosInfo(100000, 100000)
         qos_mgr.impl.get_action_instruction = MagicMock
-        qos_mgr.add_subscriber_qos(imsi, '', 0, rule_num, d, qos_info)
+        qos_mgr.add_subscriber_qos(imsi, '', 0, 'bit', rule_num, d, qos_info)
         k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
 
         exp_id = 3  # since start_idx 2 is already used
@@ -669,7 +670,7 @@ get_action_instruction",
         # add a new rule to the qos_mgr and check if it is assigned right id
         imsi, rule_num, d, qos_info = "3", 0, 0, QosInfo(100000, 100000)
         qos_mgr.impl.get_action_instruction = MagicMock
-        qos_mgr.add_subscriber_qos(imsi, '', 10, rule_num, d, qos_info)
+        qos_mgr.add_subscriber_qos(imsi, '', 10, 'bit', rule_num, d, qos_info)
         k = get_key_json(get_subscriber_key(imsi, '', rule_num, d))
 
         exp_id = 3  # since start_idx 2 is already used
@@ -789,10 +790,11 @@ get_action_instruction",
         qos_mgr._setupInternal()
         ambr_ul, ambr_dl = 250000, 500000
         imsi, ip_addr, rule_num, qos_info = ("1234", '1.1.1.1', 1, QosInfo(50000, 100000))
+        units = 'bit'
 
         # add new subscriber qos queue
-        qos_mgr.add_subscriber_qos(imsi, ip_addr, ambr_ul, rule_num, FlowMatch.UPLINK, qos_info)
-        qos_mgr.add_subscriber_qos(imsi, ip_addr, ambr_dl, rule_num, FlowMatch.DOWNLINK, qos_info)
+        qos_mgr.add_subscriber_qos(imsi, ip_addr, ambr_ul, units, rule_num, FlowMatch.UPLINK, qos_info)
+        qos_mgr.add_subscriber_qos(imsi, ip_addr, ambr_dl, units, rule_num, FlowMatch.DOWNLINK, qos_info)
 
         k1 = get_key_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.UPLINK))
         k2 = get_key_json(get_subscriber_key(imsi, ip_addr, rule_num, FlowMatch.DOWNLINK))
@@ -817,8 +819,8 @@ get_action_instruction",
 
         # add the same subscriber and ensure that we didn't create another
         # qos config for the subscriber
-        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.UPLINK, qos_info)
-        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, rule_num, FlowMatch.DOWNLINK, qos_info)
+        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, units, rule_num, FlowMatch.UPLINK, qos_info)
+        qos_mgr.add_subscriber_qos(imsi, ip_addr, 0, units, rule_num, FlowMatch.DOWNLINK, qos_info)
 
         self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][0] == (0, get_data_json(qid_info_ul)))
         self.assertTrue(qos_mgr._subscriber_state[imsi].rules[rule_num][1] == (1, get_data_json(qid_info_dl)))
@@ -906,11 +908,11 @@ class TestTrafficClass(unittest.TestCase):
         TrafficClass.init_qdisc(intf, show_error=False)
 
         # create APN level ambr
-        TrafficClass.create_class(intf, qid=parent_qid, max_bw=apn_ambr)
+        TrafficClass.create_class(intf, qid=parent_qid, units='bit', max_bw=apn_ambr)
 
         # create child queue
         TrafficClass.create_class(
-            intf, qid=qid, rate=bearer_gbr, max_bw=bearer_mbr,
+            intf, qid=qid, rate=bearer_gbr, units='bit', max_bw=bearer_mbr,
             parent_qid=parent_qid,
         )
 

--- a/lte/gateway/python/magma/pipelined/tests/test_qos_pyroute2.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos_pyroute2.py
@@ -63,10 +63,11 @@ class TcSetypTest(unittest.TestCase):
         iface = cls.IFACE
         qid = "0xae"
         max_bw = 10000
+        units = 'bit'
         rate = 1000
         parent_qid = '1:fffe'
 
-        err1 = t1.create(iface, qid, max_bw, rate, parent_qid)
+        err1 = t1.create(iface, qid, max_bw, units, rate, parent_qid)
         self.assertTrue(self.check_qid_in_tc(qid))
         err = t1.delete(iface, qid)
         self.assertFalse(self.check_qid_in_tc(qid))
@@ -79,10 +80,11 @@ class TcSetypTest(unittest.TestCase):
         iface = cls.IFACE
         qid = "0xae"
         max_bw = 10000
+        units = 'bit'
         rate = 1000
         parent_qid = '1:fffe'
 
-        err1 = t1.create(iface, qid, max_bw, rate, parent_qid, proto=0x86DD)
+        err1 = t1.create(iface, qid, max_bw, units, rate, parent_qid, proto=0x86DD)
         self.assertTrue(self.check_qid_in_tc(qid))
         err = t1.delete(iface, qid, proto=0x86DD)
         self.assertFalse(self.check_qid_in_tc(qid))
@@ -97,10 +99,11 @@ class TcSetypTest(unittest.TestCase):
         iface1 = cls.IFACE
         qid1 = "0xae"
         max_bw = 10000
+        units = 'bit'
         rate = 1000
         parent_qid1 = '1:fffe'
 
-        err1 = t1.create(iface1, qid1, max_bw, rate, parent_qid1)
+        err1 = t1.create(iface1, qid1, max_bw, units, rate, parent_qid1)
         self.assertTrue(self.check_qid_in_tc(qid1))
 
         # Second queue
@@ -110,7 +113,7 @@ class TcSetypTest(unittest.TestCase):
         rate = 1000
         parent_qid2 = '1:' + qid1
 
-        err1 = t1.create(iface1, qid2, max_bw, rate, parent_qid2)
+        err1 = t1.create(iface1, qid2, max_bw, units, rate, parent_qid2)
         self.assertTrue(self.check_qid_in_tc(qid2))
         # t1._print_classes(iface1)
         # t1._print_filters(iface1)
@@ -132,10 +135,11 @@ class TcSetypTest(unittest.TestCase):
         iface = cls.IFACE
         qid = "0xae"
         max_bw = 10000
+        units = 'bit'
         rate = 1000
         parent_qid = '1:fffe'
 
-        err1 = t1.create(iface, qid, max_bw, rate, parent_qid)
+        err1 = t1.create(iface, qid, max_bw, units, rate, parent_qid)
         self.assertTrue(self.check_qid_in_tc(qid))
 
         err = t2.del_filter(iface, qid, qid)
@@ -155,9 +159,10 @@ class TcSetypTest(unittest.TestCase):
         qid = "0xae"
         max_bw = 10000
         rate = 1000
+        unit = 'bit'
         parent_qid = '1:fffe'
 
-        err1 = t2.create_htb(iface, qid, max_bw, rate, parent_qid)
+        err1 = t2.create_htb(iface, qid, max_bw, rate, unit, parent_qid)
         self.assertEqual(err1, 0)
         err1 = t2.create_filter(iface, qid, qid)
         self.assertEqual(err1, 0)


### PR DESCRIPTION
## Summary

Fixes following degraded `Pipelined` - `QOS` test cases :
* `test_qos.py`
* `test_qos_pyroute2.py`

## Test Plan
* Tests run:
```bash
$MAGMA_ROOT/bazel/scripts/run_sudo_tests.sh
```
![image](https://github.com/magma/magma/assets/88073743/4a189323-f8ce-4940-8b88-a9b08c97a982)


