### PR TITLE
fix(orc8r): Release 1.9.0 

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -153,8 +153,6 @@ jobs:
         run: |
          echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}" 
          RELEASE_TAG="${GITHUB_REF_NAME}"
-         git config user.email bindu.akula@veltris.com
-         git config  user.name "himabinduak"
          echo "Creating release tag for version ${RELEASE_TAG}"
          git tag -a "${RELEASE_TAG}" -m "Release version ${RELEASE_TAG}" 
          git push origin refs/tags/"${RELEASE_TAG}" 

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -153,6 +153,8 @@ jobs:
         run: |
          echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}" 
          RELEASE_TAG="${GITHUB_REF_NAME}"
+         git config user.email bindu.akula@veltris.com
+         git config  user.name "himabinduak"
          echo "Creating release tag for version ${RELEASE_TAG}"
          git tag -a "${RELEASE_TAG}" -m "Release version ${RELEASE_TAG}" 
          git push origin refs/tags/"${RELEASE_TAG}" 

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
          echo "The current github.ref is: ${GITHUB_REF}"
       - name: Create and Push Release Tag
-        if: startsWith(github.ref_name, 'v1.*')  
+        if: startsWith(github.ref, 'refs/heads/v1.')  
         run: |
          echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}" 
          RELEASE_TAG="${GITHUB_REF_NAME}"

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -42,6 +42,7 @@ on:
     branches:
       - master
       - 'v1.*'
+      - focal-1.9.0
   pull_request:
     types: [ opened, reopened, synchronize ]
 
@@ -81,7 +82,6 @@ jobs:
 
       - name: verify git sha output
         run: echo "Git SHA is ${commit_hash}"
-
       - name: Create possible release Tag
         if: github.event_name == 'push' && github.ref_name != 'master'
         run: |
@@ -145,10 +145,13 @@ jobs:
           TAGS: ${{ steps.set-agwc-tags.outputs.go_image_tags }}
           TARGET: gateway_go
       - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
-      - name: Create and Push Release Tag
-        if: startsWith(github.ref,'v1.')  
+      - name: Print github.ref for debugging
         run: |
-         echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"  
+         echo "The current github.ref is: ${GITHUB_REF}"
+      - name: Create and Push Release Tag
+        if: startsWith(github.ref_name, 'v1.*')  
+        run: |
+         echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}" 
          RELEASE_TAG="${GITHUB_REF_NAME}"
          echo "Creating release tag for version ${RELEASE_TAG}"
          git tag -a "${RELEASE_TAG}" -m "Release version ${RELEASE_TAG}" 

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -42,7 +42,6 @@ on:
     branches:
       - master
       - 'v1.*'
-      - focal-1.9.0
   pull_request:
     types: [ opened, reopened, synchronize ]
 


### PR DESCRIPTION
<!--
   fix(orc8r): Release 1.9.0 
-->

## Summary
Modified not to skip the create and Release Tag step  

## Test Plan
It is able to create the release tag v1.9 according to the branch name ie v1.9 

![image](https://github.com/user-attachments/assets/4c75e661-7a21-4d69-8691-947a7fa0fa56)


