### PR TITLE
fix(agw): Fix ansible installation of nghttp2-proxy

### DIFF
--- a/orc8r/tools/ansible/roles/gateway_services/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/gateway_services/tasks/main.yml
@@ -55,7 +55,7 @@
       - libjansson-dev
       - libjemalloc-dev
       - libc-ares-dev
-      -nghttp2-proxy=1.31.1-1
+      - nghttp2-proxy=1.31.1-1
     state: present
   retries: 5
   when: preburn


### PR DESCRIPTION
## Summary

A missing space in the yaml file made the installation of nghttp2-proxy fail when provisioning an AGW with Vagrant.

## Test Plan

Before the change, the deployment of an AGW with Vagrant (`vagrant up magma`) failed with the following error:

```
PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=false ANSIBLE_SSH_ARGS='-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o IdentityFile=/home/ether/.vagrant.d/insecure_private_keys/vagrant.key.ed25519 -o IdentityFile=/home/ether/.vagrant.d/insecure_private_keys/vagrant.key.rsa -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --connection=ssh --timeout=30 --extra-vars=ansible_ssh_user\=\'vagrant\' --limit="magma" --inventory-file=deploy/hosts -v --timeout=30 deploy/magma_dev.yml
Using /home/ether/ETHER/Satellite80/magma-v1p9pp/lte/gateway/ansible.cfg as config file
ERROR! We were unable to read either as JSON nor YAML, these are the errors we got from each:
JSON: Expecting value: line 1 column 1 (char 0)

Syntax Error while loading YAML.
  could not find expected ':'

The error appears to be in '/home/ether/ETHER/Satellite80/magma-v1p9pp/orc8r/tools/ansible/roles/gateway_services/tasks/main.yml': line 58, column 21, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

      -nghttp2-proxy=1.31.1-1
                    ^ here

There appears to be both 'k=v' shorthand syntax and YAML in this task. Only one syntax may be used.
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

Now, after changing ` -nghttp2-proxy=1.31.1-1` to ` - nghttp2-proxy=1.31.1-1`  it completes gracefully.

## Additional Information

This change is not needed upstream in `master`, since the nghttp2-proxy package has been replaced.

## Security Considerations

N/A.