### PR TITLE
fix(ci): Updating the git remote url of liblfds repo 

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -107,9 +107,9 @@ def cpp_repositories():
     new_git_repository(
         name = "liblfds",
         build_file = "//bazel/external:liblfds.BUILD",
-        commit = "b36a48014574225723779c7e1e9fb8cb6fa8f7f4",
-        remote = "https://liblfds.org/git/liblfds",
-        shallow_since = "1657356839 +0000",
+        commit = "d28d20e4750aa9e5b678639b2bb9d5b67a360819",
+        remote = "https://liblfds.org/git/liblfds7.1.1",
+        shallow_since = "1657357073 +0000",
     )
 
     new_git_repository(


### PR DESCRIPTION
CHANGES:
1) Modified the liblfds repo rule
2) Updated the git url to https://liblfds.org/git/liblfds7.1.1

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information
 We have compared the logs of earlier failure https://github.com/magma/magma/actions/runs/8438197431/job/23132058035?pr=15397#step:10:4207
 where it is failing in [builder 22/23] RUN bazel build step to clone the liblfds repo as it is outdated 
 
![image](https://github.com/magma/magma/assets/136717650/1b2efd15-ca97-478f-a1b0-71f00a102466)

 We have addressed this issue by updating the rule in the lilfds 
https://github.com/magma/magma/actions/runs/8509470809/job/23429077445?pr=15400#step:10:4576
![image](https://github.com/magma/magma/assets/136717650/f59a7fc8-8a9e-4e65-89e5-81080b802d3b)

 
 

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

