### PR TITLE
fix(ci): Fixes for liblsan0 packages

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,7 @@ startup --host_jvm_args="-Xmx8g"
 build --announce_rc
 build --color=yes
 
-build:production --config=lsan --copt=-O3
+build:production 
 build:production --define=production=1
 
 # experimental_allow_tags_propagation means that tags will be propagated from


### PR DESCRIPTION
changes:
    - modified the .bazelrc file
    - removed flags in the production build

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Modified the .bazelrc to remove the sanitizer flag

## Issue Analysis
1. Leak Sanitizer Check is failing in the lsan lib init itself.
2. It is a gcc/sanitizer bug
3. It is here to stay in gcc10 which is now end-of-support. This is a bug in liblsan version 10.5.0(This is the official supported version in ubuntu20.04,gcc10).

## fixes

1. Disable the Leak Sanitizer entirely from the Production build. (Preferred as it unblocks v1.9 PRs)                               
2. Removing the --config=lsan --copt=O3 from profuction build fixes the issue.

## Test Plan
    - Build workflow jobs

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

