### PR TITLE
fix(ci): Update the MacOS runner image

### DIFF
--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -64,7 +64,7 @@ jobs:
           args: 'CWF integration test: docker build step failed in run <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}> from commit ${{ github.sha }}: ${{ github.event.head_commit.message || github.event.pull_request.title }}'
   cwf-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-12
+    runs-on: macos-12-large
     needs: docker-build
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -77,7 +77,7 @@ jobs:
 
   federated-integ-test:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-12
+    runs-on: macos-12-large
     needs: [docker-build-orc8r, docker-build-feg]
     env:
       MAGMA_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   lte-integ-test-bazel-magma-deb:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-12
+    runs-on: macos-12-large
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   lte-integ-test-containerized:
-    runs-on: macos-12
+    runs-on: macos-12-large
     steps:
       - name: Show inputs
         run: |

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   sudo-python-tests:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-12
+    runs-on: macos-12-large
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Cache magma-dev-box


### PR DESCRIPTION
**Changes:**
 1) Updated the MacOS runner to large MacOS runner , as it's supporting the nested Virtualization

<!--
    fix(ci): Update the MacOS runner image
-->

## Summary

Due to inconsistency of MacOS 12  runner images ,
 we have modified the Workflows to use macos-12-large runner images

## Test Plan

Attaching the issue links for reference
[issue-8642](  https://github.com/actions/runner-images/issues/8642)
[Gurumeditation issue](https://github.com/actions/runner-images/issues/8730)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

