### PR TITLE
fix(ci): start devcontainer from directories other than 'magma'

### DIFF
--- a/.devcontainer/post-create-commands.sh
+++ b/.devcontainer/post-create-commands.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-
 # $1: should be containerWorkspaceFolder from https://code.visualstudio.com/docs/remote/devcontainerjson-reference
+if [ "$1" != "$MAGMA_ROOT" ]
+then
+    sudo rm -rf "$MAGMA_ROOT"
+    sudo ln -s "$1" "$MAGMA_ROOT"
+fi
 
-sudo ln -s "$1"/lte/gateway/configs /etc/magma
+sudo ln -s "$MAGMA_ROOT"/lte/gateway/configs /etc/magma
 echo "alias magtivate='source /home/vscode/build/python/bin/activate'" >> ~/.bashrc
 
 echo "Generating compile_commands.json for C/C++ code navigation"
-"$1"/dev_tools/gen_compilation_database.py
+"$MAGMA_ROOT"/dev_tools/gen_compilation_database.py
 
 echo "Setting up Bazel Bash completion"
-"$1"/bazel/scripts/setup_bazel_bash_completion.sh $(cat "$1"/.bazelversion)
+"$MAGMA_ROOT"/bazel/scripts/setup_bazel_bash_completion.sh $(cat "$MAGMA_ROOT"/.bazelversion)


### PR DESCRIPTION
fix(devcontainers): for directories other than 'magma'

## Summary

Modified the `.devcontainer/post-create-commands.sh` script to create a symlink the current directory as `MAGMA_ROOT`.

## Test Plan

Start the devcontainer from a directory called `magma-fork`.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

There are no security considerations.
