### PR TITLE
fix(agw): Upgrade ASN library to the new version

### DIFF
--- a/bazel/asn1c.bzl
+++ b/bazel/asn1c.bzl
@@ -148,7 +148,7 @@ def cc_asn1_library(
     """
     gen_name = name + "_genrule"
 
-    flags = "-pdu=all -fcompound-names -fno-include-deps -gen-PER -no-gen-example"
+    flags = "-pdu=all -fcompound-names -fno-include-deps  -no-gen-example"
 
     # Taken from https://github.com/magma/magma/blob/14c1cf643a61d576b3d24642e17ed3911d19210d/lte/gateway/c/core/oai/tasks/s1ap/CMakeLists.txt#L35
     # The original PR (PR2707) doesn't give an explanation on why this is necessary.

--- a/lte/gateway/c/core/oai/tasks/ngap/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/ngap/CMakeLists.txt
@@ -25,7 +25,7 @@ if( ${ASN1_SOURCE_DIR} IS_NEWER_THAN ${ngap_generate_code_done_flag})
 
     #Create NGAP_PDU structure without pointer references
     execute_process(
-        COMMAND bash "-c" "asn1c -pdu=all -fcompound-names -fno-include-deps -gen-PER -D ${GENERATED_FULL_DIR} ${ASN1_SOURCE_DIR} ${ASN1_ERR_FILTER}"
+        COMMAND bash "-c" "asn1c -pdu=all -fcompound-names -fno-include-deps -D ${GENERATED_FULL_DIR} ${ASN1_SOURCE_DIR} ${ASN1_ERR_FILTER}"
         RESULT_VARIABLE ret
     )
     if (NOT ${ret} STREQUAL 0)

--- a/lte/gateway/c/core/oai/tasks/s1ap/CMakeLists.txt
+++ b/lte/gateway/c/core/oai/tasks/s1ap/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ASN1_ERR_FILTER "2> >(grep -v \"Parameterized type\" | grep -v \"Compiled \"
 if (${ASN1_SOURCE_DIR} IS_NEWER_THAN ${s1ap_generate_code_done_flag})
     file(REMOVE ${GENERATED_FULL_DIR}/${ASN1C_PREFIX}*.c ${GENERATED_FULL_DIR}/${ASN1C_PREFIX}*.h)
     execute_process(
-        COMMAND bash "-c" "asn1c -pdu=all -fcompound-names -gen-PER -no-gen-example -fno-include-deps -D ${GENERATED_FULL_DIR} ${ASN1_SOURCE_DIR} ${ASN1_ERR_FILTER}"
+        COMMAND bash "-c" "asn1c -pdu=all -fcompound-names  -no-gen-example -fno-include-deps -D ${GENERATED_FULL_DIR} ${ASN1_SOURCE_DIR} ${ASN1_ERR_FILTER}"
         RESULT_VARIABLE ret
     )
     if (NOT ${ret} STREQUAL 0)

--- a/lte/gateway/c/core/oai/tasks/s1ap/generate_asn1
+++ b/lte/gateway/c/core/oai/tasks/s1ap/generate_asn1
@@ -23,7 +23,7 @@ cd $1
 shift
 
 ASNC1=$(which asn1c)
-${ASNC1:-asn1c} -gen-PER -fcompound-names  $* 2>&1 | grep -v -- '->' | grep -v '^Compiled' |grep -v sample
+${ASNC1:-asn1c}  -fcompound-names  $* 2>&1 | grep -v -- '->' | grep -v '^Compiled' |grep -v sample
 
 awk ' 
   BEGIN { 

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -150,7 +150,7 @@ RUN  git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
      wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
      git clone git://liblfds.org/liblfds && \
      git clone https://gitea.osmocom.org/cellular-infrastructure/libgtpnl && \
-     git clone https://github.com/OPENAIRINTERFACE/asn1c.git && \
+     git clone https://github.com/mouse07410/asn1c.git && \
      git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
      git clone https://github.com/nlohmann/json.git
 
@@ -275,8 +275,8 @@ RUN cd libgtpnl && \
 
 #####  asn1c
 RUN cd asn1c && \
-    # Moved git clone https://github.com/OPENAIRINTERFACE/asn1c.git && \
-    git checkout f12568d617dbf48497588f8e227d70388fa217c9 && \
+    # Moved git clone https://github.com/mouse07410/asn1c.git && \
+    git checkout ebed802 && \
     autoreconf -iv && \
     ./configure && \
     make -j`nproc` && \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -85,6 +85,7 @@ RUN  git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
      git clone git://liblfds.org/liblfds && \
      git clone https://gitea.osmocom.org/cellular-infrastructure/libgtpnl && \
      git clone https://github.com/OPENAIRINTERFACE/asn1c.git && \
+     git clone https://github.com/mouse07410/asn1c.git && \
      git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \
      git clone https://github.com/nlohmann/json.git
 
@@ -207,8 +208,8 @@ RUN cd libgtpnl && \
 
 #####  asn1c
 RUN cd asn1c && \
-    # Moved git clone https://github.com/OPENAIRINTERFACE/asn1c.git && \
-    git checkout f12568d617dbf48497588f8e227d70388fa217c9 && \
+    # Moved git clone https://github.com/mouse07410/asn1c.git && \
+    git checkout ebed802 && \
     autoreconf -iv && \
     ./configure && \
     make -j`nproc` && \

--- a/third_party/build/bin/asn1c_build.sh
+++ b/third_party/build/bin/asn1c_build.sh
@@ -22,10 +22,10 @@ set -e
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "${SCRIPT_DIR}"/../lib/util.sh
 
-COMMIT_DATE=20190423
+COMMIT_DATE=20221118
 # index of the commit from a particular date, start from 0
 COMMIT_INDEX=0
-COMMIT=f12568d6
+COMMIT=ebed802
 # 0~ makes the version compatible with real version numbers
 # 0~20160721+c3~r43c4a295 < 0~20160721+c5~r43c4a295 < 0~20160722+c0~r43c4a295 < 0.1
 ITERATION=0
@@ -64,7 +64,7 @@ if [ -d ${WORK_DIR} ]; then
 fi
 mkdir ${WORK_DIR}
 cd ${WORK_DIR}
-git clone https://gitlab.eurecom.fr/oai/asn1c.git
+git clone https://github.com/mouse07410/asn1c.git
 cd asn1c
 git checkout ${COMMIT} .
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Upgrade the ASN library to the new version

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
 upgrading asn1 compiler 
 -----------------------


 Step 1: Apply Patch to Magma Repo

 	# Navigate to the Magma repository
	cd magma

	# Apply the patch
	git apply upgrade_asn.patch


 Step 2: Build and Install ASN.1 Compiler (asn1c) from mouse07410

	# Clone the asn1c repository from mouse07410
	git clone https://github.com/mouse07410/asn1c.git

	# Navigate to the cloned repository
	cd asn1c

	# Configure with default settings
	test -f configure || autoreconf -iv
	./configure

	# Build the compiler
	make

	# Install the compiler into a standard location
	sudo make install
	
Step 3: Build Magma Code Base
	# Navigate back to the Magma repository if you're not already there
	cd path/to/magma

	# Build the Magma code base
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

