### PR TITLE
docs: Add rewards program documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Magma has three major components
 - [Code](https://github.com/magma): Source code
 - [Contributing](https://github.com/magma/magma/wiki/Contributor-Guide): Contributor Guide
 - [Wiki](https://wiki.magmacore.org/): Meeting notes and project team resources
+- [Rewards Program](REWARDS_PROGRAM.md): How to participate in the Magma rewards program
 
 ## Join the Magma community
 

--- a/REWARDS_PROGRAM.md
+++ b/REWARDS_PROGRAM.md
@@ -1,0 +1,29 @@
+# Magma Rewards Program
+
+## Summary
+The Magma rewards program is intended to attract new contributors, make them familiar with the project and enable monetary gain for specific contributions.
+
+## How The Rewards Program Works
+
+### Eligibilty
+The Magma rewards program uses Github sponsorships for payment. To receive a reward you must have an active Github sponsorship account.
+
+### Reward Eligible Github Issues
+Github issues eligible for a reward can be found in the table at the end of this document. All issues are assigned a level of complexity corresponding to the potential reward. All reward eligible issues and their complexity must be approved by a recorded TSC vote.
+
+Note, reward amounts are exclusive of any fees imposed by Github or Stripe. The final reward amount received can vary depending on fees.
+
+### Claim a Reward
+To claim a reward you must file a PR that resolves a reward eligible issue. The TSC will review the PR and make a determination via a weighted vote. Please note, filing a PR does not guarantee a reward and all TSC decisions are final. In the case of multiple folks submitting PRs, they will be evaluated in the order in which they were filed (oldest first).
+
+### Weighted Voting
+The leader of the working group who proposed the reward eligible issue has a weight of 2 votes for approval/rejection of the PR while remaining TSC members will have only 1 vote.
+
+### Receiving A Reward
+Once approved, rewards are paid via a Github sponsorship one-time payment.
+
+### List Of Reward Eligible GIthub Issues
+
+|Link To Issue|Complexity|Working Group Sponsor|Status|
+|---|---|---|---|---|---|
+|   |   |   |   |   |   |

--- a/REWARDS_PROGRAM.md
+++ b/REWARDS_PROGRAM.md
@@ -1,25 +1,31 @@
 # Magma Rewards Program
 
 ## Summary
+
 The Magma rewards program is intended to attract new contributors, make them familiar with the project and enable monetary gain for specific contributions.
 
 ## How The Rewards Program Works
 
 ### Eligibilty
+
 The Magma rewards program uses Github sponsorships for payment. To receive a reward you must have an active Github sponsorship account.
 
 ### Reward Eligible Github Issues
+
 Github issues eligible for a reward can be found in the table at the end of this document. All issues are assigned a level of complexity corresponding to the potential reward. All reward eligible issues and their complexity must be approved by a recorded TSC vote.
 
 Note, reward amounts are exclusive of any fees imposed by Github or Stripe. The final reward amount received can vary depending on fees.
 
 ### Claim a Reward
+
 To claim a reward you must file a PR that resolves a reward eligible issue. The TSC will review the PR and make a determination via a weighted vote. Please note, filing a PR does not guarantee a reward and all TSC decisions are final. In the case of multiple folks submitting PRs, they will be evaluated in the order in which they were filed (oldest first).
 
 ### Weighted Voting
+
 The leader of the working group who proposed the reward eligible issue has a weight of 2 votes for approval/rejection of the PR while remaining TSC members will have only 1 vote.
 
 ### Receiving A Reward
+
 Once approved, rewards are paid via a Github sponsorship one-time payment.
 
 ### List Of Reward Eligible GIthub Issues


### PR DESCRIPTION
Fixes #15293 

## Summary
Adds documentation for the Magma rewards program.

## Test Plan
Not applicable.

## Additional Information
Not applicable.

## Security Considerations
Not applicable.

