### PR TITLE
fix(amf): Correct MSIN decoding for SUCI Profile B

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.cpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <thread>
 #include <cassert>
+#include <iomanip>
+#include <sstream>
 
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_38.413.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.501.h"
@@ -52,6 +54,15 @@ using magma::lte::M5GSUCIRegistrationRequest;
 using magma5g::amf_proc_registration_reject;
 
 extern task_zmq_ctx_t grpc_service_task_zmq_ctx;
+
+std::string to_hex_string(const std::string& input) {
+  std::stringstream ss;
+  ss << std::hex << std::setfill('0');
+  for (unsigned char c : input) {
+    ss << std::setw(2) << static_cast<int>(c);
+  }
+  return ss.str();
+}
 
 static void handle_decrypted_imsi_info_ans(
     grpc::Status status, magma::lte::M5GSUCIRegistrationAnswer response,
@@ -106,6 +117,18 @@ M5GSUCIRegistrationRequest create_decrypt_msin_request(
     const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
     const std::string& ciphertext, const std::string& mac_tag) {
   M5GSUCIRegistrationRequest request;
+
+  OAILOG_DEBUG(LOG_AMF_APP, "create_decrypt_msin_request()");
+  OAILOG_DEBUG(LOG_AMF_APP, "UE pubkey identifier: %u", ue_pubkey_identifier);
+  OAILOG_DEBUG(LOG_AMF_APP, "UE pubkey (hex): %s",
+               to_hex_string(ue_pubkey).c_str());
+  OAILOG_DEBUG(LOG_AMF_APP, "UE pubkey length: %zu", ue_pubkey.length());
+  OAILOG_DEBUG(LOG_AMF_APP, "Ciphertext (hex): %s",
+               to_hex_string(ciphertext).c_str());
+  OAILOG_DEBUG(LOG_AMF_APP, "Ciphertext length: %zu", ciphertext.length());
+  OAILOG_DEBUG(LOG_AMF_APP, "MAC tag (hex): %s",
+               to_hex_string(mac_tag).c_str());
+  OAILOG_DEBUG(LOG_AMF_APP, "MAC tag length: %zu", mac_tag.length());
 
   request.Clear();
   request.set_ue_pubkey_identifier(ue_pubkey_identifier);

--- a/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas_proc.cpp
@@ -855,7 +855,8 @@ int amf_decrypt_msin_info_answer(itti_amf_decrypted_msin_info_ans_t* aia) {
 
   if (!(amf_ctxt_p)) {
     OAILOG_ERROR(LOG_NAS_AMF,
-                 "That's embarrassing as we don't know this IMSI\n");
+                 "AMF context not found for UE ID: " AMF_UE_NGAP_ID_FMT ". ",
+                 aia->ue_id);
     OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNerror);
   }
 
@@ -885,16 +886,41 @@ int amf_decrypt_msin_info_answer(itti_amf_decrypted_msin_info_ans_t* aia) {
   supi_imsi.plmn.mnc_digit3 =
       ue_context->amf_context.m5_guti.guamfi.plmn.mnc_digit3;
 
-  supi_imsi.msin[0] =
-      (uint8_t)(((aia->msin[0] - '0') << 4) | (aia->msin[1] - '0'));
-  supi_imsi.msin[1] =
-      (uint8_t)(((aia->msin[2] - '0') << 4) | (aia->msin[3] - '0'));
-  supi_imsi.msin[2] =
-      (uint8_t)(((aia->msin[4] - '0') << 4) | (aia->msin[5] - '0'));
-  supi_imsi.msin[3] =
-      (uint8_t)(((aia->msin[6] - '0') << 4) | (aia->msin[7] - '0'));
-  supi_imsi.msin[4] =
-      (uint8_t)(((aia->msin[8] - '0') << 4) | (aia->msin[9] - '0'));
+  // Copy and print PLMN information for validation
+  memcpy(&supi_imsi.plmn, &ue_context->amf_context.m5_guti.guamfi.plmn,
+         sizeof(plmn_t));
+
+  OAILOG_DEBUG(LOG_AMF_APP, "PLMN for IMSI: MCC %d%d%d, MNC %d%d",
+               supi_imsi.plmn.mcc_digit1, supi_imsi.plmn.mcc_digit2,
+               supi_imsi.plmn.mcc_digit3, supi_imsi.plmn.mnc_digit1,
+               supi_imsi.plmn.mnc_digit2);
+
+  OAILOG_DEBUG(LOG_AMF_APP, "Aia->msin contents:");
+  for (int i = 0; i < MSIN_BCD_DIGITS_MAX; i++) {
+    OAILOG_DEBUG(LOG_AMF_APP, "aia->msin[%d]: 0x%02x ('%c')", i,
+                 (uint8_t)aia->msin[i], aia->msin[i]);
+  }
+
+  for (int i = 0; i < (MSIN_BCD_DIGITS_MAX / 2); i++) {
+    uint8_t swapped =
+        (uint8_t)(((aia->msin[i] & 0x0F) << 4) | ((aia->msin[i] & 0xF0) >> 4));
+
+    uint8_t high_nibble = (swapped >> 4) & 0x0F;
+    uint8_t low_nibble = swapped & 0x0F;
+
+    // Ensure that each nibble is valid
+    if (high_nibble > 9 || low_nibble > 9) {
+      OAILOG_ERROR(LOG_AMF_APP, "Invalid BCD digit in MSIN byte %d: 0x%02x", i,
+                   swapped);
+    }
+
+    supi_imsi.msin[i] = swapped;
+
+    OAILOG_DEBUG(
+        LOG_AMF_APP,
+        "MSIN[%d]: original 0x%02x, swapped 0x%02x (high: %d, low: %d)", i,
+        aia->msin[i], supi_imsi.msin[i], high_nibble, low_nibble);
+  }
 
   // Copy entire supi_imsi to param->imsi->u.value
   memcpy(&params->imsi->u.value, &supi_imsi, IMSI_BCD8_SIZE);

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -82,8 +82,8 @@ class AMFAppProcedureTest : public ::testing::Test {
                  .mnc_digit1 = 4};
 
   itti_amf_decrypted_msin_info_ans_t decrypted_msin = {
-      .msin = {'9', '7', '6', '5', '4', '5', '6', '6', '0'},
-      .msin_length = 10,
+      .msin = {0x79, 0x56, 0x54, 0x66, 0x00},
+      .msin_length = 5,
       .result = 1,
       .ue_id = 1};
 


### PR DESCRIPTION
## Summary

This simple PR fixes the issue with SUCI Profile B, as reported in https://github.com/magma/magma/issues/15444. The problem was the incorrect decoding of the MSIN. For example, the decoded IMSI was 99970008000, but the actual IMSI was 999700000068375 (as shown in the [logs](https://pastebin.com/raw/awvFu87h))

To sum up, the AMF failed to correctly parse the MSIN from the database which led to the IMSI being incorrect and the authentication procedure failing. The MSIN is received as 5 bytes of raw binary data in BCD (Binary Coded Decimal) format, with each byte representing two digits in reverse order. The original code assumed that the MSIN was a string of 10 digits and attempted to convert this in a wrong format (this resulted in the values being decoded incorrectly).

This PR changes the following:
- Modifies the amf_decrypt_msin_info_answer function to properly handle BCD-encoded data.
- Adds additional debug logs (some of the debug/error logs was unnecessary?).  
- Removed the old incorrect ASCII-based decoding approach.
- Also, the unit test was also wrong. Thanks to Bruno for pointing that out in his fix. I have included his modifications of the test to this PR aswell.

There will be a new PR submitted for the SUCI documentation (there are some confusion regarding key generation).

## Test Plan

The UEs that were tested w/ Profile B were IPhone and IPad using test keys from 3GPP TS. 

![image](https://github.com/user-attachments/assets/e8e41036-0f08-4909-a220-941f102d8fa2)


## Additional Information

EDIT: I am just going through the updates from  v1.8. I do find it a bit odd that this issue was mentioned in the release notes [here](https://github.com/magma/magma/issues/13683). Could there have been a rollback?


## Security Considerations



