### PR TITLE
fix(amf): Correct MSIN decoding for BCD-encoded deconcealed IMSI (v1.9)

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GSUCIRegistrationServiceClient.cpp
@@ -19,7 +19,8 @@
 #include <string>
 #include <thread>
 #include <cassert>
-
+#include <iomanip>
+#include <sstream>
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_38.413.h"
 #include "lte/gateway/c/core/oai/lib/3gpp/3gpp_24.501.h"
 
@@ -52,6 +53,15 @@ using magma::lte::M5GSUCIRegistrationRequest;
 using magma5g::amf_proc_registration_reject;
 
 extern task_zmq_ctx_t grpc_service_task_zmq_ctx;
+
+std::string to_hex_string(const std::string& input) {
+  std::stringstream ss;
+  ss << std::hex << std::setfill('0');
+  for (unsigned char c : input) {
+    ss << std::setw(2) << static_cast<int>(c);
+  }
+  return ss.str();
+}
 
 static void handle_decrypted_imsi_info_ans(
     grpc::Status status, magma::lte::M5GSUCIRegistrationAnswer response,
@@ -106,6 +116,19 @@ M5GSUCIRegistrationRequest create_decrypt_msin_request(
     const uint8_t ue_pubkey_identifier, const std::string& ue_pubkey,
     const std::string& ciphertext, const std::string& mac_tag) {
   M5GSUCIRegistrationRequest request;
+
+
+  OAILOG_DEBUG(LOG_AMF_APP, "create_decrypt_msin_request()");
+  OAILOG_DEBUG(LOG_AMF_APP, "UE pubkey identifier: %u", ue_pubkey_identifier);
+  OAILOG_DEBUG(LOG_AMF_APP, "UE pubkey (hex): %s",
+               to_hex_string(ue_pubkey).c_str());
+  OAILOG_DEBUG(LOG_AMF_APP, "UE pubkey length: %zu", ue_pubkey.length());
+  OAILOG_DEBUG(LOG_AMF_APP, "Ciphertext (hex): %s",
+               to_hex_string(ciphertext).c_str());
+  OAILOG_DEBUG(LOG_AMF_APP, "Ciphertext length: %zu", ciphertext.length());
+  OAILOG_DEBUG(LOG_AMF_APP, "MAC tag (hex): %s",
+               to_hex_string(mac_tag).c_str());
+  OAILOG_DEBUG(LOG_AMF_APP, "MAC tag length: %zu", mac_tag.length());
 
   request.Clear();
   request.set_ue_pubkey_identifier(ue_pubkey_identifier);

--- a/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
+++ b/lte/gateway/c/core/oai/test/amf/test_amf_procedures.cpp
@@ -82,8 +82,8 @@ class AMFAppProcedureTest : public ::testing::Test {
                  .mnc_digit1 = 4};
 
   itti_amf_decrypted_msin_info_ans_t decrypted_msin = {
-      .msin = {'9', '7', '6', '5', '4', '5', '6', '6', '0'},
-      .msin_length = 10,
+      .msin = {0x79, 0x56, 0x54, 0x66, 0x00},
+      .msin_length = 5,
       .result = 1,
       .ue_id = 1};
 


### PR DESCRIPTION
**Note: Recreated for this PR to be merged with v1.9 branch**

## Summary

This simple PR fixes the issue with SUCI Profile B, as reported in https://github.com/magma/magma/issues/15444. The problem was the incorrect decoding of the MSIN. For example, the decoded IMSI was 99970008000, but the actual IMSI was 999700000068375 (as shown in the [logs](https://pastebin.com/raw/awvFu87h))

To sum up, the AMF failed to correctly parse the MSIN from the database which led to the IMSI being incorrect and the authentication procedure failing. The MSIN is received as 5 bytes of raw binary data in BCD (Binary Coded Decimal) format, with each byte representing two digits in reverse order. The original code assumed that the MSIN was a string of 10 digits and attempted to convert this in a wrong format (this resulted in the values being decoded incorrectly).

This PR changes the following:
- Modifies the amf_decrypt_msin_info_answer function to properly handle BCD-encoded data.
- Adds additional debug logs (some of the debug/error logs was unnecessary?).  
- Removed the old incorrect ASCII-based decoding approach.
- Also, the unit test was also wrong. Thanks to Bruno for pointing that out in his fix. I have included his modifications of the test to this PR aswell.

There will be a new PR submitted for the SUCI documentation (there are some confusion regarding key generation).

## Test Plan

The UEs that were tested w/ Profile B were IPhone and IPad using test keys from 3GPP TS. 

![image](https://github.com/user-attachments/assets/e8e41036-0f08-4909-a220-941f102d8fa2)


## Additional Information

EDIT: I am just going through the updates from  v1.8. I do find it a bit odd that this issue was mentioned in the release notes [here](https://github.com/magma/magma/issues/13683). Could there have been a rollback?


## Security Considerations