### PR TITLE
fix(mme): Replace insecure rand() with getrandom() for TMSI generation

### DIFF
--- a/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/api/mme/mme_api.cpp
@@ -39,6 +39,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/random.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -408,6 +409,9 @@ status_code_e mme_api_unsubscribe(bstring apn) {
 }
 
 static tmsi_t generate_random_TMSI() {
-  // note srand with seed is initialized at main
-  return (tmsi_t)rand();
+  tmsi_t tmsi = (tmsi_t)0;
+  if (getrandom((void*)&tmsi, sizeof(tmsi_t), 0) != sizeof(tmsi_t)) {
+    tmsi = (tmsi_t)rand();  // Fallback in case of fundamental system error
+  }
+  return tmsi;
 }


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR addresses the vulnerability related to predictable TMSI generation in Magma's Mobility Management Entity (MME). It replaces the current insecure method with a more robust approach, enhancing user privacy and security.

## Test Plan

Validate the new TMSI generation method.



## Security Considerations

The new TMSI generation method using `getrandom()` enhances security by providing unpredictable TMSI values, mitigating the risk of tracking user associations by adversaries.



