### PR TITLE
fix(amf): Added Service Accept handling in case of Service Request with uplink data status

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -24,6 +24,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+#include "lte/gateway/c/core/oai/include/amf_as_message.h"
 #include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/common/conversions.h"
 #include "lte/gateway/c/core/oai/include/map.h"
@@ -1561,6 +1562,8 @@ status_code_e amf_app_handle_notification_received(
   MessageDef* message_p = nullptr;
   itti_ngap_paging_request_t* ngap_paging_notify = nullptr;
   status_code_e rc = RETURNok;
+  amf_as_establish_t establish = {0};
+  nas5g_establish_rsp_t nas_msg = {0};
 
   imsi64_t imsi64;
   IMSI_STRING_TO_IMSI64(notification->imsi, &imsi64);
@@ -1626,7 +1629,16 @@ status_code_e amf_app_handle_notification_received(
 
     case UE_SERVICE_REQUEST_ON_PAGING:
       OAILOG_DEBUG(LOG_AMF_APP, "Service Accept notification received\n");
-      // TODO: Service Accept code to be implemented in upcoming PR
+      establish.ue_id = ue_context->amf_ue_ngap_id;
+      establish.nas_info = AMF_AS_NAS_INFO_SR;
+      establish.pdu_session_reactivation_status =
+          AMF_AS_PDU_SESSION_REACTIVATION_STATUS;
+      establish.pdu_session_status_ie =
+          (AMF_AS_PDU_SESSION_REACTIVATION_STATUS | AMF_AS_PDU_SESSION_STATUS);
+      establish.pdu_session_status = AMF_AS_PDU_SESSION_REACTIVATION_STATUS;
+      amf_as_establish_cnf(&establish, &nas_msg);
+      break;
+
     default:
       OAILOG_DEBUG(LOG_AMF_APP, "default case nothing to do\n");
       break;


### PR DESCRIPTION

<!--
fix(amf): Added Service Accept handling in case of Service Request with uplink data status
-->

## Summary
Added Service Accept code In case If the Uplink data status IE is included in the Service Request message.


## Test Plan

Tested with Ue-Ran-Sim. 
Steps followed:
    -Bring up 5g call flow.
    -Restart Gnb.
## Additional Information
As per the 3gpp spec 24.501
If the Uplink data status IE is included in the SERVICE REQUEST message and the UE is: a) not in NB-N1 mode; or b) in NB-N1 mode and the UE does not indicate a request to have user-plane resources established for a number of PDU sessions that exceeds the UE's maximum number of supported user-plane resources; the AMF shall: a) indicate the SMF to re-establish the user-plane resources for the corresponding PDU sessions; b) include the PDU session reactivation result IE in the SERVICE ACCEPT message to indicate the user-plane resources re-establishment result of the PDU sessions for which the UE requested to re-establish the user-plane resources; and c) determine the UE presence in LADN service area and forward the UE presence in LADN service area towards the SMF, if the corresponding PDU session is a PDU session for LADN.

[Packet2610.zip](https://github.com/magma/magma/files/13174687/Packet2610.zip)

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->


