### PR TITLE
fix(mobilityd): Improving the logging message for IPv4v6 allocation er…

### DIFF
--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -225,7 +225,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
                 ipv4_address = ipv4_response.ip_list[0]
                 ipv6_address = ipv6_response.ip_list[0]
             except IndexError:
-                logging.warning("IPv4/IPv6 IP address allocation not successful")
+                logging.error("IPv4/IPv6 IP address allocation not successful, session will be rejected, check APN and/or UE configurations.")
                 resp = AllocateIPAddressResponse()
             else:
                 resp = AllocateIPAddressResponse(


### PR DESCRIPTION
fix(mobilityd) Improving the logging message for IPv4v6 allocation errors

The current message is misleading as it is "warning" instead of "error" as well as the description is not sufficient to understand the next steps for debugging

## Summary

During debugging of a connection issue the message had misled us to believe that the session establishment went in a normal path with a "warning'.

## Test Plan

No specific test is required as it is only change in the message severity and text was appended with additional explanations.


## Security Considerations

No security impact expected as the change is only with the severity of the message
