### PR TITLE
fix(ci): Change endpoints

### DIFF
--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -88,7 +88,7 @@ RUN apt-get install -y --no-install-recommends \
 
 # setup magma artifactories and install magma dependencies
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-RUN add-apt-repository 'deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main' && \
+RUN add-apt-repository 'deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main' && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bcc-tools \

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -146,7 +146,7 @@ jobs:
           TARGET: gateway_go
       - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
       - name: Create and Push Release Tag
-        if: startsWith(github.ref, 'v1.')  
+        if: startsWith(github.ref,'v1.')  
         run: |
          echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"  
          RELEASE_TAG="${GITHUB_REF_NAME}"

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Create and Push Release Tag
         if: startsWith(github.ref_name, 'v1.')  
         run: |
-         echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"  # Debug line to check if GITHUB_REF_NAME is set correctly
+         echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"  
          RELEASE_TAG="${GITHUB_REF_NAME}"
          echo "Creating release tag for version ${RELEASE_TAG}"
          git tag -a "${RELEASE_TAG}" -m "Release version ${RELEASE_TAG}" 

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -95,17 +95,17 @@ jobs:
           python_image=${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}agw_gateway_python
           go_image=${{ steps.set-registry.outputs.registry }}/${{ steps.set-registry.outputs.image_prefix }}gateway_go
 
-          echo image_tag=${commit_hash} >> $GITHUB_OUTPUT
-          if [[ ${{ github.ref_name }} = master ]]
-          then
-            echo c_image_tags=${c_image}:${commit_hash},${c_image}:latest >> $GITHUB_OUTPUT
-            echo python_image_tags=${python_image}:${commit_hash},${python_image}:latest >> $GITHUB_OUTPUT
-            echo go_image_tags=${go_image}:${commit_hash},${go_image}:latest >> $GITHUB_OUTPUT
+          echo "image_tag=${commit_hash}" >> $GITHUB_OUTPUT
+          if [[ ${{ github.ref_name }} = master ]]; then
+            echo "c_image_tags=${c_image}:${commit_hash},${c_image}:latest,${c_image}:v1.9" >> $GITHUB_OUTPUT
+            echo "python_image_tags=${python_image}:${commit_hash},${python_image}:latest,${python_image}:v1.9" >> $GITHUB_OUTPUT
+            echo "go_image_tags=${go_image}:${commit_hash},${go_image}:latest,${go_image}:v1.9" >> $GITHUB_OUTPUT
           else
-            echo c_image_tags=${c_image}:${commit_hash} >> $GITHUB_OUTPUT
-            echo python_image_tags=${python_image}:${commit_hash} >> $GITHUB_OUTPUT
-            echo go_image_tags=${go_image}:${commit_hash} >> $GITHUB_OUTPUT
+            echo "c_image_tags=${c_image}:${commit_hash},${c_image}:v1.9" >> $GITHUB_OUTPUT
+            echo "python_image_tags=${python_image}:${commit_hash},${python_image}:v1.9" >> $GITHUB_OUTPUT
+            echo "go_image_tags=${go_image}:${commit_hash},${go_image}:v1.9" >> $GITHUB_OUTPUT
           fi
+
 
       - name: Print agwc tags
         run: |
@@ -145,6 +145,16 @@ jobs:
           TAGS: ${{ steps.set-agwc-tags.outputs.go_image_tags }}
           TARGET: gateway_go
       - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
+      - name: Create and Push Release Tag
+        if: startsWith(github.ref_name, 'v1.')  
+        run: |
+         echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"  # Debug line to check if GITHUB_REF_NAME is set correctly
+         RELEASE_TAG="${GITHUB_REF_NAME}"
+         echo "Creating release tag for version ${RELEASE_TAG}"
+         git tag -a "${RELEASE_TAG}" -m "Release version ${RELEASE_TAG}" 
+         git push origin refs/tags/"${RELEASE_TAG}" 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-containers-ghz:
     runs-on: ubuntu-20.04

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -146,7 +146,7 @@ jobs:
           TARGET: gateway_go
       - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
       - name: Create and Push Release Tag
-        if: startsWith(github.ref_name, 'v1.')  
+        if: startsWith(github.ref, 'v1.')  
         run: |
          echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"  
          RELEASE_TAG="${GITHUB_REF_NAME}"

--- a/.github/workflows/agw-coverage.yml
+++ b/.github/workflows/agw-coverage.yml
@@ -31,7 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BAZEL_CACHE_PLAIN_IMAGE: "ghcr.io/magma/magma/bazel-cache-plain:latest"
+  BAZEL_CACHE_PLAIN_IMAGE: "ghcr.io/magma/magma/bazel-cache-plain:sha-cd68e2b@sha256:2f7270c96f53be1dcf1a28847f916c0ee447c50f1ac2ad0fec976d34750e1e1d"
 
 jobs:
   path_filter:

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -32,7 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BAZEL_CACHE_PLAIN_IMAGE: "ghcr.io/magma/magma/bazel-cache-plain:latest"
+  BAZEL_CACHE_PLAIN_IMAGE: "ghcr.io/magma/magma/bazel-cache-plain:sha-cd68e2b@sha256:2f7270c96f53be1dcf1a28847f916c0ee447c50f1ac2ad0fec976d34750e1e1d"
 
 jobs:
   path_filter:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -32,7 +32,8 @@ on:
       - opened
       - reopened
       - synchronize
-
+    branches:
+      - 'release/*'
 env:
   BAZEL_BASE_IMAGE: "ghcr.io/magma/magma/bazel-base:latest"
   # Warning: the values of BAZEL_CACHE_PLAIN_IMAGE and BAZEL_CACHE_PROD_IMAGE
@@ -628,7 +629,7 @@ jobs:
       - name: Publish debian packages
         id: publish_agw_deb_pkg
         env:
-          DEBIAN_META_INFO: deb.distribution=focal-ci;deb.component=main;deb.architecture=amd64
+          DEBIAN_META_INFO: deb.distribution=focal-1.9.0;deb.component=main;deb.architecture=amd64
         run: |
           RESPONSE=$(jf rt upload \
                       --recursive=false \
@@ -638,7 +639,7 @@ jobs:
                       --password ${{ secrets.LF_JFROG_PASSWORD }} \
                       ${{ env.IS_DRY }} \
                       --target-props="${DEBIAN_META_INFO}" \
-                      "packages/(*).deb" magma-packages-test/pool/focal-ci/{1}.deb)
+                      "packages/(*).deb" magma-packages-test/pool/focal-1.9.0/{1}.deb)
 
           echo "Response:"
           echo $RESPONSE | jq

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -130,14 +130,14 @@ jobs:
           cd ${MAGMA_ROOT}/orc8r/cloud/docker
           python3 build.py --all --nocache
       - name: Create and Push Release Tag
-        if: startsWith(github.ref, 'refs/heads/v1')  
+        if: startsWith(github.ref,'refs/heads/v1')  
         run: |
           RELEASE_TAG="${GITHUB_REF_NAME}"
           echo "Creating release tag for version ${RELEASE_TAG}"
           echo "TAG=${RELEASE_TAG}" >> $GITHUB_ENV
       - name: Tag and push to Jfrog Registry
         id: publish_artifacts
-        if: startsWith(github.ref, 'refs/heads/v1')  
+        if: startsWith(github.ref,'refs/heads/v1')  
         env:
           DOCKER_REGISTRY: "linuxfoundation.jfrog.io/magma-docker-orc8r-test"
           DOCKER_USER: "${{ secrets.LF_JFROG_USERNAME }}"
@@ -269,7 +269,7 @@ jobs:
           echo "TAG=${RELEASE_TAG}" >> $GITHUB_ENV
       - name: Tag and push to Jfrog Registry
         id: publish_artifacts
-        if: startsWith(github.ref, 'refs/heads/v1')
+        if: startsWith(github.ref,'refs/heads/v1')
         env:
           DOCKER_REGISTRY: "linuxfoundation.jfrog.io/magma-docker-cwag-test"
           DOCKER_USER: "${{ secrets.LF_JFROG_USERNAME }}"
@@ -330,7 +330,7 @@ jobs:
           name: pr
           path: pr/
       - name: Create and Push Release Tag
-        if: startsWith(github.ref, 'refs/heads/v1')  
+        if: startsWith(github.ref,'refs/heads/v1')  
         run: |
           RELEASE_TAG="${GITHUB_REF_NAME}"
           echo "Creating release tag for version ${RELEASE_TAG}"
@@ -407,7 +407,7 @@ jobs:
           cd ${MAGMA_ROOT}/feg/gateway/docker
           python3 build.py -e
       - name: Create and Push Release Tag
-        if: startsWith(github.ref, 'refs/heads/v1')  
+        if: startsWith(github.ref,'refs/heads/v1')  
         run: |
           RELEASE_TAG="${GITHUB_REF_NAME}"
           echo "Creating release tag for version ${RELEASE_TAG}"

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,7 +13,7 @@
 # purpose: Building and publishing cloud and gateway components
 # remediation: https://magma.github.io/magma/docs/next/basics/quick_start_guide#terminal-tab-2-build-orchestrator (orc8r), https://magma.github.io/magma/docs/next/basics/quick_start_guide#using-the-nms-ui (nms-build), https://magma.github.io/magma/docs/next/feg/deploy_build (feg-build)
 
-name: Magma Build & Publish
+name: Magma Builds & Publish
 
 on:
   workflow_dispatch: null
@@ -129,18 +129,15 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/orc8r/cloud/docker
           python3 build.py --all --nocache
-      - name: Create release Tag
-        if: github.event_name == 'push'
+      - name: Create and Push Release Tag
+        if: startsWith(github.ref, 'refs/heads/v1')  
         run: |
-          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            echo TAG="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
-          else
-            GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-            echo TAG="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
-          fi
+          RELEASE_TAG="${GITHUB_REF_NAME}"
+          echo "Creating release tag for version ${RELEASE_TAG}"
+          echo "TAG=${RELEASE_TAG}" >> $GITHUB_ENV
       - name: Tag and push to Jfrog Registry
         id: publish_artifacts
-        if: github.event_name == 'push'
+        if: startsWith(github.ref, 'refs/heads/v1')  
         env:
           DOCKER_REGISTRY: "linuxfoundation.jfrog.io/magma-docker-orc8r-test"
           DOCKER_USER: "${{ secrets.LF_JFROG_USERNAME }}"
@@ -161,7 +158,7 @@ jobs:
           SLACK_ICON_EMOJI: ":boom:"
           SLACK_COLOR: "#FF0000"
           SLACK_FOOTER: ' '
-      # Notify ci channel when push succeeds
+      # Notify the ci channel when push succeeds
       - name: Notify success to Slack
         if: success() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 # pin@v2.2.0
@@ -264,18 +261,15 @@ jobs:
         with:
           name: pr
           path: pr/
-      - name: Create release Tag
-        if: github.event_name == 'push'
+      - name: Create and Push Release Tag
+        if: startsWith(github.ref, 'refs/heads/v1')  
         run: |
-          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            echo TAG="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
-          else
-            GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-            echo TAG="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
-          fi
+          RELEASE_TAG="${GITHUB_REF_NAME}"
+          echo "Creating release tag for version ${RELEASE_TAG}"
+          echo "TAG=${RELEASE_TAG}" >> $GITHUB_ENV
       - name: Tag and push to Jfrog Registry
         id: publish_artifacts
-        if: github.event_name == 'push'
+        if: startsWith(github.ref, 'refs/heads/v1')
         env:
           DOCKER_REGISTRY: "linuxfoundation.jfrog.io/magma-docker-cwag-test"
           DOCKER_USER: "${{ secrets.LF_JFROG_USERNAME }}"
@@ -335,18 +329,15 @@ jobs:
         with:
           name: pr
           path: pr/
-      - name: Create release Tag
-        if: github.event_name == 'push'
+      - name: Create and Push Release Tag
+        if: startsWith(github.ref, 'refs/heads/v1')  
         run: |
-          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            echo TAG="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
-          else
-            GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-            echo TAG="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
-          fi
+          RELEASE_TAG="${GITHUB_REF_NAME}"
+          echo "Creating release tag for version ${RELEASE_TAG}"
+          echo "TAG=${RELEASE_TAG}" >> $GITHUB_ENV
       - name: Tag and push to Jfrog Registry
         id: publish_artifacts
-        if: github.event_name == 'push'
+        if: startsWith(github.ref, 'refs/heads/v1')
         env:
           DOCKER_REGISTRY: "linuxfoundation.jfrog.io/magma-docker-cwag-test"
           DOCKER_USER: "${{ secrets.LF_JFROG_USERNAME }}"
@@ -382,7 +373,6 @@ jobs:
           SLACK_FOOTER: ''
   feg-build:
     if: github.repository_owner == 'magma'
-    name: feg-build
     runs-on: ubuntu-20.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
@@ -416,17 +406,15 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/feg/gateway/docker
           python3 build.py -e
-      - name: Create release Tag
+      - name: Create and Push Release Tag
+        if: startsWith(github.ref, 'refs/heads/v1')  
         run: |
-          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            echo TAG="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
-          else
-            GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-            echo TAG="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
-          fi
+          RELEASE_TAG="${GITHUB_REF_NAME}"
+          echo "Creating release tag for version ${RELEASE_TAG}"
+          echo "TAG=${RELEASE_TAG}" >> $GITHUB_ENV  
       - name: Tag and push to Jfrog Registry
         id: publish_artifacts
-        if: github.event_name == 'push'
+        if: startsWith(github.ref, 'refs/heads/v1')
         env:
           DOCKER_REGISTRY: "linuxfoundation.jfrog.io/magma-docker-feg-test"
           DOCKER_USER: "${{ secrets.LF_JFROG_USERNAME }}"
@@ -479,18 +467,15 @@ jobs:
         run: |
           cd ${MAGMA_ROOT}/nms
           COMPOSE_PROJECT_NAME=magmalte docker compose --compatibility build magmalte
-      - name: Create release Tag
-        if: github.event_name == 'push'
+      - name: Create and Push Release Tag
+        if: startsWith(github.ref, 'refs/heads/v1')  
         run: |
-          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            echo TAG="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
-          else
-            GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-            echo TAG="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
-          fi
+          RELEASE_TAG="${GITHUB_REF_NAME}"
+          echo "Creating release tag for version ${RELEASE_TAG}"
+          echo "TAG=${RELEASE_TAG}" >> $GITHUB_ENV  
       - name: Tag and push to Jfrog Registry
         id: publish_artifacts
-        if: github.event_name == 'push'
+        if: startsWith(github.ref, 'refs/heads/v1') 
         env:
           DOCKER_REGISTRY: "linuxfoundation.jfrog.io/magma-docker-orc8r-test"
           DOCKER_USER: "${{ secrets.LF_JFROG_USERNAME }}"
@@ -574,18 +559,15 @@ jobs:
         working-directory: "${{ github.workspace }}/dp"
         run: |
           make _install_skaffold_ci
-      - name: Create release Tag
-        if: github.event_name == 'push'
+      - name: Create and Push Release Tag
+        if: startsWith(github.ref, 'refs/heads/v1')  
         run: |
-          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            echo TAG="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
-          else
-            GIT_BRANCH_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-            echo TAG="${GIT_BRANCH_VERSION:1}" >> $GITHUB_ENV
-          fi
+          RELEASE_TAG="${GITHUB_REF_NAME}"
+          echo "Creating release tag for version ${RELEASE_TAG}"
+          echo "TAG=${RELEASE_TAG}" >> $GITHUB_ENV  
       - name: Tag and push to Jfrog Registry
         id: publish_artifacts
-        if: github.event_name == 'push'
+        if: startsWith(github.ref, 'refs/heads/v1')
         working-directory: "${{ github.workspace }}/dp"
         env:
           DOCKER_REGISTRY: "linuxfoundation.jfrog.io/magma-docker-orc8r-test"

--- a/.github/workflows/debian-packages-promote.yml
+++ b/.github/workflows/debian-packages-promote.yml
@@ -21,7 +21,7 @@ on:
       distribution:
         description: Distribution to set?
         type: string
-        default: 'focal-ci'
+        default: 'focal-1.9.0'
         required: true
 
 jobs:
@@ -47,7 +47,7 @@ jobs:
 
       - name: Verify distribution
         run: |
-          if [ ${{ env.distribution }} != 'focal-ci' ] && [[ ! ${{ env.distribution }} =~ ^focal-1\.[0-9]+\.[0-9]+$ ]]
+          if [ ${{ env.distribution }} != 'focal-1.9.0' ] && [[ ! ${{ env.distribution }} =~ ^focal-1\.[0-9]+\.[0-9]+$ ]]
           then
               echo "You have chosen 'distribution' ${{ env.distribution }} as input."
               echo "ERROR: Distribution name format check fails. Only focal-1.x.y is allowed. Abort!"

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -160,7 +160,7 @@ jobs:
         working-directory: "${{ github.workspace }}"
         run: |
           sudo cp keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-          sudo add-apt-repository 'deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main'
+          sudo add-apt-repository 'deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main'
           sudo apt-get update -y
           sudo apt-get install -y python3-aioeventlet
           sudo rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/magma-build-3rd-party.yml
+++ b/.github/workflows/magma-build-3rd-party.yml
@@ -36,7 +36,7 @@ on:
     inputs:
       distribution:
         description: Distribution to set?
-        default: 'focal-ci'
+        default: 'focal-1.9.0'
         required: true
 
 jobs:
@@ -45,7 +45,7 @@ jobs:
     container: ghcr.io/magma/magma/devcontainer:sha-84cfceb
     env:
       repository: magma-packages-test
-      distribution: ${{ inputs.distribution || 'focal-ci' }}
+      distribution: ${{ inputs.distribution || 'focal-1.9.0' }}
       build-directory: third_party/build
 
     strategy:
@@ -84,7 +84,7 @@ jobs:
 
       - name: Verify distribution
         run: |
-          if [ ${{ env.distribution }} != 'focal-ci' ] && [[ ! ${{ env.distribution }} =~ ^focal-1\.[0-9]+\.[0-9]+$ ]]; then
+          if [ ${{ env.distribution }} != 'focal-1.9.0' ] && [[ ! ${{ env.distribution }} =~ ^focal-1\.[0-9]+\.[0-9]+$ ]]; then
               echo "You have chosen 'distribution' ${{ env.distribution }} as input."
               echo "ERROR: Distribution name format check fails. Only focal-1.x.y is allowed. Abort!"
               exit 1

--- a/.github/workflows/magma-build-openvswitch.yml
+++ b/.github/workflows/magma-build-openvswitch.yml
@@ -36,7 +36,7 @@ on:
     inputs:
       distribution:
         description: Distribution to set?
-        default: 'focal-ci'
+        default: 'focal-1.9.0'
         required: true
 
 jobs:
@@ -46,7 +46,7 @@ jobs:
       MAGMA_ROOT: ${{ github.workspace }}
       DEST: ${{ github.workspace }}/deb_packages
       repository: magma-packages-test
-      distribution: ${{ inputs.distribution || 'focal-ci' }}
+      distribution: ${{ inputs.distribution || 'focal-1.9.0' }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
 
@@ -64,7 +64,7 @@ jobs:
 
       - name: Verify distribution
         run: |
-          if [ ${{ env.distribution }} != 'focal-ci' ] && [[ ! ${{ env.distribution }} =~ ^focal-1\.[0-9]+\.[0-9]+$ ]]; then
+          if [ ${{ env.distribution }} != 'focal-1.9.0' ] && [[ ! ${{ env.distribution }} =~ ^focal-1\.[0-9]+\.[0-9]+$ ]]; then
               echo "You have chosen 'distribution' ${{ env.distribution }} as input."
               echo "ERROR: Distribution name format check fails. Only focal-1.x.y is allowed. Abort!"
               exit 1

--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 
 # Add the magma apt repo
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-RUN add-apt-repository "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main"
+RUN add-apt-repository "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main"
 
 # Install the runtime deps.
 RUN apt-get update && apt-get install -y \
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y \
     libjemalloc-dev \
     libssl-dev \
     libsystemd-dev \
-    magma-nghttpx=1.31.1-1 \
+   nghttp2-proxy\
     make \
     net-tools \
     pkg-config \

--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -76,7 +76,7 @@ COPY cwf/gateway/deploy/roles/ovs/files/magma-preferences /etc/apt/preferences.d
 
 # Add the magma apt repo
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-RUN add-apt-repository "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main" && \
+RUN add-apt-repository "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main" && \
     add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ focal-proposed restricted main multiverse universe"
 
 RUN apt-get -y update && apt-get -y install \
@@ -88,7 +88,7 @@ RUN apt-get -y update && apt-get -y install \
     libjemalloc2 \
     libssl-dev \
     libsystemd-dev \
-    magma-nghttpx=1.31.1-1 \
+   nghttp2-proxy\
     net-tools \
     openssl \
     pkg-config \

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     apt-get install -y apt-utils software-properties-common apt-transport-https
 # Add the magma apt repo
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-RUN add-apt-repository "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main"
+RUN add-apt-repository "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main"
 
 # Install the runtime deps.
 RUN apt-get update && apt-get install -y \
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y \
     libjemalloc-dev \
     libssl-dev \
     libsystemd-dev \
-    magma-nghttpx=1.31.1-1 \
+   nghttp2-proxy\
     make \
     net-tools \
     pkg-config \

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && \
     apt-get install -y apt-utils software-properties-common apt-transport-https curl
 
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-RUN add-apt-repository "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main"
+RUN add-apt-repository "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main"
 RUN curl -L http://packages.fluentbit.io/fluentbit.key > /tmp/fluentbit.key
 RUN apt-key add /tmp/fluentbit.key && \
     add-apt-repository "deb https://packages.fluentbit.io/ubuntu/focal focal main"
@@ -94,7 +94,7 @@ RUN apt-get -y update && apt-get -y install \
     libjemalloc2 \
     libssl-dev \
     libsystemd-dev \
-    magma-nghttpx=1.31.1-1 \
+   nghttp2-proxy\
     net-tools \
     openssl \
     iputils-ping \

--- a/lte/gateway/deploy/roles/magma_deploy/vars/all_master.yaml
+++ b/lte/gateway/deploy/roles/magma_deploy/vars/all_master.yaml
@@ -15,7 +15,7 @@
 magma_pkgrepo_proto: https
 magma_pkgrepo_host: linuxfoundation.jfrog.io/artifactory/magma-packages-test
 magma_pkgrepo_path: ""
-magma_pkgrepo_dist: focal-ci
+magma_pkgrepo_dist: focal-1.9.0
 magma_pkgrepo_component: main
 magma_pkgrepo_name: "magma"
 

--- a/lte/gateway/docker/services/c/Dockerfile
+++ b/lte/gateway/docker/services/c/Dockerfile
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y \
 
 # Add the magma apt repo
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-RUN echo "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main" > /etc/apt/sources.list.d/magma.list
+RUN echo "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main" > /etc/apt/sources.list.d/magma.list
 RUN apt-get update && apt-get install -y \
   grpc-dev \
   libfolly-dev \
@@ -193,7 +193,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-RUN echo "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main" > /etc/apt/sources.list.d/magma.list
+RUN echo "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main" > /etc/apt/sources.list.d/magma.list
 RUN apt-get update && apt-get install -y \
   libopenvswitch \
   openvswitch-common \

--- a/lte/gateway/docker/services/python/Dockerfile
+++ b/lte/gateway/docker/services/python/Dockerfile
@@ -121,7 +121,7 @@ ENV PATH="/magma/orc8r/gateway/python/scripts/:/magma/lte/gateway/python/scripts
 
 # Add the magma apt repo
 COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc
-RUN echo "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main" > /etc/apt/sources.list.d/magma.list
+RUN echo "deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main" > /etc/apt/sources.list.d/magma.list
 
 RUN echo "deb https://packages.fluentbit.io/ubuntu/focal focal main" > /etc/apt/sources.list.d/tda.list
 RUN wget -qO - https://packages.fluentbit.io/fluentbit.key | apt-key add -

--- a/orc8r/tools/ansible/roles/gateway_services/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/gateway_services/tasks/main.yml
@@ -55,7 +55,7 @@
       - libjansson-dev
       - libjemalloc-dev
       - libc-ares-dev
-      - magma-nghttpx=1.31.1-1
+      -nghttp2-proxy=1.31.1-1
     state: present
   retries: 5
   when: preburn

--- a/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/pkgrepo/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Configuring the registry in sources.list.d
   ansible.builtin.apt_repository:
-    repo: deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main
+    repo: deb https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-1.9.0 main
     filename: magma
     state: present
     update_cache: true


### PR DESCRIPTION
> **Summary:**
>
> Following is a list of features provided by this PR:
> 
> 1. Changed all occurrences of focal-ci to focal-1.x0.
> 2. Enabled for runs on pull requests on release branches.
> 3. Created Release tag and to push with 1.x.
> 4. Docker images pushed with the 1.x tag.
> 5. Pin the BAZEL_CACHE_PLAIN_IMAGE in "AGW Generate Coverage and AGW Lint"
>
> **Test Plan:**
>
> 1. Tested to create a release tag and pushed to GitHub depending upon the branch name. eg.: v1.9 (branch name), it will create that release tag.

![image](https://github.com/user-attachments/assets/b3e3dcb7-a99c-4ce5-ba71-498cccce6df1)
> 2. This created release tag will be pushed to Jfrog as an image tag. 
![image](https://github.com/user-attachments/assets/bda82bc8-0c28-43b2-91a9-eefb82dc0c6e)





