### PR TITLE
chore(deps): pin snowflake to v0.0.3 (#15352)

### DIFF
--- a/bazel/external/requirements.in
+++ b/bazel/external/requirements.in
@@ -9,7 +9,7 @@ pyyaml
 urllib3
 certifi
 sentry-sdk
-snowflake>=0.0.3
+snowflake==0.0.3
 #  prometheus_client==0.3.1 required (see e.g. magmad/tests/metrics_tests.py)
 prometheus_client==0.3.1
 redis-collections

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -78,7 +78,7 @@ setup(
         'pytz>=2014.4',
         'prometheus_client==0.3.1',
         'sentry_sdk>=1.5.0,<1.9',
-        'snowflake>=0.0.3',
+        'snowflake==0.0.3',
         'psutil==5.8.0',
         'cryptography>=1.9',
         'itsdangerous>=0.24',


### PR DESCRIPTION
The `snowflake` package used to create a UUID, e.g., for an AGW's `/etc/snowflake` file has been renamed to `snowflake-uuid`, and the former `snowflake` package has been taken over by a completely different piece of software. Pinning the package version to `v0.0.3` ensures that we fetch the latest available release of the former `snowflake` package, before the name change.

Fixes #15352 for Magma `v1.8`.

## Summary

The snowflake package dependency was pinned to v0.0.3 in both `bazel/external/requirements.in` and `orc8r/gateway/python/setup.py`. This ensures that the latest release of the former `snowflake` package is fetched and the `/etc/snowflake` file is generated correctly.

## Test Plan

Tested on a `v1.8` AGW in a Vagrant VM. The `magmad` service no longer complains about the snowflake package as detailed in #15352, and it correctly starts the rest of services. Also, the `show_gateway_info.py` reports a valid hardware ID (instead of miserably failing).

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

For `master` and upcoming `≥v1.9` Magma releases, the new package name `snowflake-uuid` shall be used.
