### PR TITLE
fix(amf): Fix for NG setup failure on N1 link restoration

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -1363,7 +1363,8 @@ static void amf_app_handle_ngap_ue_context_release(
       amf_nas_proc_implicit_deregister_ue_ind(ue_context_p->amf_ue_ngap_id);
     }
   } else {
-    if (cause == NGAP_RADIO_NR_GENERATED_REASON) {
+    if (cause == NGAP_RADIO_NR_GENERATED_REASON ||
+        cause == NGAP_SCTP_SHUTDOWN_OR_RESET) {
       int rc = RETURNerror;
       rc = ue_state_handle_message_initial(
           ue_context_p->mm_state, STATE_EVENT_CONTEXT_RELEASE, SESSION_NULL,
@@ -1373,7 +1374,7 @@ static void amf_app_handle_ngap_ue_context_release(
         OAILOG_WARNING(LOG_AMF_APP, "Failed transitioning to idle mode\n");
       }
 
-      amf_app_itti_ue_context_release(ue_context_p, NGAP_USER_INACTIVITY);
+      amf_app_itti_ue_context_release(ue_context_p, cause);
     }
   }
   OAILOG_FUNC_OUT(LOG_AMF_APP);
@@ -1446,8 +1447,8 @@ void amf_app_handle_gnb_deregister_ind(
     const itti_ngap_gNB_deregistered_ind_t* const gNB_deregistered_ind) {
   for (int i = 0; i < gNB_deregistered_ind->nb_ue_to_deregister; i++) {
     amf_app_handle_ngap_ue_context_release(
-        gNB_deregistered_ind->gnb_ue_ngap_id[i],
-        gNB_deregistered_ind->amf_ue_ngap_id[i], gNB_deregistered_ind->gnb_id,
+        gNB_deregistered_ind->amf_ue_ngap_id[i],
+        gNB_deregistered_ind->gnb_ue_ngap_id[i], gNB_deregistered_ind->gnb_id,
         NGAP_SCTP_SHUTDOWN_OR_RESET);
   }
 }

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf.c
@@ -351,7 +351,7 @@ void ngap_remove_ue(ngap_state_t* state, m5g_ue_description_t* ue_ref) {
   // NULL reference...
   if (ue_ref == NULL) return;
 
-  gnb_ue_ngap_id_t gnb_ue_ngap_id = ue_ref->gnb_ue_ngap_id;
+  amf_ue_ngap_id_t amf_ue_ngap_id = ue_ref->amf_ue_ngap_id;
   gNB_ref = ngap_state_get_gnb(state, ue_ref->sctp_assoc_id);
 
   // Updating number of UE
@@ -361,14 +361,14 @@ void ngap_remove_ue(ngap_state_t* state, m5g_ue_description_t* ue_ref) {
 
   hash_table_ts_t* state_ue_ht = get_ngap_ue_state();
   hashtable_ts_free(state_ue_ht, ue_ref->comp_ngap_id);
-  hashtable_ts_free(&state->amfid2associd, gnb_ue_ngap_id);
-  hashtable_uint64_ts_remove(&gNB_ref->ue_id_coll, gnb_ue_ngap_id);
+  hashtable_ts_free(&state->amfid2associd, amf_ue_ngap_id);
+  hashtable_uint64_ts_remove(&gNB_ref->ue_id_coll, amf_ue_ngap_id);
 
   imsi64_t imsi64 = INVALID_IMSI64;
   ngap_imsi_map_t* ngap_imsi_map = get_ngap_imsi_map();
 
   hashtable_uint64_ts_get(ngap_imsi_map->amf_ue_id_imsi_htbl,
-                          (const hash_key_t)gnb_ue_ngap_id, &imsi64);
+                          (const hash_key_t)amf_ue_ngap_id, &imsi64);
 
   delete_ngap_ue_state(imsi64);
 

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -2789,6 +2789,7 @@ TEST_F(AMFAppProcedureTest, SctpShutWithServiceRequest) {
                                         NGAP_INITIAL_CONTEXT_SETUP_REQ,
                                         NGAP_PDUSESSION_RESOURCE_SETUP_REQ,
                                         NGAP_PDUSESSIONRESOURCE_REL_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND,
                                         AMF_APP_NGAP_AMF_UE_ID_NOTIFICATION,
                                         NGAP_NAS_DL_DATA_REQ,
                                         NGAP_UE_CONTEXT_RELEASE_COMMAND,
@@ -2883,7 +2884,7 @@ TEST_F(AMFAppProcedureTest, SctpShutWithServiceRequest) {
   int res = RETURNerror;
 
   // Check the states of UE
-  res = check_ue_context_state(ue_id, REGISTERED_CONNECTED, M5GCM_IDLE);
+  res = check_ue_context_state(ue_id, REGISTERED_IDLE, M5GCM_IDLE);
   EXPECT_TRUE(res == RETURNok);
 
   // Service Request
@@ -3324,6 +3325,7 @@ TEST_F(AMFAppProcedureTest, GnbInitiatedNGReset) {
                                         NGAP_NAS_DL_DATA_REQ,
                                         NGAP_NAS_DL_DATA_REQ,
                                         NGAP_INITIAL_CONTEXT_SETUP_REQ,
+                                        NGAP_UE_CONTEXT_RELEASE_COMMAND,
                                         NGAP_GNB_INITIATED_RESET_ACK,
                                         NGAP_NAS_DL_DATA_REQ,
                                         NGAP_UE_CONTEXT_RELEASE_COMMAND,


### PR DESCRIPTION
## Summary

When N1 link is removed and inserted back, it did not get restored. There was a NG setup failure.
The reason for failure was that gNB state in AGW was in RESETTING state.
When N1 link is removed, SCTP link down notification is seen. At this point all the connected UEs on this gnb associations needs to be context cleaned and put into IDLE state. When all UEs info are cleaned up, gNB state will be changed from RESETTING to INIT. Post that NGAP init will be successful.

Fixes :
During SCTP down notification, UE context was not cleaned up due to

Mismatch in arguments used in call of amf_app_handle_ngap_ue_context_release () in amf_app_handle_gnb_deregister_ind()
In function ngap_remove_ue(), gnb_ue_id used to cleanup hash tables instead of amf_ue_id which is the key for the tables
In amf_app_handle_ngap_ue_context_release() function, context release calls not done for NGAP_SCTP_SHUTDOWN_OR_RESET without which proper cleanup does not happen in AMF and NGAP.

## Test Plan

Fixed failing Unit test cases and Tested.
**Logs:**
```bash
vagrant@magma-dev:~/magma$ sudo bazel test //lte/gateway/c/core/oai/test/amf:amf_procedures_test
INFO: Invocation ID: ed9e7c24-0ae2-43c6-af5e-86d1463b6aee
INFO: Reading 'startup' options from /home/vagrant/magma/.bazelrc: --output_base=/var/tmp/bazel, --host_jvm_args=-Xmx8g
INFO: Options provided by the client:
...

Target //lte/gateway/c/core/oai/test/amf:amf_procedures_test up-to-date:
  bazel-bin/lte/gateway/c/core/oai/test/amf/amf_procedures_test
INFO: Elapsed time: 3.170s, Critical Path: 1.09s
INFO: 4 processes: 2 disk cache hit, 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 4 total actions
//lte/gateway/c/core/oai/test/amf:amf_procedures_test                    PASSED in 0.6s

INFO: Build completed successfully, 4 total actions
vagrant@magma-dev:~/magma$ 
