### PR TITLE
fix(ci): Fixing the permission issue for the Backport workflow

### DIFF
--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Backport Action
         uses: sqren/backport-github-action@f54e19901f2a57f8b82360f2490d47ee82ec82c6 # pin@v8.9.3
         with:
-          github_token: ${{ secrets.GIT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: apply-
 
       - name: Info log


### PR DESCRIPTION

## Summary
Backport workflow is failing due to permission issue. Found one odd secret has been used named GIT_TOKEN in this workflow as compared to other workflows.

## Test Plan
Secrete GITHUB_TOKEN is being used in all different workflows and working fine.

## Additional Information

- [ ] This change is backwards-breaking


