### PR TITLE
fix(amf): Added Security Indication IE

### DIFF
--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.c
@@ -1133,6 +1133,31 @@ int ngap_fill_pdu_session_resource_setup_request_transfer(
   qos_flow_add_or_modify_request_list_t* qos_list =
       &session_transfer->qos_flow_add_or_mod_request_list;
 
+  /*Security Indication*/
+  transfer_request_ie =
+      (Ngap_PDUSessionResourceSetupRequestTransferIEs_t*)calloc(
+          1, sizeof(Ngap_PDUSessionResourceSetupRequestTransferIEs_t));
+  transfer_request_ie->id = Ngap_ProtocolIE_ID_id_SecurityIndication;
+  transfer_request_ie->criticality = Ngap_Criticality_reject;
+  transfer_request_ie->value.present =
+      Ngap_PDUSessionResourceSetupRequestTransferIEs__value_PR_SecurityIndication;
+  transfer_request_ie->value.choice.SecurityIndication
+      .integrityProtectionIndication =
+      Ngap_IntegrityProtectionIndication_preferred;
+  transfer_request_ie->value.choice.SecurityIndication
+      .confidentialityProtectionIndication =
+      Ngap_ConfidentialityProtectionIndication_preferred;
+  Ngap_MaximumIntegrityProtectedDataRate_t*
+      Ngap_MaximumIntegrityProtectedDataRate =
+          (Ngap_MaximumIntegrityProtectedDataRate_t*)calloc(
+              1, sizeof(Ngap_MaximumIntegrityProtectedDataRate_t));
+  *Ngap_MaximumIntegrityProtectedDataRate =
+      Ngap_MaximumIntegrityProtectedDataRate_bitrate64kbs;
+  transfer_request_ie->value.choice.SecurityIndication
+      .maximumIntegrityProtectedDataRate_UL =
+      Ngap_MaximumIntegrityProtectedDataRate;
+  ASN_SEQUENCE_ADD(&transfer_request->protocolIEs.list, transfer_request_ie);
+
   /*Qos*/
   transfer_request_ie =
       (Ngap_PDUSessionResourceSetupRequestTransferIEs_t*)calloc(


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Issue: MME rejected gNB registration

Observations from Pcap comparison:
- Security indication IE missing in magma pcap 

Implemented security indication IE.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
 Tested with UERANSIM for service request scenario.
 Attached Pcap and Logs: [logs.zip](https://github.com/magma/magma/files/12738276/logs.zip)
 
![Screenshot from 2023-09-27 17-31-39](https://github.com/magma/magma/assets/89975652/0869d158-a305-4ca8-8d89-58ea8c608d09)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

