### PR TITLE
fix(ci): Fixes for liblsan0 packages in devcontainer and bazel base image

### DIFF
--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -70,7 +70,6 @@ RUN echo "Install general purpose packages" && \
         wget \
         zip
 
-
 RUN apt-get install -y --no-install-recommends \
         libtool=2.4.6-14 && \
     echo "Install Folly dependencies" && \

--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -70,6 +70,7 @@ RUN echo "Install general purpose packages" && \
         wget \
         zip
 
+
 RUN apt-get install -y --no-install-recommends \
         libtool=2.4.6-14 && \
     echo "Install Folly dependencies" && \

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -63,7 +63,7 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM_BAZEL_BASE }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE_BAZEL_BASE }}
-          PUSH_TO_REGISTRY: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}
+          PUSH_TO_REGISTRY: "true"
       - name: Build space left after run
         shell: bash
         run: |

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -15,6 +15,7 @@
 
 name: Magma Build Docker Image Bazel Base & DevContainer
 on:
+  workflow_dispatch: null
   push:
     branches:
       - master
@@ -53,9 +54,9 @@ env:
 jobs:
   build_dockerfile_bazel_base:
     if: |
-      github.event_name == 'push' &&
+      (github.event_name == 'push' &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma'
+      github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -88,9 +89,9 @@ jobs:
   build_dockerfile_devcontainer:
     needs: build_dockerfile_bazel_base
     if: |
-      github.event_name == 'push' &&
+      (github.event_name == 'push' &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma'
+      github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -88,7 +88,7 @@ jobs:
   build_dockerfile_devcontainer:
     needs: build_dockerfile_bazel_base
     if: |
-      (github.event_name == 'push' || github.event_name != 'schedule') &&
+      github.event_name == 'push' &&
       github.ref_name == 'master' &&
       github.repository_owner == 'magma'
     runs-on: ubuntu-20.04

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   build_dockerfile_bazel_base:
     if: |
-      (github.event_name == 'push' || github.event_name != 'schedule') &&
+      github.event_name == 'push' &&
       github.ref_name == 'master' &&
       github.repository_owner == 'magma'
     runs-on: ubuntu-20.04

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -52,6 +52,10 @@ env:
 
 jobs:
   build_dockerfile_bazel_base:
+    if: |
+      (github.event_name == 'push' || github.event_name != 'schedule') &&
+      github.ref_name == 'master' &&
+      github.repository_owner == 'magma'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -83,6 +87,10 @@ jobs:
 
   build_dockerfile_devcontainer:
     needs: build_dockerfile_bazel_base
+    if: |
+      (github.event_name == 'push' || github.event_name != 'schedule') &&
+      github.ref_name == 'master' &&
+      github.repository_owner == 'magma'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -94,7 +102,7 @@ jobs:
           IMAGE_STREAM: ${{ env.IMAGE_STREAM_DEVCONTAINER }}
           IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
           DOCKERFILE: ${{ env.DOCKERFILE_DEVCONTAINER }}
-          PUSH_TO_REGISTRY: ${{ github.event_name == 'push' && github.ref_name == 'master' && github.token != null }}
+          PUSH_TO_REGISTRY: "true"
       - name: Build space left after run
         shell: bash
         run: |


### PR DESCRIPTION
<!--
   fix(ci): Fixes for liblsan0 packages in devcontainer and bazel base image
-->

## Summary

LTE integration tests are failing

1.The Magma Vagrant images used for LTE integration tests contain the latest version of GCC along with the liblsan0 package.
2.However, the container image used to build the Magma Debian package contains an older version of GCC along with the liblsan0 package.
3.This inconsistency is causing the MME service of Magma to crash during the integration test

## Test Plan


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

