### PR TITLE
fix(orc8r): Stop web-inject attack on N/W creation

### DIFF
--- a/nms/server/network/routes.ts
+++ b/nms/server/network/routes.ts
@@ -112,7 +112,9 @@ router.post(
       if (!allowedNetworkTypes.includes(data.networkType?.toUpperCase())) {
         res
           .status(400)
-          .send(`please provide a valid network type like: LTE, FEG_LTE, CWF or FEG`)
+          .send(
+            `please provide a valid network type like: LTE, FEG_LTE, CWF or FEG`,
+          )
           .end();
         return;
       }

--- a/nms/server/network/routes.ts
+++ b/nms/server/network/routes.ts
@@ -109,7 +109,7 @@ router.post(
       const {name, description} = data;
       const allowedNetworkTypes = ['LTE', 'FEG_LTE', 'CWF', 'FEG'];
 
-      if (!allowedNetworkTypes.includes(data.networkType)) {
+      if (!allowedNetworkTypes.includes(data.networkType?.toUpperCase())) {
         res
           .status(400)
           .send(`please provide a valid network type like: LTE, FEG_LTE, CWF or FEG`)

--- a/nms/server/network/routes.ts
+++ b/nms/server/network/routes.ts
@@ -107,6 +107,15 @@ router.post(
     ) => {
       const {networkID, data} = req.body;
       const {name, description} = data;
+      const allowedNetworkTypes = ['LTE', 'FEG_LTE', 'CWF', 'FEG'];
+
+      if (!allowedNetworkTypes.includes(data.networkType)) {
+        res
+          .status(400)
+          .send(`please provide a valid network type like: LTE, FEG_LTE, CWF or FEG`)
+          .end();
+        return;
+      }
       const commonField = {
         name,
         description,


### PR DESCRIPTION
fix(orc8r): Stop web-inject attack on N/W creation

## Summary
- Whitelisted Network types to prevent web injection attacks,
- first, it will sanitize the input based on network type, if the client sends some malicious script to perform some attacks it will throw the error and exit the code.
- The only allowed Network Types are `LTE, FEG_LTE, CWF, FEG`,
## Test Plan
Tested manually by sending some web-inject script it filters the input and gives error