### PR TITLE
fix(deps): specify dotenv version in dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -76,7 +76,8 @@ RUN echo "Install general purpose packages" && \
         ruby-dev \
         software-properties-common \
         tzdata \
-        virtualenv=20.0.17-1ubuntu0.4 && \
+        virtualenv=20.0.17-1ubuntu0.4
+RUN gem install dotenv -v 2.8.1 && \
     gem install fpm
 
 # Install golang


### PR DESCRIPTION
fix(deps): specify dotenv version in dockerfile

## Summary

While following the guide at `.devcontainer/README.md` file, running the `docker build -f .devcontainer/Dockerfile .` command, the below error showed up:

```
22.85 ERROR:  Error installing fpm:                                                                                                                                                                                                                                              
22.85   The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again                                                                                             
22.85   dotenv requires Ruby version >= 3.0. The current ruby version is 2.7.0.0.
23.09 Successfully installed stud-0.0.23
```

## Test Plan

The execution of `docker build -f .devcontainer/Dockerfile .` no longer presents errors.

## Additional Information

- [ x ] This change is backwards-breaking

Inserting the `gem install dotenv -v 2.8.1` before `gem install fpm` in the Dockerfile located at `.devcontainer/` shall be enough to upgrade early versions.

## Security Considerations

Using outdated packages might lead to security breaches or performance issues.
