### PR TITLE
fix(orc8r): Sanitizing user input on N/W creation

### DIFF
--- a/nms/server/network/routes.ts
+++ b/nms/server/network/routes.ts
@@ -98,7 +98,7 @@ router.post(
             name: string;
             description: string;
             fegNetworkID?: string;
-            networkType: string;
+            networkType: typeof CWF | typeof FEG | typeof FEG_LTE | typeof LTE;
             servedNetworkIDs?: string;
           };
         }
@@ -107,13 +107,17 @@ router.post(
     ) => {
       const {networkID, data} = req.body;
       const {name, description} = data;
-      const allowedNetworkTypes = ['LTE', 'FEG_LTE', 'CWF', 'FEG'];
-
-      if (!allowedNetworkTypes.includes(data.networkType?.toUpperCase())) {
+      const allowedNetworkTypes: Array<typeof data['networkType']> = [
+        LTE,
+        FEG_LTE,
+        CWF,
+        FEG,
+      ];
+      if (!allowedNetworkTypes.includes(data.networkType)) {
         res
           .status(400)
           .send(
-            `please provide a valid network type like: LTE, FEG_LTE, CWF or FEG`,
+            `please provide a valid network type like: lte, feg_lte, feg or carrier_wifi_network`,
           )
           .end();
         return;
@@ -185,10 +189,7 @@ router.post(
             },
           });
         } else {
-          res
-            .status(400)
-            .send(`Unsupported network type ${data.networkType}`)
-            .end();
+          res.status(400).send(`Unsupported network type}`).end();
           return;
         }
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
Fixes security issues [#159](https://github.com/magma/security/issues/159)

## Summary

The current implementation includes sanitization of network inputs through the use of predefined `allowedNetworkTypes`. To enhance clarity and efficiency, this modification involves removing the reference to `data.networkType` from the else section.
## Test Plan

This change was validated manually by deliberately sending a web-inject script. The testing process confirmed that the input is effectively filtered, and the system appropriately responds with an error.
