### PR TITLE
fix(ci): ci/cd builds failing due to freediameter

### DIFF
--- a/third_party/build/bin/freediameter_build.sh
+++ b/third_party/build/bin/freediameter_build.sh
@@ -8,14 +8,14 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
+# See the License for the specific language governing permissions and 
 # limitations under the License.
 
 set -e
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 PATCHES_DIR="${SCRIPT_DIR}/../../../lte/gateway/c/core/oai/patches"
 source "${SCRIPT_DIR}"/../lib/util.sh
-GIT_URL=https://github.com/lionelgo/opencord.org.freeDiameter.git
+GIT_URL=https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git
 GIT_COMMIT=13b0e7de0d66906d50e074a339f890d6e59813ad
 PKGVERSION=0.0.1
 ITERATION=1


### PR DESCRIPTION

## Summary
This pull request addresses the issue of CI/CD builds failing due to problems with freediameter. The changes involve updating  the build script and dependencies to ensure compatibility and stability during the build process.

## Test Plan
Step 1: Apply Patch to Magma Repo
```
#Navigate to the Magma repository
cd magma
# Apply the patch
git apply freediameter_fix.patch
```
Step 2: Build and Install FreeDiameter
```
# Navigate to the third_party build directory
cd third_party/build
# Execute the build script
./bin/freediameter_build.sh
```
Step 3: Verify CI/CD Pipeline
```
# Commit the changes and push to the repository to trigger the CI/CD pipeline
git add .
git commit -m "Fix CI/CD build failures due to FreeDiameter"
git push origin <branch-name>
```
Step 4: Local Testing
```
# Run the updated build script locally on both Vagrant and bare-metal environments
cd third_party/build
./bin/freediameter_build.sh
```

Expected Outcome
The CI/CD pipeline should complete successfully without any errors related to FreeDiameter.



