### PR TITLE
fix(ci): Fixing the permission issue for the Backport workflow.

### DIFF
--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Backport Action
         uses: sqren/backport-github-action@f54e19901f2a57f8b82360f2490d47ee82ec82c6 # pin@v8.9.3
         with:
-          github_token: ${{ secrets.GIT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: apply-
 
       - name: Info log


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Backport workflow is failing due to permission issue. Found one odd secret has been used named `GIT_TOKEN` in this workflow as compared to other workflows. 

## Test Plan

Secrete `GITHUB_TOKEN` is being used in all different workflows and working fine. 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->



