### PR TITLE
fix(deps): change liblfds reference to a working one

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -108,7 +108,7 @@ def cpp_repositories():
         name = "liblfds",
         build_file = "//bazel/external:liblfds.BUILD",
         commit = "b36a48014574225723779c7e1e9fb8cb6fa8f7f4",
-        remote = "https://liblfds.org/git/liblfds",
+        remote = "git://liblfds.org/liblfds",
         shallow_since = "1657356839 +0000",
     )
 

--- a/lte/gateway/docker/mme/Dockerfile.rhel8
+++ b/lte/gateway/docker/mme/Dockerfile.rhel8
@@ -148,7 +148,7 @@ RUN  git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
      git clone https://github.com/cpp-redis/cpp_redis.git && \
      wget https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
      wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
-     git clone https://liblfds.org/git/liblfds && \
+     git clone git://liblfds.org/liblfds && \
      git clone https://gitea.osmocom.org/cellular-infrastructure/libgtpnl && \
      git clone https://github.com/OPENAIRINTERFACE/asn1c.git && \
      git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -82,7 +82,7 @@ RUN  git clone --recurse-submodules -b v1.15.0 https://github.com/grpc/grpc && \
      git clone https://github.com/cpp-redis/cpp_redis.git && \
      wget https://ftp.gnu.org/gnu/nettle/nettle-2.5.tar.gz && \
      wget https://www.gnupg.org/ftp/gcrypt/gnutls/v3.1/gnutls-3.1.23.tar.xz && \
-     git clone https://liblfds.org/git/liblfds && \
+     git clone git://liblfds.org/liblfds && \
      git clone https://gitea.osmocom.org/cellular-infrastructure/libgtpnl && \
      git clone https://github.com/OPENAIRINTERFACE/asn1c.git && \
      git clone https://github.com/OPENAIRINTERFACE/opencord.org.freeDiameter.git freediameter && \


### PR DESCRIPTION
fix(deps): change liblfds reference to a working one

## Summary

The command git clone for the liblfds using https is returning 500, changing the references to git fixes this issue.

All three references of `https://liblfds.org/git/liblfds` were replaced by  `git://liblfds.org/liblfds`

## Test Plan

The steps described at the guide on the `docs/readmes/basics/quick_start_guide.md` file were performed and, where it previously presented errors, started working.

## Additional Information

- [x] This change is backwards-breaking

## Security Considerations

There is no security considerations.
