### PR TITLE
fix(ci): Fixes for liblsan0 packages in devcontainer and bazel base image

### DIFF
--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -56,7 +56,10 @@ jobs:
     if: |
       (github.event_name == 'push' &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch')
+      github.repository_owner == 'magma' || 
+      github.event_name == 'workflow_dispatch' &&
+      github.ref_name == 'master' &&
+      github.repository_owner == 'magma')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -91,7 +94,10 @@ jobs:
     if: |
       (github.event_name == 'push' &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch')
+      github.repository_owner == 'magma' || 
+      github.event_name == 'workflow_dispatch' &&
+      github.ref_name == 'master' &&
+      github.repository_owner == 'magma')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -54,12 +54,9 @@ env:
 jobs:
   build_dockerfile_bazel_base:
     if: |
-      (github.event_name == 'push' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma' ||
-      github.event_name == 'workflow_dispatch' &&
-      github.ref_name == 'master' &&
-      github.repository_owner == 'magma')
+      github.repository_owner == 'magma'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -92,12 +89,9 @@ jobs:
   build_dockerfile_devcontainer:
     needs: build_dockerfile_bazel_base
     if: |
-      (github.event_name == 'push' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma' ||
-      github.event_name == 'workflow_dispatch' &&
-      github.ref_name == 'master' &&
-      github.repository_owner == 'magma')
+      github.repository_owner == 'magma'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -15,6 +15,7 @@
 
 name: Magma Build Docker Image Bazel Base & DevContainer
 on:
+  workflow_dispatch: null
   push:
     branches:
       - master
@@ -53,9 +54,9 @@ env:
 jobs:
   build_dockerfile_bazel_base:
     if: |
-      github.event_name == 'push' &&
+      (github.event_name == 'push' &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma'
+      github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -88,9 +89,9 @@ jobs:
   build_dockerfile_devcontainer:
     needs: build_dockerfile_bazel_base
     if: |
-      github.event_name == 'push' &&
+      (github.event_name == 'push' &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma'
+      github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -56,7 +56,7 @@ jobs:
     if: |
       (github.event_name == 'push' &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma' || 
+      github.repository_owner == 'magma' ||
       github.event_name == 'workflow_dispatch' &&
       github.ref_name == 'master' &&
       github.repository_owner == 'magma')
@@ -94,7 +94,7 @@ jobs:
     if: |
       (github.event_name == 'push' &&
       github.ref_name == 'master' &&
-      github.repository_owner == 'magma' || 
+      github.repository_owner == 'magma' ||
       github.event_name == 'workflow_dispatch' &&
       github.ref_name == 'master' &&
       github.repository_owner == 'magma')


### PR DESCRIPTION
fix(ci): Fixes for liblsan0 packages in devcontainer and bazel base image


changes:
 1) Added the workflow_dispatch condition

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

LTE integration tests are failing

1.The Magma Vagrant images used for LTE integration tests contain the latest version of GCC along with the liblsan0 package.
2.However, the container image used to build the Magma Debian package contains an older version of GCC along with the liblsan0 package.
3.This inconsistency is causing the MME service of Magma to crash during the integration test



## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

