### PR TITLE
fix(ci): federated tests docker-compose fix

### DIFF
--- a/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.yml
+++ b/lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.yml
@@ -43,13 +43,11 @@ x-pyservice_base: &pyservice_base
 
 # Use generic python anchor with logging capabilities to avoid repetition for python services
 x-pyservice: &pyservice
-  <<: *pyservice_base
-  <<: *depends_on_logs
+  <<: [*pyservice_base, *depends_on_logs]
 
 # Use generic go anchor to avoid repetition for go services
 x-goservice: &goservice
-  <<: *service
-  <<: *depends_on_logs
+  <<: [*service, *depends_on_logs]
   image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
 
 


### PR DESCRIPTION
## Summary

Patch the `lte/gateway/python/integ_tests/federated_tests/docker/docker-compose.yml` file to work with  `docker compose >= v2.17`

## Test Plan
Build in local developer environment with `Docker Compose version v2.21.0`
