### PR TITLE
fix(mobilityd): Improving the logging message for IPv4v6 allocation errors

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_config.c
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_config.c
@@ -65,7 +65,7 @@ void nas5g_config_init(nas5g_config_t* nas_conf) {
   nas_conf->force_reject_tau = true;
   nas_conf->force_reject_sr = true;
   nas_conf->disable_esm_information = false;
-  nas_conf->enable_IMS_VoPS_3GPP = false;
+  nas_conf->enable_IMS_VoPS_3GPP = true;
 }
 
 /***************************************************************************

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -225,7 +225,7 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
                 ipv4_address = ipv4_response.ip_list[0]
                 ipv6_address = ipv6_response.ip_list[0]
             except IndexError:
-                logging.warning("IPv4/IPv6 IP address allocation not successful")
+                logging.error("IPv4/IPv6 IP address allocation not successful, session will be rejected, check APN and/or UE configurations.")
                 resp = AllocateIPAddressResponse()
             else:
                 resp = AllocateIPAddressResponse(


### PR DESCRIPTION
The current message is misleading as it is "warning" instead of "error" as well as the description is not sufficient to understand the next steps for debugging

## Summary

During debugging of a connection issue the message had misled us to believe that the session establishment went in a normal path with a "warning'.