### PR TITLE
refactor(amf): use 'this' instead of redundant object pointer in methods

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -108,7 +108,7 @@ def cpp_repositories():
         name = "liblfds",
         build_file = "//bazel/external:liblfds.BUILD",
         commit = "b36a48014574225723779c7e1e9fb8cb6fa8f7f4",
-        remote = "https://liblfds.org/git/liblfds",
+        remote = "git://liblfds.org/liblfds",
         shallow_since = "1657356839 +0000",
     )
 

--- a/lte/gateway/c/core/oai/common/TLVEncoder.c
+++ b/lte/gateway/c/core/oai/common/TLVEncoder.c
@@ -30,15 +30,10 @@ int errorCodeEncoder = 0;
 
 int encode_bstring(const_bstring const str, uint8_t* const buffer,
                    const uint32_t buflen) {
-  if (str) {
-    if (blength(str) > 0) {
-      CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, blength(str), buflen);
-      memcpy((void*)buffer, (void*)str->data, blength(str));
-      return blength(str);
-    } else {
-      return 0;
-    }
-  } else {
-    return 0;
-  }
+  if (!str) return 0;
+  if (blength(str) <= 0) return 0;
+  if (buffer == NULL) return TLV_BUFFER_NULL;
+  if (buflen < blength(str)) return TLV_BUFFER_TOO_SHORT;
+  memcpy((void*)buffer, (void*)str->data, blength(str));
+  return blength(str);
 }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_handler.cpp
@@ -51,7 +51,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/amf/include/amf_app_statistics.hpp"
 
 extern amf_config_t amf_config;
-extern amf_config_t amf_config;
+
 namespace magma5g {
 extern task_zmq_ctx_s amf_app_task_zmq_ctx;
 static int pdu_session_resource_modification_t3591_handler(zloop_t* loop,
@@ -553,8 +553,6 @@ static int amf_smf_session_update_pti_proc(
  * Establishment Accept Message to UE*/
 status_code_e amf_app_handle_pdu_session_response(
     itti_n11_create_pdu_session_response_t* pdu_session_resp) {
-  DLNASTransportMsg encode_msg;
-  memset(&encode_msg, 0, sizeof(encode_msg));
   ue_m5gmm_context_s* ue_context = nullptr;
   std::shared_ptr<smf_context_t> smf_ctx;
   amf_smf_t amf_smf_msg;
@@ -1049,7 +1047,7 @@ status_code_e amf_app_handle_pdu_session_accept(
   bdestroy(smf_msg->msg.pdu_session_estab_accept.authorized_qosflowdescriptors);
 
   return RETURNok;
-}  // namespace magma5g
+}
 
 /* Handling PDU Session Resource Setup Response sent from gNB*/
 void amf_app_handle_resource_setup_response(
@@ -1729,6 +1727,7 @@ void amf_app_handle_initial_context_setup_rsp(
         &amf_app_desc_p->amf_ue_contexts, ue_context, M5GCM_CONNECTED);
   }
 }
+
 using grpc::Status;
 status_code_e amf_app_handle_pdu_session_failure(
     itti_n11_create_pdu_session_failure_t* pdu_session_failure) {
@@ -1756,9 +1755,9 @@ status_code_e amf_app_handle_pdu_session_failure(
 
   if (pdu_session_failure->error_code ==
       static_cast<uint8_t>(grpc::StatusCode::ALREADY_EXISTS)) {
-    OAILOG_DEBUG(
-        LOG_AMF_APP,
-        "failure response due to duplicate PDU session,releasing existing PDU");
+    OAILOG_DEBUG(LOG_AMF_APP,
+                 "failure response due to duplicate PDU session,releasing "
+                 "existing PDU");
     amf_smf_release_t smf_message = {};
 
     smf_message.pdu_session_id = smf_context->smf_proc_data.pdu_session_id;
@@ -2004,11 +2003,11 @@ static int pdu_session_resource_modification_t3591_handler(zloop_t* loop,
         pdu_session_resource_modification_t3591_handler, id);
   } else {
     /* Abort the registration procedure */
-    OAILOG_ERROR(
-        LOG_AMF_APP,
-        "T3591: Maximum retires:%d, for PDU_SESSION_MODIFICATION_REQUEST done "
-        "hence Abort the pdu sesssion modification procedure\n",
-        smf_ctx->retransmission_count);
+    OAILOG_ERROR(LOG_AMF_APP,
+                 "T3591: Maximum retires:%d, for "
+                 "PDU_SESSION_MODIFICATION_REQUEST done "
+                 "hence Abort the pdu sesssion modification procedure\n",
+                 smf_ctx->retransmission_count);
   }
   OAILOG_FUNC_RETURN(LOG_NAS_AMF, RETURNok);
 }

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_ue_context_and_proc.hpp
@@ -539,6 +539,12 @@ union mobility_msg_u {
   ~mobility_msg_u() {}
 };
 
+/**
+ * TODO: This codebase has redundant implemmentation. It is advised to remove
+ * repeated code, build and test to see the impact on the runtime. AmfMsg
+ * defined in the file `lte/gateway/c/core/oai/tasks/nas5g/src/AmfMessage.cpp`
+ * is the class actually in use, this type (AMFMsg) is being type casted to it.
+ */
 // Procedure for NAS5G encoding and decoding
 class AMFMsg {
  public:
@@ -559,6 +565,7 @@ class AMFMsg {
 // union of plain NAS message
 typedef struct nas_message_plain_s {
   AMFMsg amf; /* 5GMM Mobility Management messages */
+  /** TODO: consider using only one implemmentation of AmfMsg/AMFMsg */
 } nas_message_plain_t;
 
 typedef struct nas_message_security_protected_s {
@@ -887,7 +894,7 @@ int nas5g_message_decode(const unsigned char* const buffer,
 
 int nas5g_message_encode(unsigned char* buffer,
                          const amf_nas_message_t* const msg, uint32_t length,
-                         void* security);
+                         amf_security_context_t* security);
 
 status_code_e amf_registration_run_procedure(amf_context_t* amf_context);
 status_code_e amf_proc_registration_complete(amf_context_t* amf_context);

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_send.cpp
@@ -150,7 +150,7 @@ int amf_send_pdusession_reject(SmfMsg* reject_req, uint8_t session_id,
   reject_req->header.message_type =
       static_cast<uint8_t>(M5GMessageType::PDU_SESSION_ESTABLISHMENT_REJECT);
   reject_req->msg.pdu_session_estab_reject.m5gsm_cause.cause_value = cause;
-  rc = reject_req->SmfMsgEncodeMsg(reject_req, buffer, 5);
+  rc = reject_req->SmfMsgEncodeMsg(buffer, 5);
   if (rc > 0) {
     // TODO: Send the message to AS for nas encode
     // and forward to NGAP. Nagetive scenario.

--- a/lte/gateway/c/core/oai/tasks/amf/amf_smf_session_qos.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_smf_session_qos.cpp
@@ -168,7 +168,7 @@ int amf_smf_session_api_fill_qos_ie_info(std::shared_ptr<smf_context_t> smf_ctx,
 
       // Convert Authorized qos into bstring
       int encoded_result = qosRuleMsg.EncodeQOSRulesMsgData(
-          &qosRuleMsg, qos_rules_msg_buffer + qos_rules_msg_buf_len,
+          qos_rules_msg_buffer + qos_rules_msg_buf_len,
           QOS_RULES_MSG_BUF_LEN_MAX);
 
       if (encoded_result < 0) {
@@ -248,7 +248,7 @@ int amf_smf_session_api_fill_qos_ie_info(std::shared_ptr<smf_context_t> smf_ctx,
       if (flow_des.numOfParams) {
         // Convert Authorized qos into bstring
         int encoded_result = flow_des.EncodeM5GQosFlowDescription(
-            &flow_des, qos_flow_desc_buffer + qos_flow_desc_buf_len,
+            qos_flow_desc_buffer + qos_flow_desc_buf_len,
             QOS_FLOW_DESC_BUF_LEN_MAX);
 
         if (encoded_result < 0) {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/AmfMessage.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/AmfMessage.hpp
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include <cstring>
 #include <sstream>
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationRequest.hpp"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationAccept.hpp"
@@ -66,6 +67,12 @@ union MMsg_u {
   PDUSessionModificationCommand pdu_sess_mod_cmd;
   MMsg_u();
   ~MMsg_u();
+  MMsg_u& operator=(const MMsg_u& other) {
+    /** TODO: implement a copy mechanism that takes into account each subtype to
+     * avoid copying invalid pointers */
+    if (this != &other) memcpy(this, &other, sizeof(MMsg_u));
+    return *this;
+  }
 };
 
 // Amf NAS Msg Class
@@ -76,13 +83,18 @@ class AmfMsg {
 
   AmfMsg();
   ~AmfMsg();
-  int M5gNasMessageEncodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len);
-  int M5gNasMessageDecodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len);
-  int AmfMsgDecodeHeaderMsg(AmfMsgHeader_s* header, uint8_t* buffer,
-                            uint32_t len);
-  int AmfMsgEncodeHeaderMsg(AmfMsgHeader_s* header, uint8_t* buffer,
-                            uint32_t len);
-  int AmfMsgDecodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len);
-  int AmfMsgEncodeMsg(AmfMsg* msg, uint8_t* buffer, uint32_t len);
+  int M5gNasMessageEncodeMsg(uint8_t* buffer, uint32_t len);
+  int M5gNasMessageDecodeMsg(uint8_t* buffer, uint32_t len);
+  int AmfMsgDecodeHeaderMsg(uint8_t* buffer, uint32_t len);
+  int AmfMsgEncodeHeaderMsg(uint8_t* buffer, uint32_t len);
+  int AmfMsgDecodeMsg(uint8_t* buffer, uint32_t len);
+  int AmfMsgEncodeMsg(uint8_t* buffer, uint32_t len);
+  AmfMsg& operator=(const AmfMsg& other) {
+    if (this != &other) {
+      this->header = other.header;
+      this->msg = other.msg;
+    }
+    return *this;
+  }
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationFailure.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationFailure.hpp
@@ -34,10 +34,8 @@ class AuthenticationFailureMsg {
 
   AuthenticationFailureMsg();
   ~AuthenticationFailureMsg();
-  int DecodeAuthenticationFailureMsg(AuthenticationFailureMsg* auth_failure,
-                                     uint8_t* buffer, uint32_t len);
-  int EncodeAuthenticationFailureMsg(AuthenticationFailureMsg* auth_failure,
-                                     uint8_t* buffer, uint32_t len);
+  int DecodeAuthenticationFailureMsg(uint8_t* buffer, uint32_t len);
+  int EncodeAuthenticationFailureMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationReject.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationReject.hpp
@@ -27,10 +27,8 @@ class AuthenticationRejectMsg {
 
   AuthenticationRejectMsg();
   ~AuthenticationRejectMsg();
-  int DecodeAuthenticationRejectMsg(AuthenticationRejectMsg* auth_reject,
-                                    uint8_t* buffer, uint32_t len);
-  int EncodeAuthenticationRejectMsg(AuthenticationRejectMsg* auth_reject,
-                                    uint8_t* buffer, uint32_t len);
+  int DecodeAuthenticationRejectMsg(uint8_t* buffer, uint32_t len);
+  int EncodeAuthenticationRejectMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 /*****************************************************************************

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationRequest.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationRequest.hpp
@@ -39,10 +39,8 @@ class AuthenticationRequestMsg {
 
   AuthenticationRequestMsg();
   ~AuthenticationRequestMsg();
-  int DecodeAuthenticationRequestMsg(AuthenticationRequestMsg* auth_request,
-                                     uint8_t* buffer, uint32_t len);
-  int EncodeAuthenticationRequestMsg(AuthenticationRequestMsg* auth_request,
-                                     uint8_t* buffer, uint32_t len);
+  int DecodeAuthenticationRequestMsg(uint8_t* buffer, uint32_t len);
+  int EncodeAuthenticationRequestMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResponse.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResponse.hpp
@@ -31,10 +31,8 @@ class AuthenticationResponseMsg {
 
   AuthenticationResponseMsg();
   ~AuthenticationResponseMsg();
-  int DecodeAuthenticationResponseMsg(AuthenticationResponseMsg* auth_response,
-                                      uint8_t* buffer, uint32_t len);
-  int EncodeAuthenticationResponseMsg(AuthenticationResponseMsg* auth_response,
-                                      uint8_t* buffer, uint32_t len);
+  int DecodeAuthenticationResponseMsg(uint8_t* buffer, uint32_t len);
+  int EncodeAuthenticationResponseMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResult.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationResult.hpp
@@ -31,10 +31,8 @@ class AuthenticationResultMsg {
   NASKeySetIdentifierMsg nas_key_set_identifier;
   EAPMessageMsg eap_message;
 #define AUTHENTICATION_RESULT_MINIMUM_LENGTH 10
-  int DecodeAuthenticationResultMsg(AuthenticationResultMsg* auth_result,
-                                    uint8_t* buffer, uint32_t len);
-  int EncodeAuthenticationResultMsg(AuthenticationResultMsg* auth_result,
-                                    uint8_t* buffer, uint32_t len);
+  int DecodeAuthenticationResultMsg(uint8_t* buffer, uint32_t len);
+  int EncodeAuthenticationResultMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h
@@ -1,8 +1,25 @@
 #pragma once
 #include <arpa/inet.h>
+#include <iostream>
+#include <cstring>
+#include <sstream>
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/oai/common/TLVDecoder.h"
+#include "lte/gateway/c/core/oai/common/TLVEncoder.h"
+#ifdef __cplusplus
+}
+#endif
+
+#include "lte/gateway/c/core/oai/lib/bstr/bstrlib.h"
 #include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/common/glogwrapper/glog_logging.hpp"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GNasEnums.h"
+#include "lte/gateway/c/core/oai/tasks/nas5g/include/M5gNasMessage.h"
 
 // AMF_TEST scheme output  nibbles needs to be reversed
 #define REV_NIBBLE(bUFFER, sIZE)                                         \

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDLNASTransport.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDLNASTransport.hpp
@@ -10,6 +10,7 @@
 */
 
 #pragma once
+#include <cstring>
 #include <sstream>
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GExtendedProtocolDiscriminator.hpp"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSpareHalfOctet.hpp"
@@ -37,10 +38,15 @@ class DLNASTransportMsg {
 
   DLNASTransportMsg();
   ~DLNASTransportMsg();
-  int DecodeDLNASTransportMsg(DLNASTransportMsg* dl_nas_transport,
-                              uint8_t* buffer, uint32_t len);
-  int EncodeDLNASTransportMsg(DLNASTransportMsg* dl_nas_transport,
-                              uint8_t* buffer, uint32_t len);
+  int DecodeDLNASTransportMsg(uint8_t* buffer, uint32_t len);
+  int EncodeDLNASTransportMsg(uint8_t* buffer, uint32_t len);
+
+  DLNASTransportMsg& operator=(const DLNASTransportMsg& other) {
+    if (this != &other) memcpy(this, &other, sizeof(DLNASTransportMsg));
+    return *this;
+    /** TODO: implement a copy mechanism that takes into account each subtype to
+     * avoid copying invalid pointers */
+  }
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDeRegistrationAcceptUEInit.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDeRegistrationAcceptUEInit.hpp
@@ -27,12 +27,8 @@ class DeRegistrationAcceptUEInitMsg {
   SpareHalfOctetMsg spare_half_octet;
   MessageTypeMsg message_type;
 #define DEREGISTRATION_ACCEPT_UEINIT_MINIMUM_LENGTH 3
-  int DecodeDeRegistrationAcceptUEInitMsg(
-      DeRegistrationAcceptUEInitMsg* de_reg_accept_ue, uint8_t* buffer,
-      uint32_t len);
-  int EncodeDeRegistrationAcceptUEInitMsg(
-      DeRegistrationAcceptUEInitMsg* de_reg_accept_ue, uint8_t* buffer,
-      uint32_t len);
+  int DecodeDeRegistrationAcceptUEInitMsg(uint8_t* buffer, uint32_t len);
+  int EncodeDeRegistrationAcceptUEInitMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDeRegistrationRequestUEInit.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GDeRegistrationRequestUEInit.hpp
@@ -33,12 +33,8 @@ class DeRegistrationRequestUEInitMsg {
   NASKeySetIdentifierMsg nas_key_set_identifier;
   M5GSMobileIdentityMsg m5gs_mobile_identity;
 #define DEREGISTRATION_REQUEST_UEINIT_MINIMUM_LENGTH 3
-  int DecodeDeRegistrationRequestUEInitMsg(
-      DeRegistrationRequestUEInitMsg* de_reg_req_ue, uint8_t* buffer,
-      uint32_t len);
-  int EncodeDeRegistrationRequestUEInitMsg(
-      DeRegistrationRequestUEInitMsg* de_reg_req_ue, uint8_t* buffer,
-      uint32_t len);
+  int DecodeDeRegistrationRequestUEInitMsg(uint8_t* buffer, uint32_t len);
+  int EncodeDeRegistrationRequestUEInitMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GIdentityRequest.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GIdentityRequest.hpp
@@ -30,10 +30,8 @@ class IdentityRequestMsg {
 
   IdentityRequestMsg();
   ~IdentityRequestMsg();
-  int DecodeIdentityRequestMsg(IdentityRequestMsg* identity_request,
-                               uint8_t* buffer, uint32_t len);
-  int EncodeIdentityRequestMsg(IdentityRequestMsg* identity_request,
-                               uint8_t* buffer, uint32_t len);
+  int DecodeIdentityRequestMsg(uint8_t* buffer, uint32_t len);
+  int EncodeIdentityRequestMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GIdentityResponse.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GIdentityResponse.hpp
@@ -30,10 +30,8 @@ class IdentityResponseMsg {
 
   IdentityResponseMsg();
   ~IdentityResponseMsg();
-  int DecodeIdentityResponseMsg(IdentityResponseMsg* identity_response,
-                                uint8_t* buffer, uint32_t len);
-  int EncodeIdentityResponseMsg(IdentityResponseMsg* identity_response,
-                                uint8_t* buffer, uint32_t len);
+  int DecodeIdentityResponseMsg(uint8_t* buffer, uint32_t len);
+  int EncodeIdentityResponseMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentAccept.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentAccept.hpp
@@ -51,12 +51,8 @@ class PDUSessionEstablishmentAcceptMsg {
 
   PDUSessionEstablishmentAcceptMsg();
   ~PDUSessionEstablishmentAcceptMsg();
-  int DecodePDUSessionEstablishmentAcceptMsg(
-      PDUSessionEstablishmentAcceptMsg* pdu_session_estab_accept,
-      uint8_t* buffer, uint32_t len);
-  int EncodePDUSessionEstablishmentAcceptMsg(
-      PDUSessionEstablishmentAcceptMsg* pdu_session_estab_accept,
-      uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionEstablishmentAcceptMsg(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionEstablishmentAcceptMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentReject.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentReject.hpp
@@ -30,12 +30,8 @@ class PDUSessionEstablishmentRejectMsg {
 
   PDUSessionEstablishmentRejectMsg();
   ~PDUSessionEstablishmentRejectMsg();
-  int DecodePDUSessionEstablishmentRejectMsg(
-      PDUSessionEstablishmentRejectMsg* pdu_session_estab_reject,
-      uint8_t* buffer, uint32_t len);
-  int EncodePDUSessionEstablishmentRejectMsg(
-      PDUSessionEstablishmentRejectMsg* pdu_session_estab_reject,
-      uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionEstablishmentRejectMsg(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionEstablishmentRejectMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentRequest.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionEstablishmentRequest.hpp
@@ -40,12 +40,8 @@ class PDUSessionEstablishmentRequestMsg {
 
   PDUSessionEstablishmentRequestMsg();
   ~PDUSessionEstablishmentRequestMsg();
-  int DecodePDUSessionEstablishmentRequestMsg(
-      PDUSessionEstablishmentRequestMsg* pdu_session_estab_request,
-      uint8_t* buffer, uint32_t len);
-  int EncodePDUSessionEstablishmentRequestMsg(
-      PDUSessionEstablishmentRequestMsg* pdu_session_estab_request,
-      uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionEstablishmentRequestMsg(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionEstablishmentRequestMsg(uint8_t* buffer, uint32_t len);
   void copy(const PDUSessionEstablishmentRequestMsg& p) {
     extended_protocol_discriminator.copy(p.extended_protocol_discriminator);
     pdu_session_identity.copy(p.pdu_session_identity);

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationCommand.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationCommand.hpp
@@ -45,11 +45,7 @@ class PDUSessionModificationCommand {
   PDUSessionModificationCommand();
   ~PDUSessionModificationCommand();
 
-  int EncodePDUSessionModificationCommand(
-      PDUSessionModificationCommand* pdu_sess_mod_com, uint8_t* buffer,
-      uint32_t len);
-  int DecodePDUSessionModificationCommand(
-      PDUSessionModificationCommand* pdu_sess_mod_com, uint8_t* buffer,
-      uint32_t len);
+  int EncodePDUSessionModificationCommand(uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionModificationCommand(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationCommandReject.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationCommandReject.hpp
@@ -45,11 +45,7 @@ class PDUSessionModificationCommandReject {
 
   PDUSessionModificationCommandReject();
   ~PDUSessionModificationCommandReject();
-  int DecodePDUSessionModificationCommandReject(
-      PDUSessionModificationCommandReject* pdu_sess_mod_comd_rej,
-      uint8_t* buffer, uint32_t len);
-  int EncodePDUSessionModificationCommandReject(
-      PDUSessionModificationCommandReject* pdu_sess_mod_comd_rej,
-      uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionModificationCommandReject(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionModificationCommandReject(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationComplete.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationComplete.hpp
@@ -32,11 +32,7 @@ class PDUSessionModificationComplete {
   ProtocolConfigurationOptions extProtocolconfigurationoptions;
   PDUSessionModificationComplete();
   ~PDUSessionModificationComplete();
-  int DecodePDUSessionModificationComplete(
-      PDUSessionModificationComplete* pdu_sess_mod_com, uint8_t* buffer,
-      uint32_t len);
-  int EncodePDUSessionModificationComplete(
-      PDUSessionModificationComplete* pdu_sess_mod_com, uint8_t* buffer,
-      uint32_t len);
+  int DecodePDUSessionModificationComplete(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionModificationComplete(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationReject.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationReject.hpp
@@ -32,12 +32,8 @@ class PDUSessionModificationRejectMsg {
 
   PDUSessionModificationRejectMsg();
   ~PDUSessionModificationRejectMsg();
-  int DecodePDUSessionModificationRejectMsg(
-      PDUSessionModificationRejectMsg* pdu_session_modif_reject,
-      uint8_t* buffer, uint32_t len);
-  int EncodePDUSessionModificationRejectMsg(
-      PDUSessionModificationRejectMsg* pdu_session_modif_reject,
-      uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionModificationRejectMsg(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionModificationRejectMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationRequest.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionModificationRequest.hpp
@@ -38,12 +38,8 @@ class PDUSessionModificationRequestMsg {
 
   PDUSessionModificationRequestMsg();
   ~PDUSessionModificationRequestMsg();
-  int DecodePDUSessionModificationRequestMsg(
-      PDUSessionModificationRequestMsg* pdu_session_modif_request,
-      uint8_t* buffer, uint32_t len);
-  int EncodePDUSessionModificationRequestMsg(
-      PDUSessionModificationRequestMsg* pdu_session_modif_request,
-      uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionModificationRequestMsg(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionModificationRequestMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseCommand.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseCommand.hpp
@@ -30,11 +30,7 @@ class PDUSessionReleaseCommandMsg {
 
   PDUSessionReleaseCommandMsg();
   ~PDUSessionReleaseCommandMsg();
-  int DecodePDUSessionReleaseCommandMsg(
-      PDUSessionReleaseCommandMsg* pdu_session_release_command, uint8_t* buffer,
-      uint32_t len);
-  int EncodePDUSessionReleaseCommandMsg(
-      PDUSessionReleaseCommandMsg* pdu_session_release_command, uint8_t* buffer,
-      uint32_t len);
+  int DecodePDUSessionReleaseCommandMsg(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionReleaseCommandMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseReject.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseReject.hpp
@@ -30,12 +30,8 @@ class PDUSessionReleaseRejectMsg {
 
   PDUSessionReleaseRejectMsg();
   ~PDUSessionReleaseRejectMsg();
-  int DecodePDUSessionReleaseRejectMsg(
-      PDUSessionReleaseRejectMsg* pdu_session_release_reject, uint8_t* buffer,
-      uint32_t len);
-  int EncodePDUSessionReleaseRejectMsg(
-      PDUSessionReleaseRejectMsg* pdu_session_release_reject, uint8_t* buffer,
-      uint32_t len);
+  int DecodePDUSessionReleaseRejectMsg(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionReleaseRejectMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseRequest.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GPDUSessionReleaseRequest.hpp
@@ -28,12 +28,8 @@ class PDUSessionReleaseRequestMsg {
 
   PDUSessionReleaseRequestMsg();
   ~PDUSessionReleaseRequestMsg();
-  int DecodePDUSessionReleaseRequestMsg(
-      PDUSessionReleaseRequestMsg* pdu_session_release_request, uint8_t* buffer,
-      uint32_t len);
-  int EncodePDUSessionReleaseRequestMsg(
-      PDUSessionReleaseRequestMsg* pdu_session_release_request, uint8_t* buffer,
-      uint32_t len);
+  int DecodePDUSessionReleaseRequestMsg(uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionReleaseRequestMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationAccept.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationAccept.hpp
@@ -41,10 +41,8 @@ class RegistrationAcceptMsg {
 
   RegistrationAcceptMsg();
   ~RegistrationAcceptMsg();
-  int DecodeRegistrationAcceptMsg(RegistrationAcceptMsg* reg_accept,
-                                  uint8_t* buffer, uint32_t len);
-  int EncodeRegistrationAcceptMsg(RegistrationAcceptMsg* reg_accept,
-                                  uint8_t* buffer, uint32_t len);
+  int DecodeRegistrationAcceptMsg(uint8_t* buffer, uint32_t len);
+  int EncodeRegistrationAcceptMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationComplete.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationComplete.hpp
@@ -29,10 +29,8 @@ class RegistrationCompleteMsg {
 
   RegistrationCompleteMsg();
   ~RegistrationCompleteMsg();
-  int DecodeRegistrationCompleteMsg(RegistrationCompleteMsg* reg_complete,
-                                    uint8_t* buffer, uint32_t len);
-  int EncodeRegistrationCompleteMsg(RegistrationCompleteMsg* reg_complete,
-                                    uint8_t* buffer, uint32_t len);
+  int DecodeRegistrationCompleteMsg(uint8_t* buffer, uint32_t len);
+  int EncodeRegistrationCompleteMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationReject.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationReject.hpp
@@ -29,10 +29,8 @@ class RegistrationRejectMsg {
 
   RegistrationRejectMsg();
   ~RegistrationRejectMsg();
-  int DecodeRegistrationRejectMsg(RegistrationRejectMsg* reg_reject,
-                                  uint8_t* buffer, uint32_t len);
-  int EncodeRegistrationRejectMsg(RegistrationRejectMsg* reg_reject,
-                                  uint8_t* buffer, uint32_t len);
+  int DecodeRegistrationRejectMsg(uint8_t* buffer, uint32_t len);
+  int EncodeRegistrationRejectMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationRequest.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationRequest.hpp
@@ -60,10 +60,8 @@ class RegistrationRequestMsg {
 
   RegistrationRequestMsg();
   ~RegistrationRequestMsg();
-  int DecodeRegistrationRequestMsg(RegistrationRequestMsg* reg_request,
-                                   uint8_t* buffer, uint32_t len);
-  int EncodeRegistrationRequestMsg(RegistrationRequestMsg* reg_request,
-                                   uint8_t* buffer, uint32_t len);
+  int DecodeRegistrationRequestMsg(uint8_t* buffer, uint32_t len);
+  int EncodeRegistrationRequestMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeCommand.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeCommand.hpp
@@ -36,10 +36,8 @@ class SecurityModeCommandMsg {
 
   SecurityModeCommandMsg();
   ~SecurityModeCommandMsg();
-  int DecodeSecurityModeCommandMsg(SecurityModeCommandMsg* sec_mode_command,
-                                   uint8_t* buffer, uint32_t len);
-  int EncodeSecurityModeCommandMsg(SecurityModeCommandMsg* sec_mode_command,
-                                   uint8_t* buffer, uint32_t len);
+  int DecodeSecurityModeCommandMsg(uint8_t* buffer, uint32_t len);
+  int EncodeSecurityModeCommandMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeComplete.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeComplete.hpp
@@ -28,10 +28,8 @@ class SecurityModeCompleteMsg {
 
   SecurityModeCompleteMsg();
   ~SecurityModeCompleteMsg();
-  int DecodeSecurityModeCompleteMsg(SecurityModeCompleteMsg* sec_mode_complete,
-                                    uint8_t* buffer, uint32_t len);
-  int EncodeSecurityModeCompleteMsg(SecurityModeCompleteMsg* sec_mode_complete,
-                                    uint8_t* buffer, uint32_t len);
+  int DecodeSecurityModeCompleteMsg(uint8_t* buffer, uint32_t len);
+  int EncodeSecurityModeCompleteMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeReject.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GSecurityModeReject.hpp
@@ -29,10 +29,8 @@ class SecurityModeRejectMsg {
 
   SecurityModeRejectMsg();
   ~SecurityModeRejectMsg();
-  int DecodeSecurityModeRejectMsg(SecurityModeRejectMsg* sec_mode_reject,
-                                  uint8_t* buffer, uint32_t len);
-  int EncodeSecurityModeRejectMsg(SecurityModeRejectMsg* sec_mode_reject,
-                                  uint8_t* buffer, uint32_t len);
+  int DecodeSecurityModeRejectMsg(uint8_t* buffer, uint32_t len);
+  int EncodeSecurityModeRejectMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 /******************************************************************************

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceAccept.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceAccept.hpp
@@ -32,9 +32,7 @@ class ServiceAcceptMsg {
 
   ServiceAcceptMsg();
   ~ServiceAcceptMsg();
-  int DecodeServiceAcceptMsg(ServiceAcceptMsg* service_accept, uint8_t* buffer,
-                             uint32_t len);
-  int EncodeServiceAcceptMsg(ServiceAcceptMsg* service_accept, uint8_t* buffer,
-                             uint32_t len);
+  int DecodeServiceAcceptMsg(uint8_t* buffer, uint32_t len);
+  int EncodeServiceAcceptMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceReject.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceReject.hpp
@@ -34,9 +34,7 @@ class ServiceRejectMsg {
 
   ServiceRejectMsg();
   ~ServiceRejectMsg();
-  int DecodeServiceRejectMsg(ServiceRejectMsg* service_reject, uint8_t* buffer,
-                             uint32_t len);
-  int EncodeServiceRejectMsg(ServiceRejectMsg* service_reject, uint8_t* buffer,
-                             uint32_t len);
+  int DecodeServiceRejectMsg(uint8_t* buffer, uint32_t len);
+  int EncodeServiceRejectMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceRequest.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GServiceRequest.hpp
@@ -38,9 +38,7 @@ class ServiceRequestMsg {
 
   ServiceRequestMsg();
   ~ServiceRequestMsg();
-  int DecodeServiceRequestMsg(ServiceRequestMsg* svc_request, uint8_t* buffer,
-                              uint32_t len);
-  int EncodeServiceRequestMsg(ServiceRequestMsg* svc_request, uint8_t* buffer,
-                              uint32_t len);
+  int DecodeServiceRequestMsg(uint8_t* buffer, uint32_t len);
+  int EncodeServiceRequestMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GULNASTransport.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GULNASTransport.hpp
@@ -39,10 +39,8 @@ class ULNASTransportMsg {
 
   ULNASTransportMsg();
   ~ULNASTransportMsg();
-  int DecodeULNASTransportMsg(ULNASTransportMsg* ul_nas_transport,
-                              uint8_t* buffer, uint32_t len);
-  int EncodeULNASTransportMsg(ULNASTransportMsg* ul_nas_transport,
-                              uint8_t* buffer, uint32_t len);
+  int DecodeULNASTransportMsg(uint8_t* buffer, uint32_t len);
+  int EncodeULNASTransportMsg(uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/SmfMessage.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/SmfMessage.hpp
@@ -73,10 +73,10 @@ class SmfMsg {
 
   SmfMsg();
   ~SmfMsg();
-  int SmfMsgDecodeHeaderMsg(SmfMsgHeader* hdr, uint8_t* buffer, uint32_t len);
-  int SmfMsgEncodeHeaderMsg(SmfMsgHeader* hdr, uint8_t* buffer, uint32_t len);
-  int SmfMsgDecodeMsg(SmfMsg* msg, uint8_t* buffer, uint32_t len);
-  int SmfMsgEncodeMsg(SmfMsg* msg, uint8_t* buffer, uint32_t len);
+  int SmfMsgDecodeHeaderMsg(uint8_t* buffer, uint32_t len);
+  int SmfMsgEncodeHeaderMsg(uint8_t* buffer, uint32_t len);
+  int SmfMsgDecodeMsg(uint8_t* buffer, uint32_t len);
+  int SmfMsgEncodeMsg(uint8_t* buffer, uint32_t len);
   void copy(const SmfMsg& s) {
     header.copy(s.header);
     switch (static_cast<M5GMessageType>(s.header.message_type)) {

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GABBA.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GABBA.hpp
@@ -22,7 +22,7 @@ class ABBAMsg {
 
   ABBAMsg();
   ~ABBAMsg();
-  int EncodeABBAMsg(ABBAMsg* abba, uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodeABBAMsg(ABBAMsg* abba, uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodeABBAMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeABBAMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationFailureIE.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationFailureIE.hpp
@@ -25,8 +25,7 @@ class M5GAuthenticationFailureIE {
 
   M5GAuthenticationFailureIE();
   ~M5GAuthenticationFailureIE();
-  int DecodeM5GAuthenticationFailureIE(
-      M5GAuthenticationFailureIE* m5g_auth_failure_ie, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
+  int DecodeM5GAuthenticationFailureIE(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterAUTN.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterAUTN.hpp
@@ -24,11 +24,9 @@ class AuthenticationParameterAUTNMsg {
 
   AuthenticationParameterAUTNMsg();
   ~AuthenticationParameterAUTNMsg();
-  int EncodeAuthenticationParameterAUTNMsg(
-      AuthenticationParameterAUTNMsg* auth_parameter_autn, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
-  int DecodeAuthenticationParameterAUTNMsg(
-      AuthenticationParameterAUTNMsg* auth_parameter_autn, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
+  int EncodeAuthenticationParameterAUTNMsg(uint8_t iei, uint8_t* buffer,
+                                           uint32_t len);
+  int DecodeAuthenticationParameterAUTNMsg(uint8_t iei, uint8_t* buffer,
+                                           uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterRAND.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationParameterRAND.hpp
@@ -24,11 +24,9 @@ class AuthenticationParameterRANDMsg {
 
   AuthenticationParameterRANDMsg();
   ~AuthenticationParameterRANDMsg();
-  int EncodeAuthenticationParameterRANDMsg(
-      AuthenticationParameterRANDMsg* auth_parameter_rand, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
-  int DecodeAuthenticationParameterRANDMsg(
-      AuthenticationParameterRANDMsg* auth_parameter_rand, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
+  int EncodeAuthenticationParameterRANDMsg(uint8_t iei, uint8_t* buffer,
+                                           uint32_t len);
+  int DecodeAuthenticationParameterRANDMsg(uint8_t iei, uint8_t* buffer,
+                                           uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationResponseParameter.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationResponseParameter.hpp
@@ -26,11 +26,9 @@ class AuthenticationResponseParameterMsg {
 
   AuthenticationResponseParameterMsg();
   ~AuthenticationResponseParameterMsg();
-  int EncodeAuthenticationResponseParameterMsg(
-      AuthenticationResponseParameterMsg* response_parameter, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
-  int DecodeAuthenticationResponseParameterMsg(
-      AuthenticationResponseParameterMsg* response_parameter, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
+  int EncodeAuthenticationResponseParameterMsg(uint8_t iei, uint8_t* buffer,
+                                               uint32_t len);
+  int DecodeAuthenticationResponseParameterMsg(uint8_t iei, uint8_t* buffer,
+                                               uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GDNN.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GDNN.hpp
@@ -26,9 +26,7 @@ class DNNMsg {
 
   DNNMsg();
   ~DNNMsg();
-  int EncodeDNNMsg(DNNMsg* eap_message, uint8_t iei, uint8_t* buffer,
-                   uint32_t len);
-  int DecodeDNNMsg(DNNMsg* eap_message, uint8_t iei, uint8_t* buffer,
-                   uint32_t len);
+  int EncodeDNNMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeDNNMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GEAPMessage.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GEAPMessage.hpp
@@ -23,9 +23,7 @@ class EAPMessageMsg {
 
   EAPMessageMsg();
   ~EAPMessageMsg();
-  int EncodeEAPMessageMsg(EAPMessageMsg* eap_message, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
-  int DecodeEAPMessageMsg(EAPMessageMsg* eap_message, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
+  int EncodeEAPMessageMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeEAPMessageMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GExtendedProtocolDiscriminator.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GExtendedProtocolDiscriminator.hpp
@@ -21,20 +21,24 @@ class ExtendedProtocolDiscriminatorMsg {
 
   ExtendedProtocolDiscriminatorMsg();
   ~ExtendedProtocolDiscriminatorMsg();
-  int EncodeExtendedProtocolDiscriminatorMsg(
-      ExtendedProtocolDiscriminatorMsg* extended_protocol_discriminator,
-      uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodeExtendedProtocolDiscriminatorMsg(
-      ExtendedProtocolDiscriminatorMsg* extended_protocol_discriminator,
-      uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodeExtendedProtocolDiscriminatorMsg(uint8_t iei, uint8_t* buffer,
+                                             uint32_t len);
+  int DecodeExtendedProtocolDiscriminatorMsg(uint8_t iei, uint8_t* buffer,
+                                             uint32_t len);
   void copy(const ExtendedProtocolDiscriminatorMsg& e) {
     extended_proto_discriminator = e.extended_proto_discriminator;
   }
-  bool isEqual(const ExtendedProtocolDiscriminatorMsg& e) {
-    if (extended_proto_discriminator == e.extended_proto_discriminator) {
-      return true;
-    }
-    return false;
+  bool isEqual(const ExtendedProtocolDiscriminatorMsg& e) { return *this == e; }
+  bool operator==(const ExtendedProtocolDiscriminatorMsg& other) {
+    return extended_proto_discriminator == other.extended_proto_discriminator;
+  }
+  bool operator!=(const ExtendedProtocolDiscriminatorMsg& other) {
+    return !(*this == other);
+  }
+  ExtendedProtocolDiscriminatorMsg& operator=(
+      const ExtendedProtocolDiscriminatorMsg& other) {
+    this->extended_proto_discriminator = other.extended_proto_discriminator;
+    return *this;
   }
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GGprsTimer2.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GGprsTimer2.hpp
@@ -23,10 +23,8 @@ class GPRSTimer2Msg {
   GPRSTimer2Msg();
   ~GPRSTimer2Msg();
 
-  int EncodeGPRSTimer2Msg(GPRSTimer2Msg* gprstimer, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
+  int EncodeGPRSTimer2Msg(uint8_t iei, uint8_t* buffer, uint32_t len);
 
-  int DecodeGPRSTimer2Msg(GPRSTimer2Msg* gprstimer, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
+  int DecodeGPRSTimer2Msg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GGprsTimer3.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GGprsTimer3.hpp
@@ -24,10 +24,8 @@ class GPRSTimer3Msg {
   GPRSTimer3Msg();
   ~GPRSTimer3Msg();
 
-  int EncodeGPRSTimer3Msg(GPRSTimer3Msg* gprstimer, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
+  int EncodeGPRSTimer3Msg(uint8_t iei, uint8_t* buffer, uint32_t len);
 
-  int DecodeGPRSTimer3Msg(GPRSTimer3Msg* gprstimer, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
+  int DecodeGPRSTimer3Msg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GIMEISVRequest.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GIMEISVRequest.hpp
@@ -23,9 +23,7 @@ class ImeisvRequestMsg {
 
   ImeisvRequestMsg();
   ~ImeisvRequestMsg();
-  int EncodeImeisvRequestMsg(ImeisvRequestMsg* imeisv_request, uint8_t iei,
-                             uint8_t* buffer, uint32_t len);
-  int DecodeImeisvRequestMsg(ImeisvRequestMsg* imeisv_request, uint8_t iei,
-                             uint8_t* buffer, uint32_t len);
+  int EncodeImeisvRequestMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeImeisvRequestMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GIntegrityProtMaxDataRate.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GIntegrityProtMaxDataRate.hpp
@@ -22,12 +22,10 @@ class IntegrityProtMaxDataRateMsg {
 
   IntegrityProtMaxDataRateMsg();
   ~IntegrityProtMaxDataRateMsg();
-  int EncodeIntegrityProtMaxDataRateMsg(
-      IntegrityProtMaxDataRateMsg* integrity_prot_max_data_rate, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
-  int DecodeIntegrityProtMaxDataRateMsg(
-      IntegrityProtMaxDataRateMsg* integrity_prot_max_data_rate, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
+  int EncodeIntegrityProtMaxDataRateMsg(uint8_t iei, uint8_t* buffer,
+                                        uint32_t len);
+  int DecodeIntegrityProtMaxDataRateMsg(uint8_t iei, uint8_t* buffer,
+                                        uint32_t len);
 
   void copy(const IntegrityProtMaxDataRateMsg& i) {
     max_uplink = i.max_uplink;

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMMCause.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMMCause.hpp
@@ -23,9 +23,7 @@ class M5GMMCauseMsg {
 
   M5GMMCauseMsg();
   ~M5GMMCauseMsg();
-  int EncodeM5GMMCauseMsg(M5GMMCauseMsg* m5gmm_cause, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
-  int DecodeM5GMMCauseMsg(M5GMMCauseMsg* m5gmm_cause, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
+  int EncodeM5GMMCauseMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeM5GMMCauseMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMaxNumOfSupportedPacketFilters.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMaxNumOfSupportedPacketFilters.hpp
@@ -21,11 +21,9 @@ class M5GMaxNumOfSupportedPacketFilters {
 
   M5GMaxNumOfSupportedPacketFilters();
   ~M5GMaxNumOfSupportedPacketFilters();
-  int EncodeMaxNumOfSupportedPacketFilters(
-      M5GMaxNumOfSupportedPacketFilters* maxNumOfSuppPktFilters, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
-  int DecodeMaxNumOfSupportedPacketFilters(
-      M5GMaxNumOfSupportedPacketFilters* maxNumOfSuppPktFilters, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
+  int EncodeMaxNumOfSupportedPacketFilters(uint8_t iei, uint8_t* buffer,
+                                           uint32_t len);
+  int DecodeMaxNumOfSupportedPacketFilters(uint8_t iei, uint8_t* buffer,
+                                           uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMessageType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMessageType.hpp
@@ -21,12 +21,18 @@ class MessageTypeMsg {
 
   MessageTypeMsg();
   ~MessageTypeMsg();
-  int EncodeMessageTypeMsg(MessageTypeMsg* message_type, uint8_t iei,
-                           uint8_t* buffer, uint32_t len);
-  int DecodeMessageTypeMsg(MessageTypeMsg* message_type, uint8_t iei,
-                           uint8_t* buffer, uint32_t len);
+  int EncodeMessageTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeMessageTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 
   void copy(const MessageTypeMsg& m) { msg_type = m.msg_type; }
-  bool isEqual(const MessageTypeMsg& m) { return (msg_type == m.msg_type); }
+  bool isEqual(const MessageTypeMsg& m) { return (*this == m); }
+  bool operator==(const MessageTypeMsg& other) {
+    return msg_type == other.msg_type;
+  }
+  bool operator!=(const MessageTypeMsg& other) { return !(*this == other); }
+  MessageTypeMsg& operator=(const MessageTypeMsg& other) {
+    this->msg_type = other.msg_type;
+    return *this;
+  }
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNASKeySetIdentifier.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNASKeySetIdentifier.hpp
@@ -23,11 +23,7 @@ class NASKeySetIdentifierMsg {
 
   NASKeySetIdentifierMsg();
   ~NASKeySetIdentifierMsg();
-  int EncodeNASKeySetIdentifierMsg(
-      NASKeySetIdentifierMsg* nas_key_set_identifier, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
-  int DecodeNASKeySetIdentifierMsg(
-      NASKeySetIdentifierMsg* nas_key_set_identifier, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
+  int EncodeNASKeySetIdentifierMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeNASKeySetIdentifierMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNASSecurityAlgorithms.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNASSecurityAlgorithms.hpp
@@ -44,11 +44,9 @@ class NASSecurityAlgorithmsMsg {
   M5GNasSecurityAlgorithms M5GNasSecurityAlgorithms_;
   NASSecurityAlgorithmsMsg();
   ~NASSecurityAlgorithmsMsg();
-  int EncodeNASSecurityAlgorithmsMsg(
-      NASSecurityAlgorithmsMsg* nas_sec_algorithms, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
-  int DecodeNASSecurityAlgorithmsMsg(
-      NASSecurityAlgorithmsMsg* nas_sec_algorithms, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
+  int EncodeNASSecurityAlgorithmsMsg(uint8_t iei, uint8_t* buffer,
+                                     uint32_t len);
+  int DecodeNASSecurityAlgorithmsMsg(uint8_t iei, uint8_t* buffer,
+                                     uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNSSAI.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNSSAI.hpp
@@ -28,10 +28,8 @@ class NSSAIMsg {
 
   NSSAIMsg();
   ~NSSAIMsg();
-  int EncodeNSSAIMsg(NSSAIMsg* nssai, uint8_t iei, uint8_t* buffer,
-                     uint32_t len);
-  int DecodeNSSAIMsg(NSSAIMsg* nssai, uint8_t iei, uint8_t* buffer,
-                     uint32_t len);
+  int EncodeNSSAIMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeNSSAIMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 
 class NSSAIMsgList {
@@ -42,7 +40,6 @@ class NSSAIMsgList {
 
   NSSAIMsgList();
   ~NSSAIMsgList();
-  int EncodeNSSAIMsgList(NSSAIMsgList* allowed_nssai, uint8_t iei,
-                         uint8_t* buffer, uint32_t len);
+  int EncodeNSSAIMsgList(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNetworkFeatureSupport.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNetworkFeatureSupport.hpp
@@ -30,12 +30,10 @@ class NetworkFeatureSupportMsg {
   NetworkFeatureSupportMsg();
   ~NetworkFeatureSupportMsg();
 
-  int EncodeNetworkFeatureSupportMsg(NetworkFeatureSupportMsg* networkfeature,
-                                     uint8_t iei, uint8_t* buffer,
+  int EncodeNetworkFeatureSupportMsg(uint8_t iei, uint8_t* buffer,
                                      uint32_t len);
 
-  int DecodeNetworkFeatureSupportMsg(NetworkFeatureSupportMsg* networkfeature,
-                                     uint8_t iei, uint8_t* buffer,
+  int DecodeNetworkFeatureSupportMsg(uint8_t iei, uint8_t* buffer,
                                      uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUAddress.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUAddress.hpp
@@ -27,9 +27,7 @@ class PDUAddressMsg {
 
   PDUAddressMsg();
   ~PDUAddressMsg();
-  int EncodePDUAddressMsg(PDUAddressMsg* pdu_address, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
-  int DecodePDUAddressMsg(PDUAddressMsg* pdu_address, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
+  int EncodePDUAddressMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodePDUAddressMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionIdentity.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionIdentity.hpp
@@ -22,10 +22,8 @@ class PDUSessionIdentityMsg {
 
   PDUSessionIdentityMsg();
   ~PDUSessionIdentityMsg();
-  int EncodePDUSessionIdentityMsg(PDUSessionIdentityMsg* pdu_session_id,
-                                  uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodePDUSessionIdentityMsg(PDUSessionIdentityMsg* pdu_session_id,
-                                  uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionIdentityMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionIdentityMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
   void copy(const PDUSessionIdentityMsg& p) {
     iei = p.iei;
     pdu_session_id = p.pdu_session_id;

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionReActivationResult.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionReActivationResult.hpp
@@ -21,11 +21,9 @@ class M5GPDUSessionReActivationResult {
 
   M5GPDUSessionReActivationResult();
   ~M5GPDUSessionReActivationResult();
-  int EncodePDUSessionReActivationResult(
-      M5GPDUSessionReActivationResult* pduSessionReActivationStatus,
-      uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodePDUSessionReActivationResult(
-      M5GPDUSessionReActivationResult* pduSessionReActivationStatus,
-      uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionReActivationResult(uint8_t iei, uint8_t* buffer,
+                                         uint32_t len);
+  int DecodePDUSessionReActivationResult(uint8_t iei, uint8_t* buffer,
+                                         uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionStatus.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionStatus.hpp
@@ -21,9 +21,7 @@ class M5GPDUSessionStatus {
 
   M5GPDUSessionStatus();
   ~M5GPDUSessionStatus();
-  int EncodePDUSessionStatus(M5GPDUSessionStatus* pduSessionStatus, uint8_t iei,
-                             uint8_t* buffer, uint32_t len);
-  int DecodePDUSessionStatus(M5GPDUSessionStatus* pduSessionStatus, uint8_t iei,
-                             uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionStatus(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionStatus(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionType.hpp
@@ -22,10 +22,8 @@ class PDUSessionTypeMsg {
 
   PDUSessionTypeMsg();
   ~PDUSessionTypeMsg();
-  int EncodePDUSessionTypeMsg(PDUSessionTypeMsg* pdu_session_type, uint8_t iei,
-                              uint8_t* buffer, uint32_t len);
-  int DecodePDUSessionTypeMsg(PDUSessionTypeMsg* pdu_session_type, uint8_t iei,
-                              uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodePDUSessionTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
   void copy(const PDUSessionTypeMsg& p) {
     iei = p.iei;
     type_val = p.type_val;

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPTI.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPTI.hpp
@@ -21,8 +21,8 @@ class PTIMsg {
 
   PTIMsg();
   ~PTIMsg();
-  int EncodePTIMsg(PTIMsg* pti, uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodePTIMsg(PTIMsg* pti, uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodePTIMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodePTIMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
   void copy(const PTIMsg& p) { pti = p.pti; }
   bool isEqual(const PTIMsg& p) {
     if (pti == p.pti) return true;

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainer.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainer.hpp
@@ -26,10 +26,8 @@ class PayloadContainerMsg {
 
   PayloadContainerMsg();
   ~PayloadContainerMsg();
-  int EncodePayloadContainerMsg(PayloadContainerMsg* payload_container,
-                                uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodePayloadContainerMsg(PayloadContainerMsg* payload_container,
-                                uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodePayloadContainerMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodePayloadContainerMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
   void copy(const PayloadContainerMsg& p) {
     iei = p.iei;
     len = p.len;

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainerType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPayloadContainerType.hpp
@@ -21,11 +21,7 @@ class PayloadContainerTypeMsg {
 
   PayloadContainerTypeMsg();
   ~PayloadContainerTypeMsg();
-  int EncodePayloadContainerTypeMsg(
-      PayloadContainerTypeMsg* payload_container_type, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
-  int DecodePayloadContainerTypeMsg(
-      PayloadContainerTypeMsg* payload_container_type, uint8_t iei,
-      uint8_t* buffer, uint32_t len);
+  int EncodePayloadContainerTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodePayloadContainerTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GProtocolConfigurationOptions.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GProtocolConfigurationOptions.hpp
@@ -31,20 +31,16 @@ class ProtocolConfigurationOptions {
   ProtocolConfigurationOptions();
   ~ProtocolConfigurationOptions();
 
-  int m5g_encode_protocol_configuration_options(
-      const protocol_configuration_options_t* const pco, uint8_t* buffer,
-      const uint32_t len);
+  int m5g_encode_protocol_configuration_options(uint8_t* buffer,
+                                                const uint32_t len);
 
-  int EncodeProtocolConfigurationOptions(ProtocolConfigurationOptions* pco,
-                                         uint8_t iei, uint8_t* buffer,
+  int EncodeProtocolConfigurationOptions(uint8_t iei, uint8_t* buffer,
                                          uint32_t len);
 
-  int m5g_decode_protocol_configuration_options(
-      protocol_configuration_options_t* pco, const uint8_t* const buffer,
-      const uint32_t len);
+  int m5g_decode_protocol_configuration_options(const uint8_t* const buffer,
+                                                const uint32_t len);
 
-  int DecodeProtocolConfigurationOptions(ProtocolConfigurationOptions* pco,
-                                         uint8_t iei, uint8_t* buffer,
+  int DecodeProtocolConfigurationOptions(uint8_t iei, uint8_t* buffer,
                                          uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQOSRules.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQOSRules.hpp
@@ -66,13 +66,9 @@ class QOSRulesMsg {
   QOSRulesMsg();
   ~QOSRulesMsg();
 
-  uint16_t EncodeQOSRulesMsgData(QOSRulesMsg* qos_rules, uint8_t* buffer,
-                                 uint32_t len);
-  int EncodeQOSRulesMsg(QOSRulesMsg* qos_rules, uint8_t iei, uint8_t* buffer,
-                        uint32_t len);
-  uint8_t DecodeQOSRulesMsgData(QOSRulesMsg* qos_rules, uint8_t* buffer,
-                                uint32_t len);
-  int DecodeQOSRulesMsg(QOSRulesMsg* qos_rules, uint8_t iei, uint8_t* buffer,
-                        uint32_t len);
+  uint16_t EncodeQOSRulesMsgData(uint8_t* buffer, uint32_t len);
+  int EncodeQOSRulesMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  uint8_t DecodeQOSRulesMsgData(uint8_t* buffer, uint32_t len);
+  int DecodeQOSRulesMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQosFlowDescriptor.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GQosFlowDescriptor.hpp
@@ -28,10 +28,8 @@ class M5GQosFlowDescription {
   uint8_t Ebit : 2;
   M5GQosFlowParam paramList[MAX_QOS_FLOW_PARAMS_LIST];
 
-  int EncodeM5GQosFlowDescription(M5GQosFlowDescription* qosFlowDesc,
-                                  uint8_t* buffer, uint32_t len);
-  int DecodeM5GQosFlowDescription(M5GQosFlowDescription* qosFlowDesc,
-                                  uint8_t* buffer, uint32_t len);
+  int EncodeM5GQosFlowDescription(uint8_t* buffer, uint32_t len);
+  int DecodeM5GQosFlowDescription(uint8_t* buffer, uint32_t len);
 
   M5GQosFlowDescription();
   ~M5GQosFlowDescription();

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GRequestType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GRequestType.hpp
@@ -19,10 +19,8 @@ class RequestType {
 
   RequestType();
   ~RequestType();
-  int EncodeRequestType(RequestType* reqest_type, uint8_t iei, uint8_t* buffer,
-                        uint32_t len);
-  int DecodeRequestType(RequestType* reqest_type, uint8_t iei, uint8_t* buffer,
-                        uint32_t len);
+  int EncodeRequestType(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeRequestType(uint8_t iei, uint8_t* buffer, uint32_t len);
   void copy(const RequestType& p) {
     iei = p.iei;
     type_val = p.type_val;

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSDeRegistrationType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSDeRegistrationType.hpp
@@ -21,11 +21,9 @@ class M5GSDeRegistrationTypeMsg {
 
   M5GSDeRegistrationTypeMsg();
   ~M5GSDeRegistrationTypeMsg();
-  int DecodeM5GSDeRegistrationTypeMsg(
-      M5GSDeRegistrationTypeMsg* m5gs_de_reg_type, uint8_t iei, uint8_t* buffer,
-      uint32_t len);
-  int EncodeM5GSDeRegistrationTypeMsg(
-      M5GSDeRegistrationTypeMsg* m5gs_de_reg_type, uint8_t iei, uint8_t* buffer,
-      uint32_t len);
+  int DecodeM5GSDeRegistrationTypeMsg(uint8_t iei, uint8_t* buffer,
+                                      uint32_t len);
+  int EncodeM5GSDeRegistrationTypeMsg(uint8_t iei, uint8_t* buffer,
+                                      uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSIdentityType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSIdentityType.hpp
@@ -22,9 +22,7 @@ class M5GSIdentityTypeMsg {
 
   M5GSIdentityTypeMsg();
   ~M5GSIdentityTypeMsg();
-  int EncodeM5GSIdentityTypeMsg(M5GSIdentityTypeMsg* m5gs_identity_type,
-                                uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodeM5GSIdentityTypeMsg(M5GSIdentityTypeMsg* m5gs_identity_type,
-                                uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodeM5GSIdentityTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeM5GSIdentityTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMCause.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMCause.hpp
@@ -22,9 +22,7 @@ class M5GSMCauseMsg {
 
   M5GSMCauseMsg();
   ~M5GSMCauseMsg();
-  int EncodeM5GSMCauseMsg(M5GSMCauseMsg* m5gsm_cause, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
-  int DecodeM5GSMCauseMsg(M5GSMCauseMsg* m5gsm_cause, uint8_t iei,
-                          uint8_t* buffer, uint32_t len);
+  int EncodeM5GSMCauseMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeM5GSMCauseMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.hpp
@@ -175,29 +175,17 @@ class M5GSMobileIdentityMsg {
 
   M5GSMobileIdentityMsg();
   ~M5GSMobileIdentityMsg();
-  int EncodeM5GSMobileIdentityMsg(M5GSMobileIdentityMsg* m5gs_mobile_identity,
-                                  uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodeM5GSMobileIdentityMsg(M5GSMobileIdentityMsg* m5gs_mobile_identity,
-                                  uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodeGutiMobileIdentityMsg(GutiM5GSMobileIdentity* guti, uint8_t* buffer,
-                                  uint8_t ielen);
-  int DecodeImeiMobileIdentityMsg(ImeiM5GSMobileIdentity* imei, uint8_t* buffer,
-                                  uint8_t ielen);
-  int DecodeImsiMobileIdentityMsg(ImsiM5GSMobileIdentity* imsi, uint8_t* buffer,
-                                  uint8_t ielen);
-  int DecodeSuciMobileIdentityMsg(SuciM5GSMobileIdentity* suci, uint8_t* buffer,
-                                  uint8_t ielen);
-  int DecodeTmsiMobileIdentityMsg(TmsiM5GSMobileIdentity* tmsi, uint8_t* buffer,
-                                  uint8_t ielen);
-  int EncodeGutiMobileIdentityMsg(GutiM5GSMobileIdentity* guti,
-                                  uint8_t* buffer);
-  int EncodeImeiMobileIdentityMsg(ImeiM5GSMobileIdentity* imei,
-                                  uint8_t* buffer);
-  int EncodeImsiMobileIdentityMsg(ImsiM5GSMobileIdentity* imsi,
-                                  uint8_t* buffer);
-  int EncodeSuciMobileIdentityMsg(SuciM5GSMobileIdentity* suci,
-                                  uint8_t* buffer);
-  int EncodeTmsiMobileIdentityMsg(TmsiM5GSMobileIdentity* tmsi,
-                                  uint8_t* buffer);
+  int EncodeM5GSMobileIdentityMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeM5GSMobileIdentityMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeGutiMobileIdentityMsg(uint8_t* buffer, uint8_t ielen);
+  int DecodeImeiMobileIdentityMsg(uint8_t* buffer, uint8_t ielen);
+  int DecodeImsiMobileIdentityMsg(uint8_t* buffer, uint8_t ielen);
+  int DecodeSuciMobileIdentityMsg(uint8_t* buffer, uint8_t ielen);
+  int DecodeTmsiMobileIdentityMsg(uint8_t* buffer, uint8_t ielen);
+  int EncodeGutiMobileIdentityMsg(uint8_t* buffer);
+  int EncodeImeiMobileIdentityMsg(uint8_t* buffer);
+  int EncodeImsiMobileIdentityMsg(uint8_t* buffer);
+  int EncodeSuciMobileIdentityMsg(uint8_t* buffer);
+  int EncodeTmsiMobileIdentityMsg(uint8_t* buffer);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationResult.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationResult.hpp
@@ -24,11 +24,9 @@ class M5GSRegistrationResultMsg {
 #define REGISTRATION_RESULT_MIN_LENGTH 2
   M5GSRegistrationResultMsg();
   ~M5GSRegistrationResultMsg();
-  int EncodeM5GSRegistrationResultMsg(
-      M5GSRegistrationResultMsg* m5gs_reg_result, uint8_t iei, uint8_t* buffer,
-      uint32_t len);
-  int DecodeM5GSRegistrationResultMsg(
-      M5GSRegistrationResultMsg* m5gs_reg_result, uint8_t iei, uint8_t* buffer,
-      uint32_t len);
+  int EncodeM5GSRegistrationResultMsg(uint8_t iei, uint8_t* buffer,
+                                      uint32_t len);
+  int DecodeM5GSRegistrationResultMsg(uint8_t iei, uint8_t* buffer,
+                                      uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationType.hpp
@@ -24,9 +24,7 @@ class M5GSRegistrationTypeMsg {
 
   M5GSRegistrationTypeMsg();
   ~M5GSRegistrationTypeMsg();
-  int EncodeM5GSRegistrationTypeMsg(M5GSRegistrationTypeMsg* m5gs_reg_type,
-                                    uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodeM5GSRegistrationTypeMsg(M5GSRegistrationTypeMsg* m5gs_reg_type,
-                                    uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodeM5GSRegistrationTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeM5GSRegistrationTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSSCMode.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSSCMode.hpp
@@ -22,10 +22,8 @@ class SSCModeMsg {
 
   SSCModeMsg();
   ~SSCModeMsg();
-  int EncodeSSCModeMsg(SSCModeMsg* ssc_mode, uint8_t iei, uint8_t* buffer,
-                       uint32_t len);
-  int DecodeSSCModeMsg(SSCModeMsg* ssc_mode, uint8_t iei, uint8_t* buffer,
-                       uint32_t len);
+  int EncodeSSCModeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeSSCModeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
   void copy(const SSCModeMsg& s) {
     iei = s.iei;
     mode_val = s.mode_val;

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSecurityHeaderType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSecurityHeaderType.hpp
@@ -21,9 +21,17 @@ class SecurityHeaderTypeMsg {
 
   SecurityHeaderTypeMsg();
   ~SecurityHeaderTypeMsg();
-  int EncodeSecurityHeaderTypeMsg(SecurityHeaderTypeMsg* sec_header_type,
-                                  uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodeSecurityHeaderTypeMsg(SecurityHeaderTypeMsg* sec_header_type,
-                                  uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodeSecurityHeaderTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeSecurityHeaderTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  bool operator==(const SecurityHeaderTypeMsg& other) {
+    return sec_hdr == other.sec_hdr;
+  }
+  bool operator!=(const SecurityHeaderTypeMsg& other) {
+    return !(*this == other);
+  }
+  SecurityHeaderTypeMsg& operator=(const SecurityHeaderTypeMsg& other) {
+    this->sec_hdr = other.sec_hdr;
+    return *this;
+  }
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GServiceType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GServiceType.hpp
@@ -28,9 +28,7 @@ class ServiceTypeMsg {
 
   ServiceTypeMsg();
   ~ServiceTypeMsg();
-  int EncodeServiceTypeMsg(ServiceTypeMsg* service_type, uint8_t iei,
-                           uint8_t* buffer, uint32_t len);
-  int DecodeServiceTypeMsg(ServiceTypeMsg* service_type, uint8_t iei,
-                           uint8_t* buffer, uint32_t len);
+  int EncodeServiceTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeServiceTypeMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSessionAMBR.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSessionAMBR.hpp
@@ -27,9 +27,7 @@ class SessionAMBRMsg {
 
   SessionAMBRMsg();
   ~SessionAMBRMsg();
-  int EncodeSessionAMBRMsg(SessionAMBRMsg* session_ambr, uint8_t iei,
-                           uint8_t* buffer, uint32_t len);
-  int DecodeSessionAMBRMsg(SessionAMBRMsg* session_ambr, uint8_t iei,
-                           uint8_t* buffer, uint32_t len);
+  int EncodeSessionAMBRMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeSessionAMBRMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSpareHalfOctet.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSpareHalfOctet.hpp
@@ -21,9 +21,7 @@ class SpareHalfOctetMsg {
 
   SpareHalfOctetMsg();
   ~SpareHalfOctetMsg();
-  int EncodeSpareHalfOctetMsg(SpareHalfOctetMsg* spare_half_octet, uint8_t iei,
-                              uint8_t* buffer, uint32_t len);
-  int DecodeSpareHalfOctetMsg(SpareHalfOctetMsg* spare_half_octet, uint8_t iei,
-                              uint8_t* buffer, uint32_t len);
+  int EncodeSpareHalfOctetMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeSpareHalfOctetMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GTAIList.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GTAIList.hpp
@@ -27,9 +27,7 @@ class TAIListMsg {
   uint8_t tac[3];
   TAIListMsg();
   ~TAIListMsg();
-  int EncodeTAIListMsg(TAIListMsg* nssai, uint8_t iei, uint8_t* buffer,
-                       uint32_t len);
-  int DecodeTAIListMsg(TAIListMsg* nssai, uint8_t iei, uint8_t* buffer,
-                       uint32_t len);
+  int EncodeTAIListMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeTAIListMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUESecurityCapability.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUESecurityCapability.hpp
@@ -57,9 +57,7 @@ class UESecurityCapabilityMsg {
 
   UESecurityCapabilityMsg();
   ~UESecurityCapabilityMsg();
-  int EncodeUESecurityCapabilityMsg(UESecurityCapabilityMsg* ue_sec_capability,
-                                    uint8_t iei, uint8_t* buffer, uint32_t len);
-  int DecodeUESecurityCapabilityMsg(UESecurityCapabilityMsg* ue_sec_capability,
-                                    uint8_t iei, uint8_t* buffer, uint32_t len);
+  int EncodeUESecurityCapabilityMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeUESecurityCapabilityMsg(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUplinkDataStatus.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUplinkDataStatus.hpp
@@ -21,9 +21,7 @@ class M5GUplinkDataStatus {
 
   M5GUplinkDataStatus();
   ~M5GUplinkDataStatus();
-  int EncodeUplinkDataStatus(M5GUplinkDataStatus* uplinkDataStatus, uint8_t iei,
-                             uint8_t* buffer, uint32_t len);
-  int DecodeUplinkDataStatus(M5GUplinkDataStatus* uplinkDataStatus, uint8_t iei,
-                             uint8_t* buffer, uint32_t len);
+  int EncodeUplinkDataStatus(uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeUplinkDataStatus(uint8_t iei, uint8_t* buffer, uint32_t len);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationFailure.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationFailure.cpp
@@ -25,41 +25,36 @@ AuthenticationFailureMsg::AuthenticationFailureMsg(){};
 AuthenticationFailureMsg::~AuthenticationFailureMsg(){};
 
 // Decoding Authentication Failure Message and its IEs
-int AuthenticationFailureMsg::DecodeAuthenticationFailureMsg(
-    AuthenticationFailureMsg* auth_failure, uint8_t* buffer, uint32_t len) {
+int AuthenticationFailureMsg::DecodeAuthenticationFailureMsg(uint8_t* buffer,
+                                                             uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, AUTHENTICATION_FAILURE_MINIMUM_LENGTH, len);
 
-  if ((decoded_result = auth_failure->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &auth_failure->extended_protocol_discriminator,
                                 0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_failure->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &auth_failure->spare_half_octet, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           auth_failure->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &auth_failure->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_failure->message_type.DecodeMessageTypeMsg(
-           &auth_failure->message_type, 0, buffer + decoded, len - decoded)) <
-      0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_failure->m5gmm_cause.DecodeM5GMMCauseMsg(
-           &auth_failure->m5gmm_cause, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->m5gmm_cause.DecodeM5GMMCauseMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -70,8 +65,7 @@ int AuthenticationFailureMsg::DecodeAuthenticationFailureMsg(
     switch (ieiDecoded) {
       case AUTHENTICATION_FAILURE_PARAMETER_IEI_AUTH_CHALLENGE:
         if ((decoded_result =
-                 auth_failure->auth_failure_ie.DecodeM5GAuthenticationFailureIE(
-                     &auth_failure->auth_failure_ie,
+                 this->auth_failure_ie.DecodeM5GAuthenticationFailureIE(
                      AUTHENTICATION_FAILURE_PARAMETER_IEI_AUTH_CHALLENGE,
                      buffer + decoded, len - decoded)) < 0)
           return decoded_result;
@@ -88,41 +82,36 @@ int AuthenticationFailureMsg::DecodeAuthenticationFailureMsg(
 }
 
 // Encoding Authentication Failure Message and its IEs
-int AuthenticationFailureMsg::EncodeAuthenticationFailureMsg(
-    AuthenticationFailureMsg* auth_failure, uint8_t* buffer, uint32_t len) {
+int AuthenticationFailureMsg::EncodeAuthenticationFailureMsg(uint8_t* buffer,
+                                                             uint32_t len) {
   uint32_t encoded = 0;
   int encodedresult = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, AUTHENTICATION_FAILURE_MINIMUM_LENGTH, len);
 
-  if ((encodedresult = auth_failure->extended_protocol_discriminator
+  if ((encodedresult = this->extended_protocol_discriminator
                            .EncodeExtendedProtocolDiscriminatorMsg(
-                               &auth_failure->extended_protocol_discriminator,
                                0, buffer + encoded, len - encoded)) < 0)
     return encodedresult;
   else
     encoded += encodedresult;
-  if ((encodedresult = auth_failure->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &auth_failure->spare_half_octet, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encodedresult = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encodedresult;
   else
     encoded += encodedresult;
-  if ((encodedresult =
-           auth_failure->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &auth_failure->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encodedresult = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encodedresult;
   else
     encoded += encodedresult;
-  if ((encodedresult = auth_failure->message_type.EncodeMessageTypeMsg(
-           &auth_failure->message_type, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encodedresult = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encodedresult;
   else
     encoded += encodedresult;
-  if ((encodedresult = auth_failure->m5gmm_cause.EncodeM5GMMCauseMsg(
-           &auth_failure->m5gmm_cause, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encodedresult = this->m5gmm_cause.EncodeM5GMMCauseMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encodedresult;
   else
     encoded += encodedresult;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationReject.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationReject.cpp
@@ -25,35 +25,31 @@ AuthenticationRejectMsg::AuthenticationRejectMsg(){};
 AuthenticationRejectMsg::~AuthenticationRejectMsg(){};
 
 // Decoding Authentication Reject Message and its IEs
-int AuthenticationRejectMsg::DecodeAuthenticationRejectMsg(
-    AuthenticationRejectMsg* auth_reject, uint8_t* buffer, uint32_t len) {
+int AuthenticationRejectMsg::DecodeAuthenticationRejectMsg(uint8_t* buffer,
+                                                           uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, AUTHENTICATION_REJECT_MINIMUM_LENGTH, len);
 
-  if ((decoded_result = auth_reject->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &auth_reject->extended_protocol_discriminator,
                                 0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_reject->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &auth_reject->spare_half_octet, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           auth_reject->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &auth_reject->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_reject->message_type.DecodeMessageTypeMsg(
-           &auth_reject->message_type, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -62,35 +58,31 @@ int AuthenticationRejectMsg::DecodeAuthenticationRejectMsg(
 }
 
 // Encoding Authentication Reject Message and its IEs
-int AuthenticationRejectMsg::EncodeAuthenticationRejectMsg(
-    AuthenticationRejectMsg* auth_reject, uint8_t* buffer, uint32_t len) {
+int AuthenticationRejectMsg::EncodeAuthenticationRejectMsg(uint8_t* buffer,
+                                                           uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, AUTHENTICATION_REJECT_MINIMUM_LENGTH, len);
 
-  if ((encoded_result = auth_reject->extended_protocol_discriminator
+  if ((encoded_result = this->extended_protocol_discriminator
                             .EncodeExtendedProtocolDiscriminatorMsg(
-                                &auth_reject->extended_protocol_discriminator,
                                 0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = auth_reject->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &auth_reject->spare_half_octet, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           auth_reject->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &auth_reject->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = auth_reject->message_type.EncodeMessageTypeMsg(
-           &auth_reject->message_type, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationRequest.cpp
@@ -26,16 +26,16 @@ AuthenticationRequestMsg::AuthenticationRequestMsg(){};
 AuthenticationRequestMsg::~AuthenticationRequestMsg(){};
 
 // Decode AuthenticationRequest Messsage
-int AuthenticationRequestMsg::DecodeAuthenticationRequestMsg(
-    AuthenticationRequestMsg* auth_request, uint8_t* buffer, uint32_t len) {
+int AuthenticationRequestMsg::DecodeAuthenticationRequestMsg(uint8_t* buffer,
+                                                             uint32_t len) {
   uint32_t decoded = 0;
   /*** Not Implemented, will be supported POST MVC ***/
   return decoded;
 };
 
 // Encode AuthenticationRequest Messsage
-int AuthenticationRequestMsg::EncodeAuthenticationRequestMsg(
-    AuthenticationRequestMsg* auth_request, uint8_t* buffer, uint32_t len) {
+int AuthenticationRequestMsg::EncodeAuthenticationRequestMsg(uint8_t* buffer,
+                                                             uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
 
@@ -44,56 +44,46 @@ int AuthenticationRequestMsg::EncodeAuthenticationRequestMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, AUTHENTICATION_REQUEST_MINIMUM_LENGTH, len);
 
-  if ((encoded_result = auth_request->extended_protocol_discriminator
+  if ((encoded_result = this->extended_protocol_discriminator
                             .EncodeExtendedProtocolDiscriminatorMsg(
-                                &auth_request->extended_protocol_discriminator,
                                 0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = auth_request->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &auth_request->spare_half_octet, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
   if ((encoded_result =
-           auth_request->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &auth_request->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result = auth_request->message_type.EncodeMessageTypeMsg(
-           &auth_request->message_type, 0, buffer + encoded, len - encoded)) <
-      0)
+           this->nas_key_set_identifier.EncodeNASKeySetIdentifierMsg(
+               0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
   if ((encoded_result =
-           auth_request->nas_key_set_identifier.EncodeNASKeySetIdentifierMsg(
-               &auth_request->nas_key_set_identifier, 0, buffer + encoded,
-               len - encoded)) < 0)
+           this->abba.EncodeABBAMsg(0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = auth_request->abba.EncodeABBAMsg(
-           &auth_request->abba, 0, buffer + encoded, len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           auth_request->auth_rand.EncodeAuthenticationParameterRANDMsg(
-               &auth_request->auth_rand, AUTH_PARAM_RAND, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->auth_rand.EncodeAuthenticationParameterRANDMsg(
+           AUTH_PARAM_RAND, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
 
-  if ((encoded_result =
-           auth_request->auth_autn.EncodeAuthenticationParameterAUTNMsg(
-               &auth_request->auth_autn, AUTH_PARAM_AUTN, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->auth_autn.EncodeAuthenticationParameterAUTNMsg(
+           AUTH_PARAM_AUTN, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResponse.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResponse.cpp
@@ -26,43 +26,37 @@ AuthenticationResponseMsg::AuthenticationResponseMsg(){};
 AuthenticationResponseMsg::~AuthenticationResponseMsg(){};
 
 // Decode AuthenticationResponse Messsage
-int AuthenticationResponseMsg::DecodeAuthenticationResponseMsg(
-    AuthenticationResponseMsg* auth_response, uint8_t* buffer, uint32_t len) {
+int AuthenticationResponseMsg::DecodeAuthenticationResponseMsg(uint8_t* buffer,
+                                                               uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, AUTHENTICATION_RESPONSE_MINIMUM_LENGTH, len);
 
-  if ((decoded_result = auth_response->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &auth_response->extended_protocol_discriminator,
                                 0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_response->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &auth_response->spare_half_octet, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           auth_response->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &auth_response->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_response->message_type.DecodeMessageTypeMsg(
-           &auth_response->message_type, 0, buffer + decoded, len - decoded)) <
-      0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_response->autn_response_parameter
+  if ((decoded_result = this->autn_response_parameter
                             .DecodeAuthenticationResponseParameterMsg(
-                                &auth_response->autn_response_parameter,
                                 AUTH_RESPONSE_PARAMETER, buffer + decoded,
                                 len - decoded)) < 0)
     return decoded_result;
@@ -73,8 +67,8 @@ int AuthenticationResponseMsg::DecodeAuthenticationResponseMsg(
 };
 
 // Encode AuthenticationResponse Messsage
-int AuthenticationResponseMsg::EncodeAuthenticationResponseMsg(
-    AuthenticationResponseMsg* auth_response, uint8_t* buffer, uint32_t len) {
+int AuthenticationResponseMsg::EncodeAuthenticationResponseMsg(uint8_t* buffer,
+                                                               uint32_t len) {
   uint32_t encoded = 0;
   // Not Implemented, Will be supported POST MVC
   return encoded;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResult.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GAuthenticationResult.cpp
@@ -26,54 +26,48 @@ AuthenticationResultMsg::AuthenticationResultMsg(){};
 AuthenticationResultMsg::~AuthenticationResultMsg(){};
 
 // Decode Authentication Result Message and its IEs
-int AuthenticationResultMsg::DecodeAuthenticationResultMsg(
-    AuthenticationResultMsg* auth_result, uint8_t* buffer, uint32_t len) {
+int AuthenticationResultMsg::DecodeAuthenticationResultMsg(uint8_t* buffer,
+                                                           uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, AUTHENTICATION_RESULT_MINIMUM_LENGTH, len);
 
-  if ((decoded_result = auth_result->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &auth_result->extended_protocol_discriminator,
                                 0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_result->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &auth_result->spare_half_octet, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if ((decoded_result =
-           auth_result->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &auth_result->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+           this->nas_key_set_identifier.DecodeNASKeySetIdentifierMsg(
+               0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = auth_result->message_type.DecodeMessageTypeMsg(
-           &auth_result->message_type, 0, buffer + decoded, len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result = auth_result->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &auth_result->spare_half_octet, 0, buffer + decoded,
-           len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           auth_result->nas_key_set_identifier.DecodeNASKeySetIdentifierMsg(
-               &auth_result->nas_key_set_identifier, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result = auth_result->eap_message.DecodeEAPMessageMsg(
-           &auth_result->eap_message, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->eap_message.DecodeEAPMessageMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -81,8 +75,8 @@ int AuthenticationResultMsg::DecodeAuthenticationResultMsg(
 };
 
 // Encode Authentication Result Message and its IEs
-int AuthenticationResultMsg::EncodeAuthenticationResultMsg(
-    AuthenticationResultMsg* auth_result, uint8_t* buffer, uint32_t len) {
+int AuthenticationResultMsg::EncodeAuthenticationResultMsg(uint8_t* buffer,
+                                                           uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
 
@@ -91,44 +85,38 @@ int AuthenticationResultMsg::EncodeAuthenticationResultMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, AUTHENTICATION_RESULT_MINIMUM_LENGTH, len);
 
-  if ((encoded_result = auth_result->extended_protocol_discriminator
+  if ((encoded_result = this->extended_protocol_discriminator
                             .EncodeExtendedProtocolDiscriminatorMsg(
-                                &auth_result->extended_protocol_discriminator,
                                 0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = auth_result->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &auth_result->spare_half_octet, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           auth_result->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &auth_result->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = auth_result->message_type.EncodeMessageTypeMsg(
-           &auth_result->message_type, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = auth_result->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &auth_result->spare_half_octet, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   if ((encoded_result =
-           auth_result->nas_key_set_identifier.EncodeNASKeySetIdentifierMsg(
-               &auth_result->nas_key_set_identifier, 0, buffer + encoded,
-               len - encoded)) < 0)
+           this->nas_key_set_identifier.EncodeNASKeySetIdentifierMsg(
+               0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = auth_result->eap_message.EncodeEAPMessageMsg(
-           &auth_result->eap_message, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->eap_message.EncodeEAPMessageMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDLNASTransport.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDLNASTransport.cpp
@@ -39,7 +39,7 @@ DLNASTransportMsg::DLNASTransportMsg() {
   this->pdu_session_identity.pdu_session_id = 0;
   this->m5gmm_cause.m5gmm_cause = 0;
   this->m5gmm_cause.iei = 0;
-};
+}
 DLNASTransportMsg::~DLNASTransportMsg(){};
 
 // Decode DLNASTransport Message and its IEs

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDLNASTransport.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDLNASTransport.cpp
@@ -11,6 +11,7 @@
  * limitations under the License.
  */
 
+#include <cstring>
 #include <sstream>
 #ifdef __cplusplus
 extern "C" {
@@ -21,14 +22,28 @@ extern "C" {
 #endif
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GDLNASTransport.hpp"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h"
+#include "lte/gateway/c/core/oai/tasks/nas/nas_procedures.hpp"
+#include "lte/gateway/c/core/oai/tasks/nas/emm/emm_data.hpp"
 
 namespace magma5g {
-DLNASTransportMsg::DLNASTransportMsg(){};
+DLNASTransportMsg::DLNASTransportMsg() {
+  memset(this, 0, sizeof(DLNASTransportMsg));
+  this->extended_protocol_discriminator.extended_proto_discriminator =
+      M5G_MOBILITY_MANAGEMENT_MESSAGES;
+  this->sec_header_type.sec_hdr = SECURITY_HEADER_TYPE_NOT_PROTECTED;
+  this->spare_half_octet.spare = 0x00;
+  this->message_type.msg_type = (uint8_t)M5GMessageType::DLNASTRANSPORT;
+  this->payload_container_type.iei = 0;
+  this->payload_container_type.type_val = 0;  // 1;  // N1_SM_INFO;
+  this->pdu_session_identity.iei = (uint8_t)M5GIei::PDU_SESSION_IDENTITY_2;
+  this->pdu_session_identity.pdu_session_id = 0;
+  this->m5gmm_cause.m5gmm_cause = 0;
+  this->m5gmm_cause.iei = 0;
+};
 DLNASTransportMsg::~DLNASTransportMsg(){};
 
 // Decode DLNASTransport Message and its IEs
-int DLNASTransportMsg::DecodeDLNASTransportMsg(
-    DLNASTransportMsg* dl_nas_transport, uint8_t* buffer, uint32_t len) {
+int DLNASTransportMsg::DecodeDLNASTransportMsg(uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
@@ -36,58 +51,46 @@ int DLNASTransportMsg::DecodeDLNASTransportMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer, DL_NAS_TRANSPORT_MINIMUM_LENGTH,
                                        len);
 
-  if ((decoded_result =
-           dl_nas_transport->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &dl_nas_transport->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0) {
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
   if ((decoded_result =
-           dl_nas_transport->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &dl_nas_transport->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0) {
+           this->payload_container_type.DecodePayloadContainerTypeMsg(
+               0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
-  if ((decoded_result =
-           dl_nas_transport->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &dl_nas_transport->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-  if ((decoded_result = dl_nas_transport->message_type.DecodeMessageTypeMsg(
-           &dl_nas_transport->message_type, 0, buffer + decoded,
-           len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-  if ((decoded_result =
-           dl_nas_transport->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &dl_nas_transport->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-  if ((decoded_result = dl_nas_transport->payload_container_type
-                            .DecodePayloadContainerTypeMsg(
-                                &dl_nas_transport->payload_container_type, 0,
-                                buffer + decoded, len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-  if ((decoded_result =
-           dl_nas_transport->payload_container.DecodePayloadContainerMsg(
-               &dl_nas_transport->payload_container, 0, buffer + decoded,
-               len - decoded)) < 0) {
+  if ((decoded_result = this->payload_container.DecodePayloadContainerMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
@@ -101,8 +104,7 @@ int DLNASTransportMsg::DecodeDLNASTransportMsg(
 
     switch (static_cast<M5GIei>(type)) {
       case M5GIei::M5GMM_CAUSE: {
-        if ((decoded_result = dl_nas_transport->m5gmm_cause.DecodeM5GMMCauseMsg(
-                 &dl_nas_transport->m5gmm_cause,
+        if ((decoded_result = this->m5gmm_cause.DecodeM5GMMCauseMsg(
                  static_cast<uint8_t>(M5GIei::M5GMM_CAUSE), buffer + decoded,
                  len - decoded)) < 0) {
           return decoded_result;
@@ -113,11 +115,9 @@ int DLNASTransportMsg::DecodeDLNASTransportMsg(
       }
       case M5GIei::PDU_SESSION_IDENTITY_2: {
         if ((decoded_result =
-                 dl_nas_transport->pdu_session_identity
-                     .DecodePDUSessionIdentityMsg(
-                         &dl_nas_transport->pdu_session_identity,
-                         static_cast<uint8_t>(M5GIei::PDU_SESSION_IDENTITY_2),
-                         buffer + decoded, len - decoded)) < 0) {
+                 this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+                     static_cast<uint8_t>(M5GIei::PDU_SESSION_IDENTITY_2),
+                     buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
         } else {
           decoded += decoded_result;
@@ -139,8 +139,7 @@ int DLNASTransportMsg::DecodeDLNASTransportMsg(
 }
 
 // Encode DL NAS Transport Message and its IEs
-int DLNASTransportMsg::EncodeDLNASTransportMsg(
-    DLNASTransportMsg* dl_nas_transport, uint8_t* buffer, uint32_t len) {
+int DLNASTransportMsg::EncodeDLNASTransportMsg(uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
 
   int encoded_result = 0;
@@ -150,66 +149,53 @@ int DLNASTransportMsg::EncodeDLNASTransportMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, DL_NAS_TRANSPORT_MINIMUM_LENGTH,
                                        len);
 
-  if ((encoded_result =
-           dl_nas_transport->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &dl_nas_transport->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0) {
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
   if ((encoded_result =
-           dl_nas_transport->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &dl_nas_transport->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0) {
+           this->payload_container_type.EncodePayloadContainerTypeMsg(
+               0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result =
-           dl_nas_transport->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &dl_nas_transport->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0) {
+  if ((encoded_result = this->payload_container.EncodePayloadContainerMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = dl_nas_transport->message_type.EncodeMessageTypeMsg(
-           &dl_nas_transport->message_type, 0, buffer + encoded,
-           len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if ((encoded_result =
-           dl_nas_transport->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &dl_nas_transport->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if ((encoded_result = dl_nas_transport->payload_container_type
-                            .EncodePayloadContainerTypeMsg(
-                                &dl_nas_transport->payload_container_type, 0,
-                                buffer + encoded, len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if ((encoded_result =
-           dl_nas_transport->payload_container.EncodePayloadContainerMsg(
-               &dl_nas_transport->payload_container, 0, buffer + encoded,
-               len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if (dl_nas_transport->pdu_session_identity.pdu_session_id) {
+  if (this->pdu_session_identity.pdu_session_id) {
     if ((encoded_result =
-             dl_nas_transport->pdu_session_identity.EncodePDUSessionIdentityMsg(
-                 &dl_nas_transport->pdu_session_identity,
+             this->pdu_session_identity.EncodePDUSessionIdentityMsg(
                  static_cast<uint8_t>(M5GIei::PDU_SESSION_IDENTITY_2),
                  buffer + encoded, len - encoded)) < 0) {
       return encoded_result;
@@ -218,9 +204,8 @@ int DLNASTransportMsg::EncodeDLNASTransportMsg(
     }
   }
 
-  if (dl_nas_transport->m5gmm_cause.m5gmm_cause) {
-    if ((encoded_result = dl_nas_transport->m5gmm_cause.EncodeM5GMMCauseMsg(
-             &dl_nas_transport->m5gmm_cause,
+  if (this->m5gmm_cause.m5gmm_cause) {
+    if ((encoded_result = this->m5gmm_cause.EncodeM5GMMCauseMsg(
              static_cast<uint8_t>(M5GIei::M5GMM_CAUSE), buffer + encoded,
              len - encoded)) < 0) {
       return encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDeRegistrationAcceptUEInit.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDeRegistrationAcceptUEInit.cpp
@@ -27,37 +27,31 @@ DeRegistrationAcceptUEInitMsg::~DeRegistrationAcceptUEInitMsg(){};
 
 // Decoding De Registration Accept Message and its IEs
 int DeRegistrationAcceptUEInitMsg::DecodeDeRegistrationAcceptUEInitMsg(
-    DeRegistrationAcceptUEInitMsg* de_reg_accept, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, DEREGISTRATION_ACCEPT_UEINIT_MINIMUM_LENGTH, len);
 
-  if ((decoded_result = de_reg_accept->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &de_reg_accept->extended_protocol_discriminator,
                                 0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = de_reg_accept->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &de_reg_accept->spare_half_octet, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           de_reg_accept->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &de_reg_accept->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = de_reg_accept->message_type.DecodeMessageTypeMsg(
-           &de_reg_accept->message_type, 0, buffer + decoded, len - decoded)) <
-      0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -66,8 +60,7 @@ int DeRegistrationAcceptUEInitMsg::DecodeDeRegistrationAcceptUEInitMsg(
 
 // Encoding De Registration Accept Message and its IEs
 int DeRegistrationAcceptUEInitMsg::EncodeDeRegistrationAcceptUEInitMsg(
-    DeRegistrationAcceptUEInitMsg* de_reg_accept, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
 
@@ -76,29 +69,24 @@ int DeRegistrationAcceptUEInitMsg::EncodeDeRegistrationAcceptUEInitMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, DEREGISTRATION_ACCEPT_UEINIT_MINIMUM_LENGTH, len);
 
-  if ((encoded_result = de_reg_accept->extended_protocol_discriminator
+  if ((encoded_result = this->extended_protocol_discriminator
                             .EncodeExtendedProtocolDiscriminatorMsg(
-                                &de_reg_accept->extended_protocol_discriminator,
                                 0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = de_reg_accept->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &de_reg_accept->spare_half_octet, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           de_reg_accept->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &de_reg_accept->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = de_reg_accept->message_type.EncodeMessageTypeMsg(
-           &de_reg_accept->message_type, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDeRegistrationRequestUEInit.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GDeRegistrationRequestUEInit.cpp
@@ -27,60 +27,47 @@ DeRegistrationRequestUEInitMsg::~DeRegistrationRequestUEInitMsg(){};
 
 // Decode De Registration Request(UE) Message and its IEs
 int DeRegistrationRequestUEInitMsg::DecodeDeRegistrationRequestUEInitMsg(
-    DeRegistrationRequestUEInitMsg* de_reg_request, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, DEREGISTRATION_REQUEST_UEINIT_MINIMUM_LENGTH, len);
 
-  if ((decoded_result =
-           de_reg_request->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &de_reg_request->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->m5gs_de_reg_type.DecodeM5GSDeRegistrationTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if ((decoded_result =
-           de_reg_request->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &de_reg_request->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0)
+           this->nas_key_set_identifier.DecodeNASKeySetIdentifierMsg(
+               0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           de_reg_request->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &de_reg_request->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result = de_reg_request->message_type.DecodeMessageTypeMsg(
-           &de_reg_request->message_type, 0, buffer + decoded, len - decoded)) <
-      0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           de_reg_request->m5gs_de_reg_type.DecodeM5GSDeRegistrationTypeMsg(
-               &de_reg_request->m5gs_de_reg_type, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           de_reg_request->nas_key_set_identifier.DecodeNASKeySetIdentifierMsg(
-               &de_reg_request->nas_key_set_identifier, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           de_reg_request->m5gs_mobile_identity.DecodeM5GSMobileIdentityMsg(
-               &de_reg_request->m5gs_mobile_identity, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->m5gs_mobile_identity.DecodeM5GSMobileIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -89,8 +76,7 @@ int DeRegistrationRequestUEInitMsg::DecodeDeRegistrationRequestUEInitMsg(
 
 // Encode De Registration Request(UE) Message and its IEs
 int DeRegistrationRequestUEInitMsg::EncodeDeRegistrationRequestUEInitMsg(
-    DeRegistrationRequestUEInitMsg* de_reg_request, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
 
@@ -99,52 +85,40 @@ int DeRegistrationRequestUEInitMsg::EncodeDeRegistrationRequestUEInitMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, DEREGISTRATION_REQUEST_UEINIT_MINIMUM_LENGTH, len);
 
-  if ((encoded_result =
-           de_reg_request->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &de_reg_request->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->m5gs_de_reg_type.EncodeM5GSDeRegistrationTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
   if ((encoded_result =
-           de_reg_request->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &de_reg_request->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0)
+           this->nas_key_set_identifier.EncodeNASKeySetIdentifierMsg(
+               0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           de_reg_request->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &de_reg_request->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result = de_reg_request->message_type.EncodeMessageTypeMsg(
-           &de_reg_request->message_type, 0, buffer + encoded, len - encoded)) <
-      0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           de_reg_request->m5gs_de_reg_type.EncodeM5GSDeRegistrationTypeMsg(
-               &de_reg_request->m5gs_de_reg_type, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           de_reg_request->nas_key_set_identifier.EncodeNASKeySetIdentifierMsg(
-               &de_reg_request->nas_key_set_identifier, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           de_reg_request->m5gs_mobile_identity.EncodeM5GSMobileIdentityMsg(
-               &de_reg_request->m5gs_mobile_identity, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->m5gs_mobile_identity.EncodeM5GSMobileIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GIdentityRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GIdentityRequest.cpp
@@ -25,8 +25,8 @@ IdentityRequestMsg::IdentityRequestMsg(){};
 IdentityRequestMsg::~IdentityRequestMsg(){};
 
 // Decode IdentityRequest Message and its IEs
-int IdentityRequestMsg::DecodeIdentityRequestMsg(
-    IdentityRequestMsg* identity_request, uint8_t* buffer, uint32_t len) {
+int IdentityRequestMsg::DecodeIdentityRequestMsg(uint8_t* buffer,
+                                                 uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
@@ -34,45 +34,34 @@ int IdentityRequestMsg::DecodeIdentityRequestMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer, IDENTITY_REQUEST_MINIMUM_LENGTH,
                                        len);
 
-  if ((decoded_result =
-           identity_request->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &identity_request->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           identity_request->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &identity_request->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           identity_request->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &identity_request->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = identity_request->message_type.DecodeMessageTypeMsg(
-           &identity_request->message_type, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           identity_request->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &identity_request->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           identity_request->m5gs_identity_type.DecodeM5GSIdentityTypeMsg(
-               &identity_request->m5gs_identity_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->m5gs_identity_type.DecodeM5GSIdentityTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -81,8 +70,8 @@ int IdentityRequestMsg::DecodeIdentityRequestMsg(
 }
 
 // Encode Identity Request Message and its IEs
-int IdentityRequestMsg::EncodeIdentityRequestMsg(
-    IdentityRequestMsg* identity_request, uint8_t* buffer, uint32_t len) {
+int IdentityRequestMsg::EncodeIdentityRequestMsg(uint8_t* buffer,
+                                                 uint32_t len) {
   uint32_t encoded = 0;
 
   int encoded_result = 0;
@@ -92,45 +81,34 @@ int IdentityRequestMsg::EncodeIdentityRequestMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, IDENTITY_REQUEST_MINIMUM_LENGTH,
                                        len);
 
-  if ((encoded_result =
-           identity_request->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &identity_request->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           identity_request->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &identity_request->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           identity_request->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &identity_request->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = identity_request->message_type.EncodeMessageTypeMsg(
-           &identity_request->message_type, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           identity_request->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &identity_request->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           identity_request->m5gs_identity_type.EncodeM5GSIdentityTypeMsg(
-               &identity_request->m5gs_identity_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->m5gs_identity_type.EncodeM5GSIdentityTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GIdentityResponse.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GIdentityResponse.cpp
@@ -25,8 +25,8 @@ IdentityResponseMsg::IdentityResponseMsg(){};
 IdentityResponseMsg::~IdentityResponseMsg(){};
 
 // Decode IdentityResponse Message and its IEs
-int IdentityResponseMsg::DecodeIdentityResponseMsg(
-    IdentityResponseMsg* identity_response, uint8_t* buffer, uint32_t len) {
+int IdentityResponseMsg::DecodeIdentityResponseMsg(uint8_t* buffer,
+                                                   uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
@@ -34,38 +34,29 @@ int IdentityResponseMsg::DecodeIdentityResponseMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer, IDENTITY_RESPONSE_MINIMUM_LENGTH,
                                        len);
 
-  if ((decoded_result =
-           identity_response->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &identity_response->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           identity_response->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &identity_response->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           identity_response->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &identity_response->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = identity_response->message_type.DecodeMessageTypeMsg(
-           &identity_response->message_type, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           identity_response->m5gs_mobile_identity.DecodeM5GSMobileIdentityMsg(
-               &identity_response->m5gs_mobile_identity, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->m5gs_mobile_identity.DecodeM5GSMobileIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -74,8 +65,8 @@ int IdentityResponseMsg::DecodeIdentityResponseMsg(
 }
 
 // Encode Identity Response Message and its IEs
-int IdentityResponseMsg::EncodeIdentityResponseMsg(
-    IdentityResponseMsg* identity_response, uint8_t* buffer, uint32_t len) {
+int IdentityResponseMsg::EncodeIdentityResponseMsg(uint8_t* buffer,
+                                                   uint32_t len) {
   uint32_t encoded = 0;
 
   int encoded_result = 0;
@@ -85,38 +76,29 @@ int IdentityResponseMsg::EncodeIdentityResponseMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, IDENTITY_RESPONSE_MINIMUM_LENGTH,
                                        len);
 
-  if ((encoded_result =
-           identity_response->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &identity_response->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           identity_response->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &identity_response->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           identity_response->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &identity_response->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = identity_response->message_type.EncodeMessageTypeMsg(
-           &identity_response->message_type, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           identity_response->m5gs_mobile_identity.EncodeM5GSMobileIdentityMsg(
-               &identity_response->m5gs_mobile_identity, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->m5gs_mobile_identity.EncodeM5GSMobileIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionEstablishmentAccept.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionEstablishmentAccept.cpp
@@ -27,8 +27,7 @@ PDUSessionEstablishmentAcceptMsg::~PDUSessionEstablishmentAcceptMsg(){};
 
 // Decode PDUSessionEstablishmentAccept Message and its IEs
 int PDUSessionEstablishmentAcceptMsg::DecodePDUSessionEstablishmentAcceptMsg(
-    PDUSessionEstablishmentAcceptMsg* pdu_session_estab_accept, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   uint8_t type_len = sizeof(uint8_t);
@@ -37,55 +36,45 @@ int PDUSessionEstablishmentAcceptMsg::DecodePDUSessionEstablishmentAcceptMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer,
                                        PDU_SESSION_ESTABLISH_ACPT_MIN_LEN, len);
 
-  if ((decoded_result =
-           pdu_session_estab_accept->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_estab_accept->extended_protocol_discriminator,
-                   0, buffer + decoded, len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-
-  if ((decoded_result = pdu_session_estab_accept->pdu_session_identity
-                            .DecodePDUSessionIdentityMsg(
-                                &pdu_session_estab_accept->pdu_session_identity,
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
                                 0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
 
-  if ((decoded_result = pdu_session_estab_accept->pti.DecodePTIMsg(
-           &pdu_session_estab_accept->pti, 0, buffer + decoded,
-           len - decoded)) < 0) {
+  if ((decoded_result = this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
 
   if ((decoded_result =
-           pdu_session_estab_accept->message_type.DecodeMessageTypeMsg(
-               &pdu_session_estab_accept->message_type, 0, buffer + decoded,
-               len - decoded)) < 0) {
+           this->pti.DecodePTIMsg(0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
 
   {
-    if ((decoded_result = pdu_session_estab_accept->ssc_mode.DecodeSSCModeMsg(
-             &pdu_session_estab_accept->ssc_mode, 0, buffer + decoded,
-             len - decoded)) < 0) {
+    if ((decoded_result = this->ssc_mode.DecodeSSCModeMsg(0, buffer + decoded,
+                                                          len - decoded)) < 0) {
       return decoded_result;
     } else {
       decoded += decoded_result;
     }
 
-    if ((decoded_result =
-             pdu_session_estab_accept->pdu_session_type.DecodePDUSessionTypeMsg(
-                 &pdu_session_estab_accept->pdu_session_type, 0,
-                 buffer + decoded, len - decoded)) < 0) {
+    if ((decoded_result = this->pdu_session_type.DecodePDUSessionTypeMsg(
+             0, buffer + decoded, len - decoded)) < 0) {
       return decoded_result;
     } else {
       decoded += decoded_result;
@@ -97,14 +86,12 @@ int PDUSessionEstablishmentAcceptMsg::DecodePDUSessionEstablishmentAcceptMsg(
   {
     uint16_t length = 0;
     IES_DECODE_U16(buffer, decoded, length);
-    pdu_session_estab_accept->authorized_qosrules = blk2bstr(buffer, length);
+    this->authorized_qosrules = blk2bstr(buffer, length);
     decoded += length;
   }
 
-  if ((decoded_result =
-           pdu_session_estab_accept->session_ambr.DecodeSessionAMBRMsg(
-               &pdu_session_estab_accept->session_ambr, 0, buffer + decoded,
-               len - decoded)) < 0) {
+  if ((decoded_result = this->session_ambr.DecodeSessionAMBRMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
@@ -118,11 +105,9 @@ int PDUSessionEstablishmentAcceptMsg::DecodePDUSessionEstablishmentAcceptMsg(
 
     switch (static_cast<M5GIei>(type)) {
       case M5GIei::PDU_ADDRESS:
-        if ((decoded_result =
-                 pdu_session_estab_accept->pdu_address.DecodePDUAddressMsg(
-                     &pdu_session_estab_accept->pdu_address,
-                     static_cast<uint8_t>(M5GIei::PDU_ADDRESS),
-                     buffer + decoded, len - decoded)) < 0) {
+        if ((decoded_result = this->pdu_address.DecodePDUAddressMsg(
+                 static_cast<uint8_t>(M5GIei::PDU_ADDRESS), buffer + decoded,
+                 len - decoded)) < 0) {
           return decoded_result;
         } else {
           decoded += decoded_result;
@@ -130,8 +115,7 @@ int PDUSessionEstablishmentAcceptMsg::DecodePDUSessionEstablishmentAcceptMsg(
         break;
 
       case M5GIei::S_NSSAI:
-        if ((decoded_result = pdu_session_estab_accept->nssai.DecodeNSSAIMsg(
-                 &pdu_session_estab_accept->nssai,
+        if ((decoded_result = this->nssai.DecodeNSSAIMsg(
                  static_cast<uint8_t>(M5GIei::S_NSSAI), buffer + decoded,
                  len - decoded)) < 0) {
           return decoded_result;
@@ -148,10 +132,9 @@ int PDUSessionEstablishmentAcceptMsg::DecodePDUSessionEstablishmentAcceptMsg(
         decoded += (length_len + decoded_result);
         break;
       case M5GIei::DNN:
-        if ((decoded_result = pdu_session_estab_accept->dnn.DecodeDNNMsg(
-                 &pdu_session_estab_accept->dnn,
-                 static_cast<uint8_t>(M5GIei::DNN), buffer + decoded,
-                 len - decoded)) < 0) {
+        if ((decoded_result =
+                 this->dnn.DecodeDNNMsg(static_cast<uint8_t>(M5GIei::DNN),
+                                        buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
         } else {
           decoded += decoded_result;
@@ -159,10 +142,8 @@ int PDUSessionEstablishmentAcceptMsg::DecodePDUSessionEstablishmentAcceptMsg(
         break;
       case M5GIei::EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS:
         if ((decoded_result =
-                 pdu_session_estab_accept->protocolconfigurationoptions
+                 this->protocolconfigurationoptions
                      .DecodeProtocolConfigurationOptions(
-                         &pdu_session_estab_accept
-                              ->protocolconfigurationoptions,
                          static_cast<uint8_t>(
                              M5GIei::EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS),
                          buffer + decoded, len - decoded)) < 0) {
@@ -185,123 +166,101 @@ int PDUSessionEstablishmentAcceptMsg::DecodePDUSessionEstablishmentAcceptMsg(
 
 // Encode PDUSessionEstablishmentAccept Message and its IEs
 int PDUSessionEstablishmentAcceptMsg::EncodePDUSessionEstablishmentAcceptMsg(
-    PDUSessionEstablishmentAcceptMsg* pdu_session_estab_accept, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   uint32_t encoded_result = 0;
 
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer,
                                        PDU_SESSION_ESTABLISH_ACPT_MIN_LEN, len);
 
-  if ((encoded_result =
-           pdu_session_estab_accept->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_estab_accept->extended_protocol_discriminator,
-                   0, buffer + encoded, len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if ((encoded_result = pdu_session_estab_accept->pdu_session_identity
-                            .EncodePDUSessionIdentityMsg(
-                                &pdu_session_estab_accept->pdu_session_identity,
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
                                 0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_session_estab_accept->pti.EncodePTIMsg(
-           &pdu_session_estab_accept->pti, 0, buffer + encoded,
-           len - encoded)) < 0) {
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
   if ((encoded_result =
-           pdu_session_estab_accept->message_type.EncodeMessageTypeMsg(
-               &pdu_session_estab_accept->message_type, 0, buffer + encoded,
-               len - encoded)) < 0) {
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_session_estab_accept->ssc_mode.EncodeSSCModeMsg(
-           &pdu_session_estab_accept->ssc_mode, 0, buffer + encoded,
-           len - encoded)) < 0) {
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result =
-           pdu_session_estab_accept->pdu_session_type.EncodePDUSessionTypeMsg(
-               &pdu_session_estab_accept->pdu_session_type, 0, buffer + encoded,
-               len - encoded)) < 0) {
+  if ((encoded_result = this->ssc_mode.EncodeSSCModeMsg(0, buffer + encoded,
+                                                        len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->pdu_session_type.EncodePDUSessionTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
 
-  if (blength(pdu_session_estab_accept->authorized_qosrules)) {
+  if (blength(this->authorized_qosrules)) {
     // Encode the IE of Authorized QoS Rules
     // Encode the length of the IE
-    IES_ENCODE_U16(buffer, encoded,
-                   blength(pdu_session_estab_accept->authorized_qosrules));
+    IES_ENCODE_U16(buffer, encoded, blength(this->authorized_qosrules));
 
-    memcpy(buffer + encoded,
-           pdu_session_estab_accept->authorized_qosrules->data,
-           blength(pdu_session_estab_accept->authorized_qosrules));
+    memcpy(buffer + encoded, this->authorized_qosrules->data,
+           blength(this->authorized_qosrules));
 
-    encoded += blength(pdu_session_estab_accept->authorized_qosrules);
+    encoded += blength(this->authorized_qosrules);
   }
 
-  if ((encoded_result =
-           pdu_session_estab_accept->session_ambr.EncodeSessionAMBRMsg(
-               &pdu_session_estab_accept->session_ambr, 0, buffer + encoded,
-               len - encoded)) < 0) {
+  if ((encoded_result = this->session_ambr.EncodeSessionAMBRMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result =
-           pdu_session_estab_accept->pdu_address.EncodePDUAddressMsg(
-               &pdu_session_estab_accept->pdu_address,
-               static_cast<uint8_t>(M5GIei::PDU_ADDRESS), buffer + encoded,
-               len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-
-  if ((encoded_result = pdu_session_estab_accept->nssai.EncodeNSSAIMsg(
-           &pdu_session_estab_accept->nssai,
-           static_cast<uint8_t>(M5GIei::S_NSSAI), buffer + encoded,
+  if ((encoded_result = this->pdu_address.EncodePDUAddressMsg(
+           static_cast<uint8_t>(M5GIei::PDU_ADDRESS), buffer + encoded,
            len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
 
-  if (blength(pdu_session_estab_accept->authorized_qosflowdescriptors)) {
+  if ((encoded_result =
+           this->nssai.EncodeNSSAIMsg(static_cast<uint8_t>(M5GIei::S_NSSAI),
+                                      buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+
+  if (blength(this->authorized_qosflowdescriptors)) {
     // Encode the IE of Authorized QOS Flow descriptions
-    *(buffer + encoded) = PDU_SESSION_QOS_FLOW_DESC_IE_TYPE;
-    encoded++;
+    *(buffer + encoded++) = PDU_SESSION_QOS_FLOW_DESC_IE_TYPE;
 
     // Encode the length of the IE
-    IES_ENCODE_U16(
-        buffer, encoded,
-        blength(pdu_session_estab_accept->authorized_qosflowdescriptors));
+    IES_ENCODE_U16(buffer, encoded,
+                   blength(this->authorized_qosflowdescriptors));
 
-    memcpy(buffer + encoded,
-           pdu_session_estab_accept->authorized_qosflowdescriptors->data,
-           blength(pdu_session_estab_accept->authorized_qosflowdescriptors));
+    memcpy(buffer + encoded, this->authorized_qosflowdescriptors->data,
+           blength(this->authorized_qosflowdescriptors));
 
-    encoded += blength(pdu_session_estab_accept->authorized_qosflowdescriptors);
+    encoded += blength(this->authorized_qosflowdescriptors);
   }
 
   if ((encoded_result =
-           pdu_session_estab_accept->protocolconfigurationoptions
+           this->protocolconfigurationoptions
                .EncodeProtocolConfigurationOptions(
-                   &pdu_session_estab_accept->protocolconfigurationoptions,
                    static_cast<uint8_t>(
                        M5GIei::EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS),
                    buffer + encoded, len - encoded)) < 0) {
@@ -309,10 +268,10 @@ int PDUSessionEstablishmentAcceptMsg::EncodePDUSessionEstablishmentAcceptMsg(
   } else {
     encoded += encoded_result;
   }
-  if (pdu_session_estab_accept->dnn.dnn[0]) {
-    if ((encoded_result = pdu_session_estab_accept->dnn.EncodeDNNMsg(
-             &pdu_session_estab_accept->dnn, static_cast<uint8_t>(M5GIei::DNN),
-             buffer + encoded, len - encoded)) < 0) {
+  if (this->dnn.dnn[0]) {
+    if ((encoded_result =
+             this->dnn.EncodeDNNMsg(static_cast<uint8_t>(M5GIei::DNN),
+                                    buffer + encoded, len - encoded)) < 0) {
       return encoded_result;
     } else {
       encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionEstablishmentReject.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionEstablishmentReject.cpp
@@ -26,47 +26,37 @@ PDUSessionEstablishmentRejectMsg::~PDUSessionEstablishmentRejectMsg(){};
 
 // Decode PDUSessionEstablishmentReject Message and its IEs
 int PDUSessionEstablishmentRejectMsg::DecodePDUSessionEstablishmentRejectMsg(
-    PDUSessionEstablishmentRejectMsg* pdu_session_estab_reject, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, PDU_SESSION_ESTABLISHMENT_REJ_MIN_LEN, len);
 
-  if ((decoded_result =
-           pdu_session_estab_reject->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_estab_reject->extended_protocol_discriminator,
-                   0, buffer + decoded, len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-
-  if ((decoded_result = pdu_session_estab_reject->pdu_session_identity
-                            .DecodePDUSessionIdentityMsg(
-                                &pdu_session_estab_reject->pdu_session_identity,
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
                                 0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = pdu_session_estab_reject->pti.DecodePTIMsg(
-           &pdu_session_estab_reject->pti, 0, buffer + decoded,
-           len - decoded)) < 0)
+
+  if ((decoded_result = this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if ((decoded_result =
-           pdu_session_estab_reject->message_type.DecodeMessageTypeMsg(
-               &pdu_session_estab_reject->message_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+           this->pti.DecodePTIMsg(0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           pdu_session_estab_reject->m5gsm_cause.DecodeM5GSMCauseMsg(
-               &pdu_session_estab_reject->m5gsm_cause, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->m5gsm_cause.DecodeM5GSMCauseMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -75,45 +65,35 @@ int PDUSessionEstablishmentRejectMsg::DecodePDUSessionEstablishmentRejectMsg(
 
 // Encode PDUSessionEstablishmentReject Message and its IEs
 int PDUSessionEstablishmentRejectMsg::EncodePDUSessionEstablishmentRejectMsg(
-    PDUSessionEstablishmentRejectMsg* pdu_session_estab_reject, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, PDU_SESSION_ESTABLISHMENT_REJ_MIN_LEN, len);
 
-  if ((encoded_result =
-           pdu_session_estab_reject->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_estab_reject->extended_protocol_discriminator,
-                   0, buffer + encoded, len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result = pdu_session_estab_reject->pdu_session_identity
-                            .EncodePDUSessionIdentityMsg(
-                                &pdu_session_estab_reject->pdu_session_identity,
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
                                 0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = pdu_session_estab_reject->pti.EncodePTIMsg(
-           &pdu_session_estab_reject->pti, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
   if ((encoded_result =
-           pdu_session_estab_reject->message_type.EncodeMessageTypeMsg(
-               &pdu_session_estab_reject->message_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           pdu_session_estab_reject->m5gsm_cause.EncodeM5GSMCauseMsg(
-               &pdu_session_estab_reject->m5gsm_cause, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->m5gsm_cause.EncodeM5GSMCauseMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionEstablishmentRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionEstablishmentRequest.cpp
@@ -187,7 +187,7 @@ int PDUSessionEstablishmentRequestMsg::EncodePDUSessionEstablishmentRequestMsg(
     encoded += encoded_result;
   }
 
-  if ((uint32_t)this->pdu_session_type.type_val) {
+  if (static_cast<uint32_t>(this->pdu_session_type.type_val)) {
     if ((encoded_result = this->pdu_session_type.EncodePDUSessionTypeMsg(
              REQUEST_PDU_SESSION_TYPE_TYPE, buffer + encoded, len - encoded)) <
         0) {
@@ -197,7 +197,7 @@ int PDUSessionEstablishmentRequestMsg::EncodePDUSessionEstablishmentRequestMsg(
     }
   }
 
-  if ((uint32_t)this->ssc_mode.mode_val) {
+  if (static_cast<uint32_t>(this->ssc_mode.mode_val)) {
     if ((encoded_result = this->ssc_mode.EncodeSSCModeMsg(
              REQUEST_SSC_MODE_TYPE, buffer + encoded, len - encoded)) < 0) {
       return encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionEstablishmentRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionEstablishmentRequest.cpp
@@ -27,7 +27,6 @@ PDUSessionEstablishmentRequestMsg::~PDUSessionEstablishmentRequestMsg(){};
 
 // Decode PDUSessionEstablishmentRequest Message and its IEs
 int PDUSessionEstablishmentRequestMsg::DecodePDUSessionEstablishmentRequestMsg(
-    PDUSessionEstablishmentRequestMsg* pdu_session_estab_request,
     uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
@@ -37,40 +36,30 @@ int PDUSessionEstablishmentRequestMsg::DecodePDUSessionEstablishmentRequestMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer,
                                        PDU_SESSION_ESTABLISH_REQ_MIN_LEN, len);
 
-  if ((decoded_result =
-           pdu_session_estab_request->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_estab_request->extended_protocol_discriminator,
-                   0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if ((decoded_result =
-           pdu_session_estab_request->pdu_session_identity
-               .DecodePDUSessionIdentityMsg(
-                   &pdu_session_estab_request->pdu_session_identity, 0,
-                   buffer + decoded, len - decoded)) < 0)
+           this->pti.DecodePTIMsg(0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = pdu_session_estab_request->pti.DecodePTIMsg(
-           &pdu_session_estab_request->pti, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if ((decoded_result =
-           pdu_session_estab_request->message_type.DecodeMessageTypeMsg(
-               &pdu_session_estab_request->message_type, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           pdu_session_estab_request->integrity_prot_max_data_rate
-               .DecodeIntegrityProtMaxDataRateMsg(
-                   &pdu_session_estab_request->integrity_prot_max_data_rate, 0,
-                   buffer + decoded, len - decoded)) < 0)
+           this->integrity_prot_max_data_rate.DecodeIntegrityProtMaxDataRateMsg(
+               0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -83,12 +72,9 @@ int PDUSessionEstablishmentRequestMsg::DecodePDUSessionEstablishmentRequestMsg(
 
     switch (type) {
       case REQUEST_PDU_SESSION_TYPE_TYPE:
-        if ((decoded_result =
-                 pdu_session_estab_request->pdu_session_type
-                     .DecodePDUSessionTypeMsg(
-                         &pdu_session_estab_request->pdu_session_type,
-                         REQUEST_PDU_SESSION_TYPE_TYPE, buffer + decoded,
-                         len - decoded)) < 0) {
+        if ((decoded_result = this->pdu_session_type.DecodePDUSessionTypeMsg(
+                 REQUEST_PDU_SESSION_TYPE_TYPE, buffer + decoded,
+                 len - decoded)) < 0) {
           return decoded_result;
         } else {
           decoded += decoded_result;
@@ -96,11 +82,8 @@ int PDUSessionEstablishmentRequestMsg::DecodePDUSessionEstablishmentRequestMsg(
         break;
 
       case REQUEST_SSC_MODE_TYPE:
-        if ((decoded_result =
-                 pdu_session_estab_request->ssc_mode.DecodeSSCModeMsg(
-                     &pdu_session_estab_request->ssc_mode,
-                     REQUEST_SSC_MODE_TYPE, buffer + decoded, len - decoded)) <
-            0) {
+        if ((decoded_result = this->ssc_mode.DecodeSSCModeMsg(
+                 REQUEST_SSC_MODE_TYPE, buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
         } else {
           decoded += decoded_result;
@@ -108,10 +91,8 @@ int PDUSessionEstablishmentRequestMsg::DecodePDUSessionEstablishmentRequestMsg(
         break;
       case REQUEST_EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS_TYPE:
         if ((decoded_result =
-                 pdu_session_estab_request->protocolconfigurationoptions
+                 this->protocolconfigurationoptions
                      .DecodeProtocolConfigurationOptions(
-                         &pdu_session_estab_request
-                              ->protocolconfigurationoptions,
                          REQUEST_EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS_TYPE,
                          buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
@@ -121,9 +102,8 @@ int PDUSessionEstablishmentRequestMsg::DecodePDUSessionEstablishmentRequestMsg(
         break;
       case MAXIMUM_NUMBER_OF_SUPPORTED_PACKET_FILTERS_TYPE:
         if ((decoded_result =
-                 pdu_session_estab_request->maxNumOfSuppPacketFilters
+                 this->maxNumOfSuppPacketFilters
                      .DecodeMaxNumOfSupportedPacketFilters(
-                         &pdu_session_estab_request->maxNumOfSuppPacketFilters,
                          MAXIMUM_NUMBER_OF_SUPPORTED_PACKET_FILTERS_TYPE,
                          buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
@@ -162,12 +142,11 @@ int PDUSessionEstablishmentRequestMsg::DecodePDUSessionEstablishmentRequestMsg(
 
 // Encode PDUSessionEstablishmentRequest Message and its IEs
 int PDUSessionEstablishmentRequestMsg::EncodePDUSessionEstablishmentRequestMsg(
-    PDUSessionEstablishmentRequestMsg* pdu_session_estab_request,
     uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   uint32_t encoded_result = 0;
 
-  if (!pdu_session_estab_request || !buffer || (0 == len)) {
+  if (!buffer || (0 == len)) {
     OAILOG_ERROR(LOG_NAS5G, "Input arguments are not valid");
     return -1;
   }
@@ -175,65 +154,52 @@ int PDUSessionEstablishmentRequestMsg::EncodePDUSessionEstablishmentRequestMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer,
                                        PDU_SESSION_ESTABLISH_REQ_MIN_LEN, len);
 
-  if ((encoded_result =
-           pdu_session_estab_request->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_estab_request->extended_protocol_discriminator,
-                   0, buffer + encoded, len - encoded)) < 0) {
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
   if ((encoded_result =
-           pdu_session_estab_request->pdu_session_identity
-               .EncodePDUSessionIdentityMsg(
-                   &pdu_session_estab_request->pdu_session_identity, 0,
-                   buffer + encoded, len - encoded)) < 0) {
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_session_estab_request->pti.EncodePTIMsg(
-           &pdu_session_estab_request->pti, 0, buffer + encoded,
-           len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if ((encoded_result =
-           pdu_session_estab_request->message_type.EncodeMessageTypeMsg(
-               &pdu_session_estab_request->message_type, 0, buffer + encoded,
-               len - encoded)) < 0) {
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
   if ((encoded_result =
-           pdu_session_estab_request->integrity_prot_max_data_rate
-               .EncodeIntegrityProtMaxDataRateMsg(
-                   &pdu_session_estab_request->integrity_prot_max_data_rate, 0,
-                   buffer + encoded, len - encoded)) < 0) {
+           this->integrity_prot_max_data_rate.EncodeIntegrityProtMaxDataRateMsg(
+               0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
 
-  if ((uint32_t)pdu_session_estab_request->pdu_session_type.type_val) {
-    if ((encoded_result = pdu_session_estab_request->pdu_session_type
-                              .EncodePDUSessionTypeMsg(
-                                  &pdu_session_estab_request->pdu_session_type,
-                                  REQUEST_PDU_SESSION_TYPE_TYPE,
-                                  buffer + encoded, len - encoded)) < 0) {
+  if ((uint32_t)this->pdu_session_type.type_val) {
+    if ((encoded_result = this->pdu_session_type.EncodePDUSessionTypeMsg(
+             REQUEST_PDU_SESSION_TYPE_TYPE, buffer + encoded, len - encoded)) <
+        0) {
       return encoded_result;
     } else {
       encoded += encoded_result;
     }
   }
 
-  if ((uint32_t)pdu_session_estab_request->ssc_mode.mode_val) {
-    if ((encoded_result = pdu_session_estab_request->ssc_mode.EncodeSSCModeMsg(
-             &pdu_session_estab_request->ssc_mode, REQUEST_SSC_MODE_TYPE,
-             buffer + encoded, len - encoded)) < 0) {
+  if ((uint32_t)this->ssc_mode.mode_val) {
+    if ((encoded_result = this->ssc_mode.EncodeSSCModeMsg(
+             REQUEST_SSC_MODE_TYPE, buffer + encoded, len - encoded)) < 0) {
       return encoded_result;
     } else {
       encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationCommand.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationCommand.cpp
@@ -27,99 +27,87 @@ PDUSessionModificationCommand::PDUSessionModificationCommand() {}
 PDUSessionModificationCommand::~PDUSessionModificationCommand() {}
 
 int PDUSessionModificationCommand::EncodePDUSessionModificationCommand(
-    PDUSessionModificationCommand* pdu_sess_mod_comd, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   uint32_t encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, PDU_SESSION_MODIFICATION_COMMAND_MIN_LEN, len);
 
   OAILOG_DEBUG(LOG_NAS5G, "EncodePDUSessionModificationCommand");
-  if ((encoded_result =
-           pdu_sess_mod_comd->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_sess_mod_comd->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0) {
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
   if ((encoded_result =
-           pdu_sess_mod_comd->pdu_session_identity.EncodePDUSessionIdentityMsg(
-               &pdu_sess_mod_comd->pdu_session_identity, 0, buffer + encoded,
-               len - encoded)) < 0) {
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_sess_mod_comd->pti.EncodePTIMsg(
-           &pdu_sess_mod_comd->pti, 0, buffer + encoded, len - encoded)) < 0) {
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_sess_mod_comd->message_type.EncodeMessageTypeMsg(
-           &pdu_sess_mod_comd->message_type, 0, buffer + encoded,
-           len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if (pdu_sess_mod_comd->cause.iei) {
-    if ((encoded_result = pdu_sess_mod_comd->cause.EncodeM5GSMCauseMsg(
-             &pdu_sess_mod_comd->cause, 0, buffer + encoded, len - encoded)) <
-        0) {
+  if (this->cause.iei) {
+    if ((encoded_result = this->cause.EncodeM5GSMCauseMsg(0, buffer + encoded,
+                                                          len - encoded)) < 0) {
       return encoded_result;
     } else {
       encoded += encoded_result;
     }
   }
-  if (pdu_sess_mod_comd->sessionambr.iei) {
-    if ((encoded_result = pdu_sess_mod_comd->sessionambr.EncodeSessionAMBRMsg(
-             &pdu_sess_mod_comd->sessionambr, PDU_SESSION_AMBR_IE_TYPE,
-             buffer + encoded, len - encoded)) < 0) {
+  if (this->sessionambr.iei) {
+    if ((encoded_result = this->sessionambr.EncodeSessionAMBRMsg(
+             PDU_SESSION_AMBR_IE_TYPE, buffer + encoded, len - encoded)) < 0) {
       return encoded_result;
     } else {
       encoded += encoded_result;
     }
   }
 
-  if (blength(pdu_sess_mod_comd->authorized_qosrules)) {
+  if (blength(this->authorized_qosrules)) {
     // Encode the IE of Authorized QoS Rules
-    buffer[encoded++] = PDU_SESSION_QOS_RULES_IE_TYPE;
+    *(buffer + encoded++) = PDU_SESSION_QOS_RULES_IE_TYPE;
 
     // Encode the length of the IE
-    IES_ENCODE_U16(buffer, encoded,
-                   blength(pdu_sess_mod_comd->authorized_qosrules));
+    IES_ENCODE_U16(buffer, encoded, blength(this->authorized_qosrules));
 
-    memcpy(buffer + encoded, pdu_sess_mod_comd->authorized_qosrules->data,
-           blength(pdu_sess_mod_comd->authorized_qosrules));
+    memcpy(buffer + encoded, this->authorized_qosrules->data,
+           blength(this->authorized_qosrules));
 
-    encoded += blength(pdu_sess_mod_comd->authorized_qosrules);
+    encoded += blength(this->authorized_qosrules);
   }
 
-  if (blength(pdu_sess_mod_comd->authorized_qosflowdescriptors)) {
+  if (blength(this->authorized_qosflowdescriptors)) {
     // Encode the IE of Authorized QOS Flow descriptions
-    *(buffer + encoded) = PDU_SESSION_QOS_FLOW_DESC_IE_TYPE;
-    encoded++;
+    *(buffer + encoded++) = PDU_SESSION_QOS_FLOW_DESC_IE_TYPE;
 
     // Encode the length of the IE
     IES_ENCODE_U16(buffer, encoded,
-                   blength(pdu_sess_mod_comd->authorized_qosflowdescriptors));
+                   blength(this->authorized_qosflowdescriptors));
 
-    memcpy(buffer + encoded,
-           pdu_sess_mod_comd->authorized_qosflowdescriptors->data,
-           blength(pdu_sess_mod_comd->authorized_qosflowdescriptors));
+    memcpy(buffer + encoded, this->authorized_qosflowdescriptors->data,
+           blength(this->authorized_qosflowdescriptors));
 
-    encoded += blength(pdu_sess_mod_comd->authorized_qosflowdescriptors);
+    encoded += blength(this->authorized_qosflowdescriptors);
   }
 
   return encoded;
 }
 
 int PDUSessionModificationCommand::DecodePDUSessionModificationCommand(
-    PDUSessionModificationCommand* pdu_sess_mod_comd, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   uint32_t decoded_result = 0;
 
@@ -127,32 +115,27 @@ int PDUSessionModificationCommand::DecodePDUSessionModificationCommand(
       buffer, PDU_SESSION_MODIFICATION_COMMAND_MIN_LEN, len);
 
   OAILOG_DEBUG(LOG_NAS5G, "DecodePDUSessionModificationCommandMsg");
-  if ((decoded_result =
-           pdu_sess_mod_comd->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_sess_mod_comd->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0) {
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+  if ((decoded_result = this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
   if ((decoded_result =
-           pdu_sess_mod_comd->pdu_session_identity.DecodePDUSessionIdentityMsg(
-               &pdu_sess_mod_comd->pdu_session_identity, 0, buffer + decoded,
-               len - decoded)) < 0) {
+           this->pti.DecodePTIMsg(0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
-  if ((decoded_result = pdu_sess_mod_comd->pti.DecodePTIMsg(
-           &pdu_sess_mod_comd->pti, 0, buffer + decoded, len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-  if ((decoded_result = pdu_sess_mod_comd->message_type.DecodeMessageTypeMsg(
-           &pdu_sess_mod_comd->message_type, 0, buffer + decoded,
-           len - decoded)) < 0) {
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
@@ -162,19 +145,17 @@ int PDUSessionModificationCommand::DecodePDUSessionModificationCommand(
 
     switch (ie_type) {
       case M5GSM_CAUSE: {
-        if ((decoded_result = pdu_sess_mod_comd->cause.DecodeM5GSMCauseMsg(
-                 &pdu_sess_mod_comd->cause, M5GSM_CAUSE, buffer + decoded,
-                 len - decoded)) < 0) {
+        if ((decoded_result = this->cause.DecodeM5GSMCauseMsg(
+                 M5GSM_CAUSE, buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
         } else {
           decoded += decoded_result;
         }
       } break;
       case PDU_SESSION_AMBR_IE_TYPE: {
-        if ((decoded_result =
-                 pdu_sess_mod_comd->sessionambr.DecodeSessionAMBRMsg(
-                     &pdu_sess_mod_comd->sessionambr, PDU_SESSION_AMBR_IE_TYPE,
-                     buffer + decoded, len - decoded)) < 0) {
+        if ((decoded_result = this->sessionambr.DecodeSessionAMBRMsg(
+                 PDU_SESSION_AMBR_IE_TYPE, buffer + decoded, len - decoded)) <
+            0) {
           return decoded_result;
         } else {
           decoded += decoded_result;
@@ -189,7 +170,7 @@ int PDUSessionModificationCommand::DecodePDUSessionModificationCommand(
         IES_DECODE_U16(buffer, decoded, qos_rules_buf_len);
 
         // Store the information in Bstring
-        pdu_sess_mod_comd->authorized_qosrules =
+        this->authorized_qosrules =
             blk2bstr(buffer + decoded, qos_rules_buf_len);
         decoded += qos_rules_buf_len;
       } break;
@@ -202,15 +183,14 @@ int PDUSessionModificationCommand::DecodePDUSessionModificationCommand(
         IES_DECODE_U16(buffer, decoded, qos_flow_desc_buf_len);
 
         // Store the information in Bstring
-        pdu_sess_mod_comd->authorized_qosflowdescriptors =
+        this->authorized_qosflowdescriptors =
             blk2bstr(buffer + decoded, qos_flow_desc_buf_len);
         decoded += qos_flow_desc_buf_len;
       } break;
       case REQUEST_EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS_TYPE: {
         if ((decoded_result =
-                 pdu_sess_mod_comd->extprotocolconfigurationoptions
+                 this->extprotocolconfigurationoptions
                      .DecodeProtocolConfigurationOptions(
-                         &pdu_sess_mod_comd->extprotocolconfigurationoptions,
                          REQUEST_EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS_TYPE,
                          buffer + decoded, len - decoded)) < 0) {
           return decoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationCommandReject.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationCommandReject.cpp
@@ -27,9 +27,7 @@ PDUSessionModificationCommandReject::PDUSessionModificationCommandReject() {}
 PDUSessionModificationCommandReject::~PDUSessionModificationCommandReject() {}
 
 int PDUSessionModificationCommandReject::
-    EncodePDUSessionModificationCommandReject(
-        PDUSessionModificationCommandReject* pdu_sess_mod_comd_rej,
-        uint8_t* buffer, uint32_t len) {
+    EncodePDUSessionModificationCommandReject(uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   uint32_t encoded_result = 0;
 
@@ -37,41 +35,33 @@ int PDUSessionModificationCommandReject::
       buffer, PDU_SESSION_MODIFICATION_COMMAND_REJECT_MIN_LEN, len);
 
   OAILOG_DEBUG(LOG_NAS5G, "EncodePDUSessionModificationCommandReject");
-  if ((encoded_result =
-           pdu_sess_mod_comd_rej->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_sess_mod_comd_rej->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0) {
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_sess_mod_comd_rej->pdu_session_identity
-                            .EncodePDUSessionIdentityMsg(
-                                &pdu_sess_mod_comd_rej->pdu_session_identity, 0,
-                                buffer + encoded, len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if ((encoded_result = pdu_sess_mod_comd_rej->pti.EncodePTIMsg(
-           &pdu_sess_mod_comd_rej->pti, 0, buffer + encoded, len - encoded)) <
-      0) {
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
   if ((encoded_result =
-           pdu_sess_mod_comd_rej->message_type.EncodeMessageTypeMsg(
-               &pdu_sess_mod_comd_rej->message_type, 0, buffer + encoded,
-               len - encoded)) < 0) {
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_sess_mod_comd_rej->cause.EncodeM5GSMCauseMsg(
-           &pdu_sess_mod_comd_rej->cause, M5GSM_CAUSE, buffer + encoded,
-           len - encoded)) < 0) {
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->cause.EncodeM5GSMCauseMsg(
+           M5GSM_CAUSE, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
@@ -81,9 +71,7 @@ int PDUSessionModificationCommandReject::
 }
 
 int PDUSessionModificationCommandReject::
-    DecodePDUSessionModificationCommandReject(
-        PDUSessionModificationCommandReject* pdu_sess_mod_comd_rej,
-        uint8_t* buffer, uint32_t len) {
+    DecodePDUSessionModificationCommandReject(uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   uint32_t decoded_result = 0;
 
@@ -91,50 +79,41 @@ int PDUSessionModificationCommandReject::
       buffer, PDU_SESSION_MODIFICATION_COMMAND_REJECT_MIN_LEN, len);
 
   OAILOG_DEBUG(LOG_NAS5G, "DecodePDUSessionModificationCommandReject : ");
-  if ((decoded_result =
-           pdu_sess_mod_comd_rej->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_sess_mod_comd_rej->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0) {
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
-  if ((decoded_result = pdu_sess_mod_comd_rej->pdu_session_identity
-                            .DecodePDUSessionIdentityMsg(
-                                &pdu_sess_mod_comd_rej->pdu_session_identity, 0,
-                                buffer + decoded, len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-  if ((decoded_result = pdu_sess_mod_comd_rej->pti.DecodePTIMsg(
-           &pdu_sess_mod_comd_rej->pti, 0, buffer + decoded, len - decoded)) <
-      0) {
+  if ((decoded_result = this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
   if ((decoded_result =
-           pdu_sess_mod_comd_rej->message_type.DecodeMessageTypeMsg(
-               &pdu_sess_mod_comd_rej->message_type, 0, buffer + decoded,
-               len - decoded)) < 0) {
+           this->pti.DecodePTIMsg(0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
-  if ((decoded_result = pdu_sess_mod_comd_rej->cause.DecodeM5GSMCauseMsg(
-           &pdu_sess_mod_comd_rej->cause, M5GSM_CAUSE, buffer + decoded,
-           len - decoded)) < 0) {
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+  if ((decoded_result = this->cause.DecodeM5GSMCauseMsg(
+           M5GSM_CAUSE, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
   if (decoded < len) {
     if ((decoded_result =
-             pdu_sess_mod_comd_rej->extProtocolconfigurationoptions
+             this->extProtocolconfigurationoptions
                  .DecodeProtocolConfigurationOptions(
-                     &pdu_sess_mod_comd_rej->extProtocolconfigurationoptions,
                      REQUEST_EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS_TYPE,
                      buffer + decoded, len - decoded)) < 0) {
       return decoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationComplete.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationComplete.cpp
@@ -27,8 +27,7 @@ PDUSessionModificationComplete::PDUSessionModificationComplete() {}
 PDUSessionModificationComplete::~PDUSessionModificationComplete() {}
 
 int PDUSessionModificationComplete::EncodePDUSessionModificationComplete(
-    PDUSessionModificationComplete* pdu_sess_mod_com, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   uint32_t encoded_result = 0;
 
@@ -36,32 +35,27 @@ int PDUSessionModificationComplete::EncodePDUSessionModificationComplete(
       buffer, PDU_SESSION_MODIFICATION_COMPLETE_MIN_LEN, len);
 
   OAILOG_DEBUG(LOG_NAS5G, "EncodePDUSessionModificationComplete");
-  if ((encoded_result =
-           pdu_sess_mod_com->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_sess_mod_com->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0) {
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
   if ((encoded_result =
-           pdu_sess_mod_com->pdu_session_identity.EncodePDUSessionIdentityMsg(
-               &pdu_sess_mod_com->pdu_session_identity, 0, buffer + encoded,
-               len - encoded)) < 0) {
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_sess_mod_com->pti.EncodePTIMsg(
-           &pdu_sess_mod_com->pti, 0, buffer + encoded, len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if ((encoded_result = pdu_sess_mod_com->message_type.EncodeMessageTypeMsg(
-           &pdu_sess_mod_com->message_type, 0, buffer + encoded,
-           len - encoded)) < 0) {
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
@@ -71,8 +65,7 @@ int PDUSessionModificationComplete::EncodePDUSessionModificationComplete(
 }
 
 int PDUSessionModificationComplete::DecodePDUSessionModificationComplete(
-    PDUSessionModificationComplete* pdu_sess_mod_com, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   uint32_t decoded_result = 0;
 
@@ -80,32 +73,27 @@ int PDUSessionModificationComplete::DecodePDUSessionModificationComplete(
       buffer, PDU_SESSION_MODIFICATION_COMPLETE_MIN_LEN, len);
 
   OAILOG_DEBUG(LOG_NAS5G, "DecodePDUSessionModificationComplete");
-  if ((decoded_result =
-           pdu_sess_mod_com->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_sess_mod_com->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0) {
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+  if ((decoded_result = this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
   if ((decoded_result =
-           pdu_sess_mod_com->pdu_session_identity.DecodePDUSessionIdentityMsg(
-               &pdu_sess_mod_com->pdu_session_identity, 0, buffer + decoded,
-               len - decoded)) < 0) {
+           this->pti.DecodePTIMsg(0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
-  if ((decoded_result = pdu_sess_mod_com->pti.DecodePTIMsg(
-           &pdu_sess_mod_com->pti, 0, buffer + decoded, len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-  if ((decoded_result = pdu_sess_mod_com->message_type.DecodeMessageTypeMsg(
-           &pdu_sess_mod_com->message_type, 0, buffer + decoded,
-           len - decoded)) < 0) {
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationReject.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationReject.cpp
@@ -27,8 +27,7 @@ PDUSessionModificationRejectMsg::~PDUSessionModificationRejectMsg(){};
 
 // Decode PDUSessionModificationReject Message and its IEs
 int PDUSessionModificationRejectMsg::DecodePDUSessionModificationRejectMsg(
-    PDUSessionModificationRejectMsg* pdu_session_modif_reject, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   uint32_t decoded_result = 0;
 
@@ -36,51 +35,41 @@ int PDUSessionModificationRejectMsg::DecodePDUSessionModificationRejectMsg(
       buffer, PDU_SESSION_MODIFICATION_REJECT_MIN_LEN, len);
 
   OAILOG_DEBUG(LOG_NAS5G, "DecodePDUSessionModificationRejectMessage : ");
-  if ((decoded_result =
-           pdu_session_modif_reject->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_modif_reject->extended_protocol_discriminator,
-                   0, buffer + decoded, len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-  if ((decoded_result = pdu_session_modif_reject->pdu_session_identity
-                            .DecodePDUSessionIdentityMsg(
-                                &pdu_session_modif_reject->pdu_session_identity,
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
                                 0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
-  if ((decoded_result = pdu_session_modif_reject->pti.DecodePTIMsg(
-           &pdu_session_modif_reject->pti, 0, buffer + decoded,
-           len - decoded)) < 0) {
+  if ((decoded_result = this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
   if ((decoded_result =
-           pdu_session_modif_reject->message_type.DecodeMessageTypeMsg(
-               &pdu_session_modif_reject->message_type, 0, buffer + decoded,
-               len - decoded)) < 0) {
+           this->pti.DecodePTIMsg(0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
-  if ((decoded_result =
-           pdu_session_modif_reject->m5gsm_cause.DecodeM5GSMCauseMsg(
-               &pdu_session_modif_reject->m5gsm_cause, 0, buffer + decoded,
-               len - decoded)) < 0) {
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+  if ((decoded_result = this->m5gsm_cause.DecodeM5GSMCauseMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
   if (decoded < len) {
     if ((decoded_result =
-             pdu_session_modif_reject->extProtocolconfigurationoptions
+             this->extProtocolconfigurationoptions
                  .DecodeProtocolConfigurationOptions(
-                     &pdu_session_modif_reject->extProtocolconfigurationoptions,
                      REQUEST_EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS_TYPE,
                      buffer + decoded, len - decoded)) < 0) {
       return decoded_result;
@@ -93,8 +82,7 @@ int PDUSessionModificationRejectMsg::DecodePDUSessionModificationRejectMsg(
 }
 // Encode PDUSessionModificationReject Message and its IEs
 int PDUSessionModificationRejectMsg::EncodePDUSessionModificationRejectMsg(
-    PDUSessionModificationRejectMsg* pdu_session_modif_reject, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
@@ -102,42 +90,33 @@ int PDUSessionModificationRejectMsg::EncodePDUSessionModificationRejectMsg(
 
   OAILOG_DEBUG(LOG_NAS5G, "EncodePDUSessionModificationRejectMessage");
 
-  if ((encoded_result =
-           pdu_session_modif_reject->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_modif_reject->extended_protocol_discriminator,
-                   0, buffer + encoded, len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if ((encoded_result = pdu_session_modif_reject->pdu_session_identity
-                            .EncodePDUSessionIdentityMsg(
-                                &pdu_session_modif_reject->pdu_session_identity,
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
                                 0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_session_modif_reject->pti.EncodePTIMsg(
-           &pdu_session_modif_reject->pti, 0, buffer + encoded,
-           len - encoded)) < 0) {
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
   if ((encoded_result =
-           pdu_session_modif_reject->message_type.EncodeMessageTypeMsg(
-               &pdu_session_modif_reject->message_type, 0, buffer + encoded,
-               len - encoded)) < 0) {
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result =
-           pdu_session_modif_reject->m5gsm_cause.EncodeM5GSMCauseMsg(
-               &pdu_session_modif_reject->m5gsm_cause, 0, buffer + encoded,
-               len - encoded)) < 0) {
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->m5gsm_cause.EncodeM5GSMCauseMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionModificationRequest.cpp
@@ -29,7 +29,6 @@ PDUSessionModificationRequestMsg::~PDUSessionModificationRequestMsg(){};
 
 // Decode PDUSessionModificationRequest Message and its IEs
 int PDUSessionModificationRequestMsg::DecodePDUSessionModificationRequestMsg(
-    PDUSessionModificationRequestMsg* pdu_session_modif_request,
     uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
@@ -38,35 +37,27 @@ int PDUSessionModificationRequestMsg::DecodePDUSessionModificationRequestMsg(
 
   OAILOG_DEBUG(LOG_NAS5G, "DecodePDUSessionModificationRequestMessage");
 
-  if ((decoded_result =
-           pdu_session_modif_request->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_modif_request->extended_protocol_discriminator,
-                   0, buffer + decoded, len - decoded)) < 0) {
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0) {
+    return decoded_result;
+  } else {
+    decoded += decoded_result;
+  }
+  if ((decoded_result = this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
   if ((decoded_result =
-           pdu_session_modif_request->pdu_session_identity
-               .DecodePDUSessionIdentityMsg(
-                   &pdu_session_modif_request->pdu_session_identity, 0,
-                   buffer + decoded, len - decoded)) < 0) {
+           this->pti.DecodePTIMsg(0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
   }
-  if ((decoded_result = pdu_session_modif_request->pti.DecodePTIMsg(
-           &pdu_session_modif_request->pti, 0, buffer + decoded,
-           len - decoded)) < 0) {
-    return decoded_result;
-  } else {
-    decoded += decoded_result;
-  }
-  if ((decoded_result =
-           pdu_session_modif_request->message_type.DecodeMessageTypeMsg(
-               &pdu_session_modif_request->message_type, 0, buffer + decoded,
-               len - decoded)) < 0) {
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0) {
     return decoded_result;
   } else {
     decoded += decoded_result;
@@ -76,10 +67,8 @@ int PDUSessionModificationRequestMsg::DecodePDUSessionModificationRequestMsg(
 
     switch (ie_type) {
       case M5GSM_CAUSE: {
-        if ((decoded_result =
-                 pdu_session_modif_request->cause.DecodeM5GSMCauseMsg(
-                     &pdu_session_modif_request->cause, M5GSM_CAUSE,
-                     buffer + decoded, len - decoded)) < 0) {
+        if ((decoded_result = this->cause.DecodeM5GSMCauseMsg(
+                 M5GSM_CAUSE, buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
         } else {
           decoded += decoded_result;
@@ -88,11 +77,11 @@ int PDUSessionModificationRequestMsg::DecodePDUSessionModificationRequestMsg(
       case PDU_SESSION_QOS_RULES_IE_TYPE: {
         QOSRulesMsg qosRules;
         if ((decoded_result = qosRules.DecodeQOSRulesMsg(
-                 &qosRules, PDU_SESSION_QOS_RULES_IE_TYPE, buffer + decoded,
+                 PDU_SESSION_QOS_RULES_IE_TYPE, buffer + decoded,
                  len - decoded)) < 0) {
           return decoded_result;
         } else {
-          pdu_session_modif_request->authqosrules.push_back(qosRules);
+          this->authqosrules.push_back(qosRules);
           decoded += decoded_result;
         }
       } break;
@@ -101,19 +90,17 @@ int PDUSessionModificationRequestMsg::DecodePDUSessionModificationRequestMsg(
         decoded += 3;
         M5GQosFlowDescription flowDes;
         if ((decoded_result = flowDes.DecodeM5GQosFlowDescription(
-                 &flowDes, buffer + decoded, len - decoded)) < 0) {
+                 buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
         } else {
-          pdu_session_modif_request->authqosflowdescriptors.push_back(flowDes);
+          this->authqosflowdescriptors.push_back(flowDes);
           decoded += decoded_result;
         }
       } break;
       case REQUEST_EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS_TYPE: {
         if ((decoded_result =
-                 pdu_session_modif_request->extprotocolconfigurationoptions
+                 this->extprotocolconfigurationoptions
                      .DecodeProtocolConfigurationOptions(
-                         &pdu_session_modif_request
-                              ->extprotocolconfigurationoptions,
                          REQUEST_EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS_TYPE,
                          buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
@@ -130,7 +117,6 @@ int PDUSessionModificationRequestMsg::DecodePDUSessionModificationRequestMsg(
 
 // Encode PDUSessionModificationRequest Message and its IEs
 int PDUSessionModificationRequestMsg::EncodePDUSessionModificationRequestMsg(
-    PDUSessionModificationRequestMsg* pdu_session_modif_request,
     uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   uint32_t encoded_result = 0;
@@ -139,67 +125,53 @@ int PDUSessionModificationRequestMsg::EncodePDUSessionModificationRequestMsg(
       buffer, PDU_SESSION_MODIFICATION_REQ_MIN_LEN, len);
 
   OAILOG_DEBUG(LOG_NAS5G, "EncodePDUSessionModificationRequestMessage");
-  if ((encoded_result =
-           pdu_session_modif_request->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_modif_request->extended_protocol_discriminator,
-                   0, buffer + encoded, len - encoded)) < 0) {
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0) {
+    return encoded_result;
+  } else {
+    encoded += encoded_result;
+  }
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
   if ((encoded_result =
-           pdu_session_modif_request->pdu_session_identity
-               .EncodePDUSessionIdentityMsg(
-                   &pdu_session_modif_request->pdu_session_identity, 0,
-                   buffer + encoded, len - encoded)) < 0) {
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result = pdu_session_modif_request->pti.EncodePTIMsg(
-           &pdu_session_modif_request->pti, 0, buffer + encoded,
-           len - encoded)) < 0) {
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0) {
     return encoded_result;
   } else {
     encoded += encoded_result;
   }
-  if ((encoded_result =
-           pdu_session_modif_request->message_type.EncodeMessageTypeMsg(
-               &pdu_session_modif_request->message_type, 0, buffer + encoded,
-               len - encoded)) < 0) {
-    return encoded_result;
-  } else {
-    encoded += encoded_result;
-  }
-  if (pdu_session_modif_request->cause.iei) {
-    if ((encoded_result = pdu_session_modif_request->cause.EncodeM5GSMCauseMsg(
-             &pdu_session_modif_request->cause, 0, buffer + encoded,
-             len - encoded)) < 0) {
+  if (this->cause.iei) {
+    if ((encoded_result = this->cause.EncodeM5GSMCauseMsg(0, buffer + encoded,
+                                                          len - encoded)) < 0) {
       return encoded_result;
     } else {
       encoded += encoded_result;
     }
   }
-  for (uint8_t i = 0; i < pdu_session_modif_request->authqosrules.size(); i++) {
-    if ((encoded_result =
-             pdu_session_modif_request->authqosrules[i].EncodeQOSRulesMsg(
-                 &pdu_session_modif_request->authqosrules[i],
-                 PDU_SESSION_QOS_RULES_IE_TYPE, buffer + encoded,
-                 len - encoded)) < 0) {
+  for (uint8_t i = 0; i < this->authqosrules.size(); i++) {
+    if ((encoded_result = this->authqosrules[i].EncodeQOSRulesMsg(
+             PDU_SESSION_QOS_RULES_IE_TYPE, buffer + encoded, len - encoded)) <
+        0) {
       return encoded_result;
     } else {
       encoded += encoded_result;
     }
   }
-  pdu_session_modif_request->authqosrules.clear();
-  for (uint8_t i = 0;
-       i < pdu_session_modif_request->authqosflowdescriptors.size(); i++) {
+  this->authqosrules.clear();
+  for (uint8_t i = 0; i < this->authqosflowdescriptors.size(); i++) {
     if ((encoded_result =
-             pdu_session_modif_request->authqosflowdescriptors[i]
-                 .EncodeM5GQosFlowDescription(
-                     &pdu_session_modif_request->authqosflowdescriptors[i],
-                     buffer + encoded + 3, len - encoded)) < 0) {
+             this->authqosflowdescriptors[i].EncodeM5GQosFlowDescription(
+                 buffer + encoded + 3, len - encoded)) < 0) {
       return encoded_result;
     } else {
       qos_flow_des_encoded += encoded_result;
@@ -208,11 +180,10 @@ int PDUSessionModificationRequestMsg::EncodePDUSessionModificationRequestMsg(
 
   if (qos_flow_des_encoded) {
     // iei
-    *(buffer + encoded) = 0x79;
-    encoded++;
+    *(buffer + encoded++) = 0x79;
     IES_ENCODE_U16(buffer, encoded, qos_flow_des_encoded);
     encoded += qos_flow_des_encoded;
-    pdu_session_modif_request->authqosflowdescriptors.clear();
+    this->authqosflowdescriptors.clear();
   }
 
   return encoded;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionReleaseCommand.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionReleaseCommand.cpp
@@ -26,55 +26,42 @@ PDUSessionReleaseCommandMsg::~PDUSessionReleaseCommandMsg(){};
 
 // Decode PDUSessionReleaseCommand Message and its IEs
 int PDUSessionReleaseCommandMsg::DecodePDUSessionReleaseCommandMsg(
-    PDUSessionReleaseCommandMsg* pdu_session_release_command, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   // Not yet implemented, will be supported POST MVC
   return 0;
 }
 
 // Encode PDUSessionReleaseCommand Message and its IEs
 int PDUSessionReleaseCommandMsg::EncodePDUSessionReleaseCommandMsg(
-    PDUSessionReleaseCommandMsg* pdu_session_release_command, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, PDU_SESSION_RELEASE_COMMAND_MIN_LEN, len);
 
-  if ((encoded_result =
-           pdu_session_release_command->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_release_command
-                        ->extended_protocol_discriminator,
-                   0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
   if ((encoded_result =
-           pdu_session_release_command->pdu_session_identity
-               .EncodePDUSessionIdentityMsg(
-                   &pdu_session_release_command->pdu_session_identity, 0,
-                   buffer + encoded, len - encoded)) < 0)
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = pdu_session_release_command->pti.EncodePTIMsg(
-           &pdu_session_release_command->pti, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           pdu_session_release_command->message_type.EncodeMessageTypeMsg(
-               &pdu_session_release_command->message_type, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           pdu_session_release_command->m5gsm_cause.EncodeM5GSMCauseMsg(
-               &pdu_session_release_command->m5gsm_cause, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->m5gsm_cause.EncodeM5GSMCauseMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionReleaseReject.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionReleaseReject.cpp
@@ -26,54 +26,42 @@ PDUSessionReleaseRejectMsg::~PDUSessionReleaseRejectMsg(){};
 
 // Decode PDUSessionReleaseReject Message and its IEs
 int PDUSessionReleaseRejectMsg::DecodePDUSessionReleaseRejectMsg(
-    PDUSessionReleaseRejectMsg* pdu_session_release_reject, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   // Not yet implemented, will be supported POST MVC
   return 0;
 }
 
 // Encode PDUSessionReleaseReject Message and its IEs
 int PDUSessionReleaseRejectMsg::EncodePDUSessionReleaseRejectMsg(
-    PDUSessionReleaseRejectMsg* pdu_session_release_reject, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer,
                                        PDU_SESSION_RELEASE_REJECT_MIN_LEN, len);
 
-  if ((encoded_result =
-           pdu_session_release_reject->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_release_reject->extended_protocol_discriminator,
-                   0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->pdu_session_identity.EncodePDUSessionIdentityMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
   if ((encoded_result =
-           pdu_session_release_reject->pdu_session_identity
-               .EncodePDUSessionIdentityMsg(
-                   &pdu_session_release_reject->pdu_session_identity, 0,
-                   buffer + encoded, len - encoded)) < 0)
+           this->pti.EncodePTIMsg(0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = pdu_session_release_reject->pti.EncodePTIMsg(
-           &pdu_session_release_reject->pti, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           pdu_session_release_reject->message_type.EncodeMessageTypeMsg(
-               &pdu_session_release_reject->message_type, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           pdu_session_release_reject->m5gsm_cause.EncodeM5GSMCauseMsg(
-               &pdu_session_release_reject->m5gsm_cause, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->m5gsm_cause.EncodeM5GSMCauseMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionReleaseRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GPDUSessionReleaseRequest.cpp
@@ -26,40 +26,30 @@ PDUSessionReleaseRequestMsg::~PDUSessionReleaseRequestMsg(){};
 
 // Decode PDUSessionReleaseRequest Message and its IEs
 int PDUSessionReleaseRequestMsg::DecodePDUSessionReleaseRequestMsg(
-    PDUSessionReleaseRequestMsg* pdu_session_release_request, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer, PDU_SESSION_RELEASE_REQ_MIN_LEN,
                                        len);
 
-  if ((decoded_result =
-           pdu_session_release_request->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &pdu_session_release_request
-                        ->extended_protocol_discriminator,
-                   0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->pdu_session_identity.DecodePDUSessionIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if ((decoded_result =
-           pdu_session_release_request->pdu_session_identity
-               .DecodePDUSessionIdentityMsg(
-                   &pdu_session_release_request->pdu_session_identity, 0,
-                   buffer + decoded, len - decoded)) < 0)
+           this->pti.DecodePTIMsg(0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = pdu_session_release_request->pti.DecodePTIMsg(
-           &pdu_session_release_request->pti, 0, buffer + decoded,
-           len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           pdu_session_release_request->message_type.DecodeMessageTypeMsg(
-               &pdu_session_release_request->message_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -69,8 +59,7 @@ int PDUSessionReleaseRequestMsg::DecodePDUSessionReleaseRequestMsg(
 
 // Encode PDUSessionReleaseRequest Message and its IEs
 int PDUSessionReleaseRequestMsg::EncodePDUSessionReleaseRequestMsg(
-    PDUSessionReleaseRequestMsg* pdu_session_release_request, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t* buffer, uint32_t len) {
   return 0;
 }
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationAccept.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationAccept.cpp
@@ -26,41 +26,36 @@ RegistrationAcceptMsg::RegistrationAcceptMsg(){};
 RegistrationAcceptMsg::~RegistrationAcceptMsg(){};
 
 // Decoding Registration Accept Message and its IEs
-int RegistrationAcceptMsg::DecodeRegistrationAcceptMsg(
-    RegistrationAcceptMsg* reg_accept, uint8_t* buffer, uint32_t len) {
+int RegistrationAcceptMsg::DecodeRegistrationAcceptMsg(uint8_t* buffer,
+                                                       uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer,
                                        REGISTRATION_ACCEPT_MINIMUM_LENGTH, len);
 
-  if ((decoded_result = reg_accept->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &reg_accept->extended_protocol_discriminator, 0,
-                                buffer + decoded, len - decoded)) < 0)
+                                0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_accept->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &reg_accept->spare_half_octet, 0, buffer + decoded, len - decoded)) <
-      0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_accept->sec_header_type.DecodeSecurityHeaderTypeMsg(
-           &reg_accept->sec_header_type, 0, buffer + decoded, len - decoded)) <
-      0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_accept->message_type.DecodeMessageTypeMsg(
-           &reg_accept->message_type, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           reg_accept->m5gs_reg_result.DecodeM5GSRegistrationResultMsg(
-               &reg_accept->m5gs_reg_result, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->m5gs_reg_result.DecodeM5GSRegistrationResultMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -69,69 +64,61 @@ int RegistrationAcceptMsg::DecodeRegistrationAcceptMsg(
 }
 
 // Encoding Registration Accept Message and its IEs
-int RegistrationAcceptMsg::EncodeRegistrationAcceptMsg(
-    RegistrationAcceptMsg* reg_accept, uint8_t* buffer, uint32_t len) {
+int RegistrationAcceptMsg::EncodeRegistrationAcceptMsg(uint8_t* buffer,
+                                                       uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer,
                                        REGISTRATION_ACCEPT_MINIMUM_LENGTH, len);
 
-  if ((encoded_result = reg_accept->extended_protocol_discriminator
+  if ((encoded_result = this->extended_protocol_discriminator
                             .EncodeExtendedProtocolDiscriminatorMsg(
-                                &reg_accept->extended_protocol_discriminator, 0,
-                                buffer + encoded, len - encoded)) < 0)
+                                0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_accept->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &reg_accept->spare_half_octet, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_accept->sec_header_type.EncodeSecurityHeaderTypeMsg(
-           &reg_accept->sec_header_type, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_accept->message_type.EncodeMessageTypeMsg(
-           &reg_accept->message_type, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           reg_accept->m5gs_reg_result.EncodeM5GSRegistrationResultMsg(
-               &reg_accept->m5gs_reg_result, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->m5gs_reg_result.EncodeM5GSRegistrationResultMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_accept->mobile_id.EncodeM5GSMobileIdentityMsg(
-           &reg_accept->mobile_id, 0x77, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->mobile_id.EncodeM5GSMobileIdentityMsg(
+           0x77, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_accept->tai_list.EncodeTAIListMsg(
-           &reg_accept->tai_list, 0x54, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->tai_list.EncodeTAIListMsg(0x54, buffer + encoded,
+                                                        len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_accept->allowed_nssai.EncodeNSSAIMsgList(
-           &reg_accept->allowed_nssai, ALLOWED_NSSAI, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->allowed_nssai.EncodeNSSAIMsgList(
+           ALLOWED_NSSAI, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           reg_accept->network_feature.EncodeNetworkFeatureSupportMsg(
-               &reg_accept->network_feature, 0x21, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->network_feature.EncodeNetworkFeatureSupportMsg(
+           0x21, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_accept->gprs_timer.EncodeGPRSTimer3Msg(
-           &reg_accept->gprs_timer, 0x5E, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->gprs_timer.EncodeGPRSTimer3Msg(
+           0x5E, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationComplete.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationComplete.cpp
@@ -25,36 +25,31 @@ RegistrationCompleteMsg::RegistrationCompleteMsg(){};
 RegistrationCompleteMsg::~RegistrationCompleteMsg(){};
 
 // Decoding Registration Complete Message and its IEs
-int RegistrationCompleteMsg::DecodeRegistrationCompleteMsg(
-    RegistrationCompleteMsg* reg_complete, uint8_t* buffer, uint32_t len) {
+int RegistrationCompleteMsg::DecodeRegistrationCompleteMsg(uint8_t* buffer,
+                                                           uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, REGISTRATION_COMPLETE_MINIMUM_LENGTH, len);
 
-  if ((decoded_result = reg_complete->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &reg_complete->extended_protocol_discriminator,
                                 0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_complete->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &reg_complete->spare_half_octet, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           reg_complete->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &reg_complete->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_complete->message_type.DecodeMessageTypeMsg(
-           &reg_complete->message_type, 0, buffer + decoded, len - decoded)) <
-      0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -63,36 +58,31 @@ int RegistrationCompleteMsg::DecodeRegistrationCompleteMsg(
 }
 
 // Encoding Registration Complete Message and its IEs
-int RegistrationCompleteMsg::EncodeRegistrationCompleteMsg(
-    RegistrationCompleteMsg* reg_complete, uint8_t* buffer, uint32_t len) {
+int RegistrationCompleteMsg::EncodeRegistrationCompleteMsg(uint8_t* buffer,
+                                                           uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, REGISTRATION_COMPLETE_MINIMUM_LENGTH, len);
 
-  if ((encoded_result = reg_complete->extended_protocol_discriminator
+  if ((encoded_result = this->extended_protocol_discriminator
                             .EncodeExtendedProtocolDiscriminatorMsg(
-                                &reg_complete->extended_protocol_discriminator,
                                 0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_complete->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &reg_complete->spare_half_octet, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           reg_complete->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &reg_complete->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_complete->message_type.EncodeMessageTypeMsg(
-           &reg_complete->message_type, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationReject.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationReject.cpp
@@ -25,39 +25,36 @@ RegistrationRejectMsg::RegistrationRejectMsg(){};
 RegistrationRejectMsg::~RegistrationRejectMsg(){};
 
 // Decoding Registration Reject Message and its IEs
-int RegistrationRejectMsg::DecodeRegistrationRejectMsg(
-    RegistrationRejectMsg* reg_reject, uint8_t* buffer, uint32_t len) {
+int RegistrationRejectMsg::DecodeRegistrationRejectMsg(uint8_t* buffer,
+                                                       uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer,
                                        REGISTRATION_REJECT_MINIMUM_LENGTH, len);
 
-  if ((decoded_result = reg_reject->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &reg_reject->extended_protocol_discriminator, 0,
-                                buffer + decoded, len - decoded)) < 0)
+                                0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_reject->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &reg_reject->spare_half_octet, 0, buffer + decoded, len - decoded)) <
-      0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_reject->sec_header_type.DecodeSecurityHeaderTypeMsg(
-           &reg_reject->sec_header_type, 0, buffer + decoded, len - decoded)) <
-      0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_reject->message_type.DecodeMessageTypeMsg(
-           &reg_reject->message_type, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_reject->m5gmm_cause.DecodeM5GMMCauseMsg(
-           &reg_reject->m5gmm_cause, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->m5gmm_cause.DecodeM5GMMCauseMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -66,39 +63,36 @@ int RegistrationRejectMsg::DecodeRegistrationRejectMsg(
 }
 
 // Encoding Registration Reject Message and its IEs
-int RegistrationRejectMsg::EncodeRegistrationRejectMsg(
-    RegistrationRejectMsg* reg_reject, uint8_t* buffer, uint32_t len) {
+int RegistrationRejectMsg::EncodeRegistrationRejectMsg(uint8_t* buffer,
+                                                       uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer,
                                        REGISTRATION_REJECT_MINIMUM_LENGTH, len);
 
-  if ((encoded_result = reg_reject->extended_protocol_discriminator
+  if ((encoded_result = this->extended_protocol_discriminator
                             .EncodeExtendedProtocolDiscriminatorMsg(
-                                &reg_reject->extended_protocol_discriminator, 0,
-                                buffer + encoded, len - encoded)) < 0)
+                                0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_reject->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &reg_reject->spare_half_octet, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_reject->sec_header_type.EncodeSecurityHeaderTypeMsg(
-           &reg_reject->sec_header_type, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_reject->message_type.EncodeMessageTypeMsg(
-           &reg_reject->message_type, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = reg_reject->m5gmm_cause.EncodeM5GMMCauseMsg(
-           &reg_reject->m5gmm_cause, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->m5gmm_cause.EncodeM5GMMCauseMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GRegistrationRequest.cpp
@@ -26,8 +26,8 @@ RegistrationRequestMsg::RegistrationRequestMsg(){};
 RegistrationRequestMsg::~RegistrationRequestMsg(){};
 
 // Decode RegistrationRequest Message and its IEs
-int RegistrationRequestMsg::DecodeRegistrationRequestMsg(
-    RegistrationRequestMsg* reg_request, uint8_t* buffer, uint32_t len) {
+int RegistrationRequestMsg::DecodeRegistrationRequestMsg(uint8_t* buffer,
+                                                         uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   uint8_t type_len = 0;
@@ -36,49 +36,40 @@ int RegistrationRequestMsg::DecodeRegistrationRequestMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, REGISTRATION_REQUEST_MINIMUM_LENGTH, len);
 
-  if ((decoded_result = reg_request->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &reg_request->extended_protocol_discriminator,
                                 0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_request->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &reg_request->spare_half_octet, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->m5gs_reg_type.DecodeM5GSRegistrationTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if ((decoded_result =
-           reg_request->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &reg_request->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+           this->nas_key_set_identifier.DecodeNASKeySetIdentifierMsg(
+               0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = reg_request->message_type.DecodeMessageTypeMsg(
-           &reg_request->message_type, 0, buffer + decoded, len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           reg_request->m5gs_reg_type.DecodeM5GSRegistrationTypeMsg(
-               &reg_request->m5gs_reg_type, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           reg_request->nas_key_set_identifier.DecodeNASKeySetIdentifierMsg(
-               &reg_request->nas_key_set_identifier, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           reg_request->m5gs_mobile_identity.DecodeM5GSMobileIdentityMsg(
-               &reg_request->m5gs_mobile_identity, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->m5gs_mobile_identity.DecodeM5GSMobileIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -91,11 +82,9 @@ int RegistrationRequestMsg::DecodeRegistrationRequestMsg(
 
     switch (type) {
       case REGISTRATION_REQUEST_UE_SECURITY_CAPABILITY_TYPE:
-        decoded_result =
-            reg_request->ue_sec_capability.DecodeUESecurityCapabilityMsg(
-                &reg_request->ue_sec_capability,
-                REGISTRATION_REQUEST_UE_SECURITY_CAPABILITY_TYPE,
-                buffer + decoded, len - decoded);
+        decoded_result = this->ue_sec_capability.DecodeUESecurityCapabilityMsg(
+            REGISTRATION_REQUEST_UE_SECURITY_CAPABILITY_TYPE, buffer + decoded,
+            len - decoded);
         if (decoded_result < 0) {
           return decoded_result;
         }
@@ -154,8 +143,8 @@ int RegistrationRequestMsg::DecodeRegistrationRequestMsg(
 
 // Will be supported POST MVC
 // Encode Registration Request Message and its IEs
-int RegistrationRequestMsg::EncodeRegistrationRequestMsg(
-    RegistrationRequestMsg* reg_request, uint8_t* buffer, uint32_t len) {
+int RegistrationRequestMsg::EncodeRegistrationRequestMsg(uint8_t* buffer,
+                                                         uint32_t len) {
   uint32_t encoded = 0;
   // Will be supported POST MVC
   return encoded;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GSecurityModeCommand.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GSecurityModeCommand.cpp
@@ -25,8 +25,8 @@ SecurityModeCommandMsg::SecurityModeCommandMsg(){};
 SecurityModeCommandMsg::~SecurityModeCommandMsg(){};
 
 // Decode SecurityModeCommand Message and its IEs
-int SecurityModeCommandMsg::DecodeSecurityModeCommandMsg(
-    SecurityModeCommandMsg* sec_mode_command, uint8_t* buffer, uint32_t len) {
+int SecurityModeCommandMsg::DecodeSecurityModeCommandMsg(uint8_t* buffer,
+                                                         uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
@@ -34,59 +34,45 @@ int SecurityModeCommandMsg::DecodeSecurityModeCommandMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, SECURITY_MODE_COMMAND_MINIMUM_LENGTH, len);
 
-  if ((decoded_result =
-           sec_mode_command->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &sec_mode_command->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->nas_sec_algorithms.DecodeNASSecurityAlgorithmsMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if ((decoded_result =
-           sec_mode_command->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &sec_mode_command->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0)
+           this->nas_key_set_identifier.DecodeNASKeySetIdentifierMsg(
+               0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           sec_mode_command->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &sec_mode_command->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result = sec_mode_command->message_type.DecodeMessageTypeMsg(
-           &sec_mode_command->message_type, 0, buffer + decoded,
-           len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           sec_mode_command->nas_sec_algorithms.DecodeNASSecurityAlgorithmsMsg(
-               &sec_mode_command->nas_sec_algorithms, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           sec_mode_command->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &sec_mode_command->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result = sec_mode_command->nas_key_set_identifier
-                            .DecodeNASKeySetIdentifierMsg(
-                                &sec_mode_command->nas_key_set_identifier, 0,
-                                buffer + decoded, len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           sec_mode_command->ue_sec_capability.DecodeUESecurityCapabilityMsg(
-               &sec_mode_command->ue_sec_capability, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->ue_sec_capability.DecodeUESecurityCapabilityMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -95,8 +81,8 @@ int SecurityModeCommandMsg::DecodeSecurityModeCommandMsg(
 }
 
 // Encode Security Mode Command Message and its IEs
-int SecurityModeCommandMsg::EncodeSecurityModeCommandMsg(
-    SecurityModeCommandMsg* sec_mode_command, uint8_t* buffer, uint32_t len) {
+int SecurityModeCommandMsg::EncodeSecurityModeCommandMsg(uint8_t* buffer,
+                                                         uint32_t len) {
   uint32_t encoded = 0;
 
   int encoded_result = 0;
@@ -106,65 +92,50 @@ int SecurityModeCommandMsg::EncodeSecurityModeCommandMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, SECURITY_MODE_COMMAND_MINIMUM_LENGTH, len);
 
-  if ((encoded_result =
-           sec_mode_command->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &sec_mode_command->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->nas_sec_algorithms.EncodeNASSecurityAlgorithmsMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
   if ((encoded_result =
-           sec_mode_command->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &sec_mode_command->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0)
+           this->nas_key_set_identifier.EncodeNASKeySetIdentifierMsg(
+               0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           sec_mode_command->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &sec_mode_command->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->ue_sec_capability.EncodeUESecurityCapabilityMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = sec_mode_command->message_type.EncodeMessageTypeMsg(
-           &sec_mode_command->message_type, 0, buffer + encoded,
-           len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           sec_mode_command->nas_sec_algorithms.EncodeNASSecurityAlgorithmsMsg(
-               &sec_mode_command->nas_sec_algorithms, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           sec_mode_command->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &sec_mode_command->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result = sec_mode_command->nas_key_set_identifier
-                            .EncodeNASKeySetIdentifierMsg(
-                                &sec_mode_command->nas_key_set_identifier, 0,
-                                buffer + encoded, len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           sec_mode_command->ue_sec_capability.EncodeUESecurityCapabilityMsg(
-               &sec_mode_command->ue_sec_capability, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result = sec_mode_command->imeisv_request.EncodeImeisvRequestMsg(
-           &sec_mode_command->imeisv_request, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->imeisv_request.EncodeImeisvRequestMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GSecurityModeComplete.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GSecurityModeComplete.cpp
@@ -25,38 +25,31 @@ SecurityModeCompleteMsg::SecurityModeCompleteMsg(){};
 SecurityModeCompleteMsg::~SecurityModeCompleteMsg(){};
 
 // Decode SecurityModeComplete Message and its IEs
-int SecurityModeCompleteMsg::DecodeSecurityModeCompleteMsg(
-    SecurityModeCompleteMsg* sec_mode_complete, uint8_t* buffer, uint32_t len) {
+int SecurityModeCompleteMsg::DecodeSecurityModeCompleteMsg(uint8_t* buffer,
+                                                           uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, SECURITY_MODE_COMPLETE_MINIMUM_LENGTH, len);
 
-  if ((decoded_result =
-           sec_mode_complete->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &sec_mode_complete->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           sec_mode_complete->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &sec_mode_complete->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           sec_mode_complete->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &sec_mode_complete->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = sec_mode_complete->message_type.DecodeMessageTypeMsg(
-           &sec_mode_complete->message_type, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -65,8 +58,8 @@ int SecurityModeCompleteMsg::DecodeSecurityModeCompleteMsg(
 
 // Will be supported POST MVC
 // Encode Security Mode Complete Message and its IEs
-int SecurityModeCompleteMsg::EncodeSecurityModeCompleteMsg(
-    SecurityModeCompleteMsg* sec_mode_complete, uint8_t* buffer, uint32_t len) {
+int SecurityModeCompleteMsg::EncodeSecurityModeCompleteMsg(uint8_t* buffer,
+                                                           uint32_t len) {
   uint32_t encoded = 0;
 
 #ifdef HANDLE_POST_MVC
@@ -77,22 +70,18 @@ int SecurityModeCompleteMsg::EncodeSecurityModeCompleteMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, SECURITY_MODE_COMPLETE_MINIMUM_LENGTH, len);
 
+  if ((encoded_result = this->EncodeExtendedProtocolDiscriminatorMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->EncodeSecurityHeaderTypeMsg(0, buffer + encoded,
+                                                          len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
   if ((encoded_result =
-           sec_mode_complete->EncodeExtendedProtocolDiscriminatorMsg(
-               sec_mode_complete->extended_protocol_discriminator, 0,
-               buffer + encoded, len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result = sec_mode_complete->EncodeSecurityHeaderTypeMsg(
-           sec_mode_complete->sec_header_type, 0, buffer + encoded,
-           len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result = sec_mode_complete->EncodeMessageTypeMsg(
-           sec_mode_complete->message_type, 0, buffer + encoded,
-           len - encoded)) < 0)
+           this->EncodeMessageTypeMsg(0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GSecurityModeReject.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GSecurityModeReject.cpp
@@ -25,44 +25,36 @@ SecurityModeRejectMsg::SecurityModeRejectMsg(){};
 SecurityModeRejectMsg::~SecurityModeRejectMsg(){};
 
 // Decoding Security Mode Reject Message and its IEs
-int SecurityModeRejectMsg::DecodeSecurityModeRejectMsg(
-    SecurityModeRejectMsg* sec_mode_reject, uint8_t* buffer, uint32_t len) {
+int SecurityModeRejectMsg::DecodeSecurityModeRejectMsg(uint8_t* buffer,
+                                                       uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(
       buffer, SECURITY_MODE_REJECT_MINIMUM_LENGTH, len);
 
-  if ((decoded_result =
-           sec_mode_reject->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &sec_mode_reject->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           sec_mode_reject->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &sec_mode_reject->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result =
-           sec_mode_reject->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &sec_mode_reject->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = sec_mode_reject->message_type.DecodeMessageTypeMsg(
-           &sec_mode_reject->message_type, 0, buffer + decoded,
-           len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = sec_mode_reject->m5gmm_cause.DecodeM5GMMCauseMsg(
-           &sec_mode_reject->m5gmm_cause, 0, buffer + decoded, len - decoded)) <
-      0)
+  if ((decoded_result = this->m5gmm_cause.DecodeM5GMMCauseMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -71,44 +63,36 @@ int SecurityModeRejectMsg::DecodeSecurityModeRejectMsg(
 }
 
 // Encoding Security Mode Reject Message and its IEs
-int SecurityModeRejectMsg::EncodeSecurityModeRejectMsg(
-    SecurityModeRejectMsg* sec_mode_reject, uint8_t* buffer, uint32_t len) {
+int SecurityModeRejectMsg::EncodeSecurityModeRejectMsg(uint8_t* buffer,
+                                                       uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(
       buffer, SECURITY_MODE_REJECT_MINIMUM_LENGTH, len);
 
-  if ((encoded_result =
-           sec_mode_reject->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &sec_mode_reject->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           sec_mode_reject->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &sec_mode_reject->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           sec_mode_reject->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &sec_mode_reject->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = sec_mode_reject->message_type.EncodeMessageTypeMsg(
-           &sec_mode_reject->message_type, 0, buffer + encoded,
-           len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = sec_mode_reject->m5gmm_cause.EncodeM5GMMCauseMsg(
-           &sec_mode_reject->m5gmm_cause, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->m5gmm_cause.EncodeM5GMMCauseMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceAccept.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceAccept.cpp
@@ -25,52 +25,46 @@ ServiceAcceptMsg::ServiceAcceptMsg(){};
 ServiceAcceptMsg::~ServiceAcceptMsg(){};
 
 // Decoding Service Accept Message and its IEs
-int ServiceAcceptMsg::DecodeServiceAcceptMsg(ServiceAcceptMsg* svc_acpt,
-                                             uint8_t* buffer, uint32_t len) {
+int ServiceAcceptMsg::DecodeServiceAcceptMsg(uint8_t* buffer, uint32_t len) {
   return 0;
 }
 
 // Encoding Service Accept Message and its IEs
-int ServiceAcceptMsg::EncodeServiceAcceptMsg(ServiceAcceptMsg* svc_acpt,
-                                             uint8_t* buffer, uint32_t len) {
+int ServiceAcceptMsg::EncodeServiceAcceptMsg(uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, SERVICE_ACCEPT_MINIMUM_LENGTH,
                                        len);
 
-  if ((encoded_result = svc_acpt->extended_protocol_discriminator
+  if ((encoded_result = this->extended_protocol_discriminator
                             .EncodeExtendedProtocolDiscriminatorMsg(
-                                &svc_acpt->extended_protocol_discriminator, 0,
-                                buffer + encoded, len - encoded)) < 0)
+                                0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_acpt->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &svc_acpt->spare_half_octet, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_acpt->sec_header_type.EncodeSecurityHeaderTypeMsg(
-           &svc_acpt->sec_header_type, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_acpt->message_type.EncodeMessageTypeMsg(
-           &svc_acpt->message_type, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_acpt->pdu_session_status.EncodePDUSessionStatus(
-           &svc_acpt->pdu_session_status, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->pdu_session_status.EncodePDUSessionStatus(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_acpt->pdu_re_activation_status
-                            .EncodePDUSessionReActivationResult(
-                                &svc_acpt->pdu_re_activation_status, 0,
-                                buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result =
+           this->pdu_re_activation_status.EncodePDUSessionReActivationResult(
+               0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceReject.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceReject.cpp
@@ -26,42 +26,39 @@ ServiceRejectMsg::ServiceRejectMsg(){};
 ServiceRejectMsg::~ServiceRejectMsg(){};
 
 // Decoding Service Reject Message and its IEs
-int ServiceRejectMsg::DecodeServiceRejectMsg(ServiceRejectMsg* svc_rej,
-                                             uint8_t* buffer, uint32_t len) {
+int ServiceRejectMsg::DecodeServiceRejectMsg(uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
-  if ((decoded_result = svc_rej->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &svc_rej->extended_protocol_discriminator, 0,
-                                buffer + decoded, len - decoded)) < 0)
+                                0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = svc_rej->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &svc_rej->spare_half_octet, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = svc_rej->sec_header_type.DecodeSecurityHeaderTypeMsg(
-           &svc_rej->sec_header_type, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = svc_rej->message_type.DecodeMessageTypeMsg(
-           &svc_rej->message_type, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = svc_rej->cause.DecodeM5GMMCauseMsg(
-           &svc_rej->cause, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->cause.DecodeM5GMMCauseMsg(0, buffer + decoded,
+                                                        len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if (decoded < len) {
-    if ((decoded_result = svc_rej->pdu_session_status.DecodePDUSessionStatus(
-             &svc_rej->pdu_session_status, PDU_SESSION_STATUS, buffer + decoded,
-             len - decoded)) < 0)
+    if ((decoded_result = this->pdu_session_status.DecodePDUSessionStatus(
+             PDU_SESSION_STATUS, buffer + decoded, len - decoded)) < 0)
       return decoded_result;
     else
       decoded += decoded_result;
@@ -71,48 +68,45 @@ int ServiceRejectMsg::DecodeServiceRejectMsg(ServiceRejectMsg* svc_rej,
 }
 
 // Encoding Service Reject Message and its IEs
-int ServiceRejectMsg::EncodeServiceRejectMsg(ServiceRejectMsg* svc_rej,
-                                             uint8_t* buffer, uint32_t len) {
+int ServiceRejectMsg::EncodeServiceRejectMsg(uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
   int encoded_result = 0;
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer,
                                        M5G_SERVICE_REJECT_MINIMUM_LENGTH, len);
 
-  if ((encoded_result = svc_rej->extended_protocol_discriminator
+  if ((encoded_result = this->extended_protocol_discriminator
                             .EncodeExtendedProtocolDiscriminatorMsg(
-                                &svc_rej->extended_protocol_discriminator, 0,
-                                buffer + encoded, len - encoded)) < 0)
+                                0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_rej->spare_half_octet.EncodeSpareHalfOctetMsg(
-           &svc_rej->spare_half_octet, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_rej->sec_header_type.EncodeSecurityHeaderTypeMsg(
-           &svc_rej->sec_header_type, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_rej->message_type.EncodeMessageTypeMsg(
-           &svc_rej->message_type, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_rej->cause.EncodeM5GMMCauseMsg(
-           &svc_rej->cause, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->cause.EncodeM5GMMCauseMsg(0, buffer + encoded,
+                                                        len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_rej->pdu_session_status.EncodePDUSessionStatus(
-           &svc_rej->pdu_session_status, 0, buffer + encoded, len - encoded)) <
-      0)
+  if ((encoded_result = this->pdu_session_status.EncodePDUSessionStatus(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result = svc_rej->t3346Value.EncodeGPRSTimer2Msg(
-           &svc_rej->t3346Value, 0, buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->t3346Value.EncodeGPRSTimer2Msg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GServiceRequest.cpp
@@ -27,8 +27,7 @@ ServiceRequestMsg::ServiceRequestMsg(){};
 ServiceRequestMsg::~ServiceRequestMsg(){};
 
 // Decode ServiceRequest Messsage
-int ServiceRequestMsg::DecodeServiceRequestMsg(ServiceRequestMsg* svc_req,
-                                               uint8_t* buffer, uint32_t len) {
+int ServiceRequestMsg::DecodeServiceRequestMsg(uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
 
@@ -37,44 +36,40 @@ int ServiceRequestMsg::DecodeServiceRequestMsg(ServiceRequestMsg* svc_req,
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer, SERVICE_REQUEST_MINIMUM_LENGTH,
                                        len);
 
-  if ((decoded_result = svc_req->extended_protocol_discriminator
+  if ((decoded_result = this->extended_protocol_discriminator
                             .DecodeExtendedProtocolDiscriminatorMsg(
-                                &svc_req->extended_protocol_discriminator, 0,
-                                buffer + decoded, len - decoded)) < 0)
+                                0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = svc_req->spare_half_octet.DecodeSpareHalfOctetMsg(
-           &svc_req->spare_half_octet, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = svc_req->sec_header_type.DecodeSecurityHeaderTypeMsg(
-           &svc_req->sec_header_type, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = svc_req->message_type.DecodeMessageTypeMsg(
-           &svc_req->message_type, 0, buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
-  if ((decoded_result = svc_req->service_type.DecodeServiceTypeMsg(
-           &svc_req->service_type, 0, buffer + decoded, len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-  if ((decoded_result =
-           svc_req->nas_key_set_identifier.DecodeNASKeySetIdentifierMsg(
-               &svc_req->nas_key_set_identifier, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->service_type.DecodeServiceTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
   if ((decoded_result =
-           svc_req->m5gs_mobile_identity.DecodeM5GSMobileIdentityMsg(
-               &svc_req->m5gs_mobile_identity, 0, buffer + decoded,
-               len - decoded)) < 0)
+           this->nas_key_set_identifier.DecodeNASKeySetIdentifierMsg(
+               0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+  if ((decoded_result = this->m5gs_mobile_identity.DecodeM5GSMobileIdentityMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -83,26 +78,22 @@ int ServiceRequestMsg::DecodeServiceRequestMsg(ServiceRequestMsg* svc_req,
     uint8_t type = *(buffer + decoded);
     switch (type) {
       case UP_LINK_DATA_STATUS: {
-        if ((decoded_result =
-                 svc_req->uplink_data_status.DecodeUplinkDataStatus(
-                     &svc_req->uplink_data_status, UP_LINK_DATA_STATUS,
-                     buffer + decoded, len - decoded)) < 0)
+        if ((decoded_result = this->uplink_data_status.DecodeUplinkDataStatus(
+                 UP_LINK_DATA_STATUS, buffer + decoded, len - decoded)) < 0)
           return decoded_result;
         else
           decoded += decoded_result;
       } break;
       case PDU_SESSION_STATUS: {
-        if ((decoded_result =
-                 svc_req->pdu_session_status.DecodePDUSessionStatus(
-                     &svc_req->pdu_session_status, PDU_SESSION_STATUS,
-                     buffer + decoded, len - decoded)) < 0)
+        if ((decoded_result = this->pdu_session_status.DecodePDUSessionStatus(
+                 PDU_SESSION_STATUS, buffer + decoded, len - decoded)) < 0)
           return decoded_result;
         else
           decoded += decoded_result;
       } break;
       case NAS_MESSAGE_CONTAINER: {
-        if ((decoded_result = DecodeServiceRequestMsg(
-                 svc_req, buffer + (decoded + 3), len - (decoded + 3))) < 0) {
+        if ((decoded_result = this->DecodeServiceRequestMsg(
+                 buffer + (decoded + 3), len - (decoded + 3))) < 0) {
           return decoded_result;
         } else {
           decoded += (decoded_result + 3);
@@ -118,8 +109,7 @@ int ServiceRequestMsg::DecodeServiceRequestMsg(ServiceRequestMsg* svc_req,
 };
 
 // Encode ServiceRequest Messsage
-int ServiceRequestMsg::EncodeServiceRequestMsg(ServiceRequestMsg* svc_req,
-                                               uint8_t* buffer, uint32_t len) {
+int ServiceRequestMsg::EncodeServiceRequestMsg(uint8_t* buffer, uint32_t len) {
   /*** Not Implemented, will be supported POST MVC ***/
   return 0;
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/M5GULNASTransport.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/M5GULNASTransport.cpp
@@ -26,8 +26,7 @@ ULNASTransportMsg::ULNASTransportMsg(){};
 ULNASTransportMsg::~ULNASTransportMsg(){};
 
 // Decode ULNASTransport Message and its IEs
-int ULNASTransportMsg::DecodeULNASTransportMsg(
-    ULNASTransportMsg* ul_nas_transport, uint8_t* buffer, uint32_t len) {
+int ULNASTransportMsg::DecodeULNASTransportMsg(uint8_t* buffer, uint32_t len) {
   uint32_t decoded = 0;
   int decoded_result = 0;
   uint8_t type_len = 0;
@@ -37,50 +36,40 @@ int ULNASTransportMsg::DecodeULNASTransportMsg(
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer, UL_NAS_TRANSPORT_MINIMUM_LENGTH,
                                        len);
 
-  if ((decoded_result =
-           ul_nas_transport->extended_protocol_discriminator
-               .DecodeExtendedProtocolDiscriminatorMsg(
-                   &ul_nas_transport->extended_protocol_discriminator, 0,
-                   buffer + decoded, len - decoded)) < 0)
+  if ((decoded_result = this->extended_protocol_discriminator
+                            .DecodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+
+  if ((decoded_result = this->spare_half_octet.DecodeSpareHalfOctetMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+
+  if ((decoded_result = this->sec_header_type.DecodeSecurityHeaderTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
+    return decoded_result;
+  else
+    decoded += decoded_result;
+
+  if ((decoded_result = this->message_type.DecodeMessageTypeMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
 
   if ((decoded_result =
-           ul_nas_transport->spare_half_octet.DecodeSpareHalfOctetMsg(
-               &ul_nas_transport->spare_half_octet, 0, buffer + decoded,
-               len - decoded)) < 0)
+           this->payload_container_type.DecodePayloadContainerTypeMsg(
+               0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
 
-  if ((decoded_result =
-           ul_nas_transport->sec_header_type.DecodeSecurityHeaderTypeMsg(
-               &ul_nas_transport->sec_header_type, 0, buffer + decoded,
-               len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-
-  if ((decoded_result = ul_nas_transport->message_type.DecodeMessageTypeMsg(
-           &ul_nas_transport->message_type, 0, buffer + decoded,
-           len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-
-  if ((decoded_result = ul_nas_transport->payload_container_type
-                            .DecodePayloadContainerTypeMsg(
-                                &ul_nas_transport->payload_container_type, 0,
-                                buffer + decoded, len - decoded)) < 0)
-    return decoded_result;
-  else
-    decoded += decoded_result;
-
-  if ((decoded_result =
-           ul_nas_transport->payload_container.DecodePayloadContainerMsg(
-               &ul_nas_transport->payload_container, 0, buffer + decoded,
-               len - decoded)) < 0)
+  if ((decoded_result = this->payload_container.DecodePayloadContainerMsg(
+           0, buffer + decoded, len - decoded)) < 0)
     return decoded_result;
   else
     decoded += decoded_result;
@@ -93,8 +82,7 @@ int ULNASTransportMsg::DecodeULNASTransportMsg(
 
     switch (static_cast<M5GIei>(type)) {
       case M5GIei::REQUEST_TYPE: {
-        if ((decoded_result = ul_nas_transport->request_type.DecodeRequestType(
-                 &ul_nas_transport->request_type,
+        if ((decoded_result = this->request_type.DecodeRequestType(
                  static_cast<uint8_t>(M5GIei::REQUEST_TYPE), buffer + decoded,
                  len - decoded)) < 0) {
           return decoded_result;
@@ -114,17 +102,16 @@ int ULNASTransportMsg::DecodeULNASTransportMsg(
         decoded += decoded_result;
         break;
       case M5GIei::DNN:
-        if ((decoded_result = ul_nas_transport->dnn.DecodeDNNMsg(
-                 &ul_nas_transport->dnn, static_cast<uint8_t>(M5GIei::DNN),
-                 buffer + decoded, len - decoded)) < 0) {
+        if ((decoded_result =
+                 this->dnn.DecodeDNNMsg(static_cast<uint8_t>(M5GIei::DNN),
+                                        buffer + decoded, len - decoded)) < 0) {
           return decoded_result;
         } else {
           decoded += decoded_result;
         }
         break;
       case M5GIei::S_NSSAI:
-        if ((decoded_result = ul_nas_transport->nssai.DecodeNSSAIMsg(
-                 &ul_nas_transport->nssai,
+        if ((decoded_result = this->nssai.DecodeNSSAIMsg(
                  static_cast<uint8_t>(M5GIei::S_NSSAI), buffer + decoded,
                  len - decoded)) < 0) {
           return decoded_result;
@@ -154,8 +141,7 @@ int ULNASTransportMsg::DecodeULNASTransportMsg(
 }
 
 // Encode DL NAS Transport Message and its IEs
-int ULNASTransportMsg::EncodeULNASTransportMsg(
-    ULNASTransportMsg* ul_nas_transport, uint8_t* buffer, uint32_t len) {
+int ULNASTransportMsg::EncodeULNASTransportMsg(uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
 
   int encoded_result = 0;
@@ -165,59 +151,46 @@ int ULNASTransportMsg::EncodeULNASTransportMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, UL_NAS_TRANSPORT_MINIMUM_LENGTH,
                                        len);
 
-  if ((encoded_result =
-           ul_nas_transport->extended_protocol_discriminator
-               .EncodeExtendedProtocolDiscriminatorMsg(
-                   &ul_nas_transport->extended_protocol_discriminator, 0,
-                   buffer + encoded, len - encoded)) < 0)
+  if ((encoded_result = this->extended_protocol_discriminator
+                            .EncodeExtendedProtocolDiscriminatorMsg(
+                                0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->sec_header_type.EncodeSecurityHeaderTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->message_type.EncodeMessageTypeMsg(
+           0, buffer + encoded, len - encoded)) < 0)
+    return encoded_result;
+  else
+    encoded += encoded_result;
+  if ((encoded_result = this->spare_half_octet.EncodeSpareHalfOctetMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
   if ((encoded_result =
-           ul_nas_transport->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &ul_nas_transport->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0)
+           this->payload_container_type.EncodePayloadContainerTypeMsg(
+               0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
-  if ((encoded_result =
-           ul_nas_transport->sec_header_type.EncodeSecurityHeaderTypeMsg(
-               &ul_nas_transport->sec_header_type, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result = ul_nas_transport->message_type.EncodeMessageTypeMsg(
-           &ul_nas_transport->message_type, 0, buffer + encoded,
-           len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           ul_nas_transport->spare_half_octet.EncodeSpareHalfOctetMsg(
-               &ul_nas_transport->spare_half_octet, 0, buffer + encoded,
-               len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result = ul_nas_transport->payload_container_type
-                            .EncodePayloadContainerTypeMsg(
-                                &ul_nas_transport->payload_container_type, 0,
-                                buffer + encoded, len - encoded)) < 0)
-    return encoded_result;
-  else
-    encoded += encoded_result;
-  if ((encoded_result =
-           ul_nas_transport->payload_container.EncodePayloadContainerMsg(
-               &ul_nas_transport->payload_container, 0, buffer + encoded,
-               len - encoded)) < 0)
+  if ((encoded_result = this->payload_container.EncodePayloadContainerMsg(
+           0, buffer + encoded, len - encoded)) < 0)
     return encoded_result;
   else
     encoded += encoded_result;
 
-  if ((uint32_t)ul_nas_transport->request_type.type_val) {
-    if ((encoded_result = ul_nas_transport->request_type.EncodeRequestType(
-             &ul_nas_transport->request_type,
+  if ((uint32_t)this->request_type.type_val) {
+    if ((encoded_result = this->request_type.EncodeRequestType(
              static_cast<uint8_t>(M5GIei::REQUEST_TYPE), buffer + encoded,
              len - encoded)) < 0) {
       return encoded_result;
@@ -226,20 +199,20 @@ int ULNASTransportMsg::EncodeULNASTransportMsg(
     }
   }
 
-  if ((uint32_t)ul_nas_transport->dnn.len) {
-    if ((encoded_result = ul_nas_transport->dnn.EncodeDNNMsg(
-             &ul_nas_transport->dnn, static_cast<uint8_t>(M5GIei::DNN),
-             buffer + encoded, len - encoded)) < 0) {
+  if ((uint32_t)this->dnn.len) {
+    if ((encoded_result =
+             this->dnn.EncodeDNNMsg(static_cast<uint8_t>(M5GIei::DNN),
+                                    buffer + encoded, len - encoded)) < 0) {
       return encoded_result;
     } else {
       encoded += encoded_result;
     }
   }
 
-  if ((uint32_t)ul_nas_transport->nssai.len) {
-    if ((encoded_result = ul_nas_transport->nssai.EncodeNSSAIMsg(
-             &ul_nas_transport->nssai, static_cast<uint8_t>(M5GIei::S_NSSAI),
-             buffer + encoded, len - encoded)) < 0) {
+  if ((uint32_t)this->nssai.len) {
+    if ((encoded_result =
+             this->nssai.EncodeNSSAIMsg(static_cast<uint8_t>(M5GIei::S_NSSAI),
+                                        buffer + encoded, len - encoded)) < 0) {
       return encoded_result;
     } else {
       encoded += encoded_result;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GABBA.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GABBA.cpp
@@ -27,16 +27,14 @@ ABBAMsg::ABBAMsg(){};
 ABBAMsg::~ABBAMsg(){};
 
 // Decode ABBA Message IE
-int ABBAMsg::DecodeABBAMsg(ABBAMsg* abba, uint8_t iei, uint8_t* buffer,
-                           uint32_t len) {
+int ABBAMsg::DecodeABBAMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t decoded = 0;
   /*** Not Implemented, Will be supported POST MVC ***/
   return (decoded);
 };
 
 // Encode ABBA Message IE
-int ABBAMsg::EncodeABBAMsg(ABBAMsg* abba, uint8_t iei, uint8_t* buffer,
-                           uint32_t len) {
+int ABBAMsg::EncodeABBAMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t* lenPtr;
   uint32_t encoded = 0;
 
@@ -44,14 +42,12 @@ int ABBAMsg::EncodeABBAMsg(ABBAMsg* abba, uint8_t iei, uint8_t* buffer,
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, ABBA_MIN_LEN, len);
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER((unsigned char)iei, abba->iei);
-    *buffer = iei;
-    encoded++;
+    CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
+    *(buffer + encoded++) = iei;
   }
 
-  lenPtr = buffer + encoded;
-  encoded++;
-  memcpy(buffer + encoded, abba->contents, ABBA_MIN_LEN);
+  lenPtr = (buffer + encoded++);
+  memcpy(buffer + encoded, this->contents, ABBA_MIN_LEN);
   encoded = encoded + ABBA_MIN_LEN;
   *lenPtr = encoded - 1 - ((iei > 0) ? 1 : 0);
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationFailureIE.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationFailureIE.cpp
@@ -27,22 +27,18 @@ M5GAuthenticationFailureIE::~M5GAuthenticationFailureIE(){};
 
 // Decode 5GMMCause IE
 int M5GAuthenticationFailureIE::DecodeM5GAuthenticationFailureIE(
-    M5GAuthenticationFailureIE* m5g_auth_failure_ie, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t decoded = 0;
   uint8_t ielen = 0;
 
   if (iei > 0) {
-    m5g_auth_failure_ie->iei = *(buffer + decoded);
-    CHECK_IEI_DECODER((unsigned char)iei, m5g_auth_failure_ie->iei);
-    decoded++;
+    this->iei = *(buffer + decoded++);
+    CHECK_IEI_DECODER((unsigned char)iei, this->iei);
   }
 
-  ielen = *(buffer + decoded);
-  decoded++;
+  ielen = *(buffer + decoded++);
 
-  m5g_auth_failure_ie->authentication_failure_info =
-      blk2bstr(buffer + decoded, ielen);
+  this->authentication_failure_info = blk2bstr(buffer + decoded, ielen);
 
   decoded += ielen;
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationParameterAUTN.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationParameterAUTN.cpp
@@ -28,8 +28,7 @@ AuthenticationParameterAUTNMsg::~AuthenticationParameterAUTNMsg(){};
 
 // Decode AuthenticationParameterAUTN IE
 int AuthenticationParameterAUTNMsg::DecodeAuthenticationParameterAUTNMsg(
-    AuthenticationParameterAUTNMsg* autn, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t decoded = 0;
   /*** Not Implemented, Will be supported POST MVC ***/
   return (decoded);
@@ -37,8 +36,7 @@ int AuthenticationParameterAUTNMsg::DecodeAuthenticationParameterAUTNMsg(
 
 // Encode AuthenticationParameterAUTN IE
 int AuthenticationParameterAUTNMsg::EncodeAuthenticationParameterAUTNMsg(
-    AuthenticationParameterAUTNMsg* autn, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t* lenPtr;
   uint32_t encoded = 0;
 
@@ -46,14 +44,14 @@ int AuthenticationParameterAUTNMsg::EncodeAuthenticationParameterAUTNMsg(
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, AUTN_MIN_LEN, len);
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER((unsigned char)iei, autn->iei);
+    CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
     *buffer = iei;
     encoded++;
   }
 
   lenPtr = (uint8_t*)(buffer + encoded);
   encoded++;
-  memcpy(buffer + encoded, autn->AUTN, AUTN_MAX_LEN);
+  memcpy(buffer + encoded, this->AUTN, AUTN_MAX_LEN);
   encoded = encoded + AUTN_MAX_LEN;
   *lenPtr = encoded - 1 - ((iei > 0) ? 1 : 0);
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationParameterRAND.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationParameterRAND.cpp
@@ -28,8 +28,7 @@ AuthenticationParameterRANDMsg::~AuthenticationParameterRANDMsg(){};
 
 // Decode AuthenticationParameterRAND IE
 int AuthenticationParameterRANDMsg::DecodeAuthenticationParameterRANDMsg(
-    AuthenticationParameterRANDMsg* rand, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t decoded = 0;
   /*** Not Implemented, Will be supported POST MVC ***/
   return (decoded);
@@ -37,20 +36,19 @@ int AuthenticationParameterRANDMsg::DecodeAuthenticationParameterRANDMsg(
 
 // Encode AuthenticationParameterRAND IE
 int AuthenticationParameterRANDMsg::EncodeAuthenticationParameterRANDMsg(
-    AuthenticationParameterRANDMsg* rand, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint32_t encoded = 0;
 
   // Checking IEI and pointer
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, RAND_MIN_LEN, len);
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER((unsigned char)iei, rand->iei);
+    CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
     *buffer = iei;
     encoded++;
   }
 
-  memcpy(buffer + encoded, rand->rand_val, RAND_MAX_LEN);
+  memcpy(buffer + encoded, this->rand_val, RAND_MAX_LEN);
   encoded = encoded + RAND_MAX_LEN;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationResponseParameter.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GAuthenticationResponseParameter.cpp
@@ -29,31 +29,26 @@ AuthenticationResponseParameterMsg::~AuthenticationResponseParameterMsg(){};
 
 // Decode AuthenticationResponseParameter IE
 int AuthenticationResponseParameterMsg::
-    DecodeAuthenticationResponseParameterMsg(
-        AuthenticationResponseParameterMsg* response_parameter, uint8_t iei,
-        uint8_t* buffer, uint32_t len) {
+    DecodeAuthenticationResponseParameterMsg(uint8_t iei, uint8_t* buffer,
+                                             uint32_t len) {
   uint32_t decoded = 0;
 
   if (iei > 0) {
     CHECK_IEI_DECODER(iei, *buffer);
-    response_parameter->iei = *(buffer + decoded);
-    decoded++;
+    this->iei = *(buffer + decoded++);
   }
-  response_parameter->length = *(buffer + decoded);
-  decoded++;
-  response_parameter->response_parameter[0] = 0;
-  for (int i = 0; i < (int)(response_parameter->length); i++) {
-    response_parameter->response_parameter[i] = *(buffer + decoded);
-    decoded++;
+  this->length = *(buffer + decoded++);
+  this->response_parameter[0] = 0;
+  for (int i = 0; i < (int)(this->length); i++) {
+    this->response_parameter[i] = *(buffer + decoded++);
   }
   return (decoded);
 };
 
 // Encode AuthenticationResponseParameter IE
 int AuthenticationResponseParameterMsg::
-    EncodeAuthenticationResponseParameterMsg(
-        AuthenticationResponseParameterMsg* response_parameter, uint8_t iei,
-        uint8_t* buffer, uint32_t len) {
+    EncodeAuthenticationResponseParameterMsg(uint8_t iei, uint8_t* buffer,
+                                             uint32_t len) {
   uint32_t encoded = 0;
 #ifdef HANDLE_POST_MVC
   // Checking IEI and pointer
@@ -61,7 +56,7 @@ int AuthenticationResponseParameterMsg::
       buffer, AUTHENTICATION_RESPONSE_PARAMETER_MIN_LEN, len);
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER((unsigned char)iei, response_parameter->iei);
+    CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
     *buffer = iei;
     encoded++;
   } else {
@@ -70,9 +65,9 @@ int AuthenticationResponseParameterMsg::
 
   lenPtr = (uint16_t*)(buffer + encoded);
   encoded++;
-  std::copy(response_parameter->response_parameter.begin(),
-            response_parameter->response_parameter.end(), buffer + encoded);
-  encoded = encoded + response_parameter->response_parameter.length();
+  std::copy(this->response_parameter.begin(), this->response_parameter.end(),
+            buffer + encoded);
+  encoded = encoded + this->response_parameter.length();
   *lenPtr = encoded - 1 - ((iei > 0) ? 1 : 0);
 #endif
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GEAPMessage.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GEAPMessage.cpp
@@ -27,8 +27,8 @@ EAPMessageMsg::EAPMessageMsg(){};
 EAPMessageMsg::~EAPMessageMsg(){};
 
 // Decode EAP Message
-int EAPMessageMsg::DecodeEAPMessageMsg(EAPMessageMsg* eap_message, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int EAPMessageMsg::DecodeEAPMessageMsg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   int decoded = 0;
   uint8_t ielen = 0;
 
@@ -42,22 +42,21 @@ int EAPMessageMsg::DecodeEAPMessageMsg(EAPMessageMsg* eap_message, uint8_t iei,
 };
 
 // Encode EAP Message
-int EAPMessageMsg::EncodeEAPMessageMsg(EAPMessageMsg* eap_message, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int EAPMessageMsg::EncodeEAPMessageMsg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   uint32_t encoded = 0;
 
   // Checking IEI and pointer
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, EAP_MIN_LENGTH, len);
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER(iei, (unsigned char)eap_message->iei);
-    *buffer = iei;
-    encoded++;
+    CHECK_IEI_ENCODER(iei, (unsigned char)this->iei);
+    *(buffer + encoded++) = iei;
   }
 
-  IES_ENCODE_U16(buffer, encoded, eap_message->len);
-  std::copy(eap_message->eap.begin(), eap_message->eap.end(), buffer + encoded);
-  encoded = encoded + eap_message->eap.length();
+  IES_ENCODE_U16(buffer, encoded, this->len);
+  std::copy(this->eap.begin(), this->eap.end(), buffer + encoded);
+  encoded = encoded + this->eap.length();
 
   return encoded;
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GExtendedProtocolDiscriminator.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GExtendedProtocolDiscriminator.cpp
@@ -20,25 +20,17 @@ ExtendedProtocolDiscriminatorMsg::~ExtendedProtocolDiscriminatorMsg(){};
 
 // Decode ExtendedProtocolDiscriminator IE
 int ExtendedProtocolDiscriminatorMsg::DecodeExtendedProtocolDiscriminatorMsg(
-    ExtendedProtocolDiscriminatorMsg* extended_protocol_discriminator,
     uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t decoded = 0;
-
-  extended_protocol_discriminator->extended_proto_discriminator =
-      *(buffer + decoded);
-  decoded++;
+  this->extended_proto_discriminator = *(buffer + decoded++);
   return (decoded);
 };
 
 // Encode ExtendedProtocolDiscriminator IE
 int ExtendedProtocolDiscriminatorMsg::EncodeExtendedProtocolDiscriminatorMsg(
-    ExtendedProtocolDiscriminatorMsg* extended_protocol_discriminator,
     uint8_t iei, uint8_t* buffer, uint32_t len) {
   int encoded = 0;
-
-  *(buffer + encoded) =
-      extended_protocol_discriminator->extended_proto_discriminator;
-  encoded++;
+  *(buffer + encoded++) = this->extended_proto_discriminator;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GGprsTimer2.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GGprsTimer2.cpp
@@ -26,35 +26,26 @@ namespace magma5g {
 GPRSTimer2Msg::GPRSTimer2Msg(){};
 GPRSTimer2Msg::~GPRSTimer2Msg(){};
 
-int GPRSTimer2Msg::DecodeGPRSTimer2Msg(GPRSTimer2Msg* gprstimer, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int GPRSTimer2Msg::DecodeGPRSTimer2Msg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   int decoded = 0;
   if (iei > 0) {
-    gprstimer->iei = *buffer;
-    decoded++;
-
-    gprstimer->len = *(buffer + decoded);
-    decoded++;
-
-    gprstimer->timervalue = *(buffer + decoded);
-    decoded++;
+    this->iei = *(buffer + decoded++);
+    this->len = *(buffer + decoded++);
+    this->timervalue = *(buffer + decoded++);
   }
 
   return decoded;
 };
 
-int GPRSTimer2Msg::EncodeGPRSTimer2Msg(GPRSTimer2Msg* gprstimer, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int GPRSTimer2Msg::EncodeGPRSTimer2Msg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   uint32_t encoded = 0;
 
   if (iei > 0) {
-    *buffer = iei;
-    encoded++;
-
-    *(buffer + encoded) = gprstimer->len;
-    encoded++;
-    *(buffer + encoded) = gprstimer->timervalue;
-    encoded++;
+    *(buffer + encoded++) = iei;
+    *(buffer + encoded++) = this->len;
+    *(buffer + encoded++) = this->timervalue;
   }
 
   return encoded;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GGprsTimer3.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GGprsTimer3.cpp
@@ -26,8 +26,8 @@ namespace magma5g {
 GPRSTimer3Msg::GPRSTimer3Msg(){};
 GPRSTimer3Msg::~GPRSTimer3Msg(){};
 
-int GPRSTimer3Msg::DecodeGPRSTimer3Msg(GPRSTimer3Msg* gprstimer, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int GPRSTimer3Msg::DecodeGPRSTimer3Msg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   int decoded = 0;
 
   if (iei > 0) {
@@ -35,14 +35,14 @@ int GPRSTimer3Msg::DecodeGPRSTimer3Msg(GPRSTimer3Msg* gprstimer, uint8_t iei,
     decoded++;
   }
 
-  gprstimer->unit = (*(buffer + decoded) >> 5) & 0x7;
-  gprstimer->timervalue = *(buffer + decoded) & 0x1f;
+  this->unit = (*(buffer + decoded) >> 5) & 0x7;
+  this->timervalue = *(buffer + decoded) & 0x1f;
   decoded++;
   return decoded;
 };
 
-int GPRSTimer3Msg::EncodeGPRSTimer3Msg(GPRSTimer3Msg* gprstimer, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int GPRSTimer3Msg::EncodeGPRSTimer3Msg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   uint32_t encoded = 0;
 
   /*
@@ -51,15 +51,12 @@ int GPRSTimer3Msg::EncodeGPRSTimer3Msg(GPRSTimer3Msg* gprstimer, uint8_t iei,
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, GPRS_TIMER3_MINIMUM_LENGTH, len);
 
   if (iei > 0) {
-    *buffer = iei;
-    encoded++;
+    *(buffer + encoded++) = iei;
   }
 
-  *(buffer + encoded) = gprstimer->len;
-  encoded++;
-  *(buffer + encoded) =
-      0x00 | ((gprstimer->unit & 0x7) << 5) | (gprstimer->timervalue & 0x1f);
-  encoded++;
+  *(buffer + encoded++) = this->len;
+  *(buffer + encoded++) =
+      0x00 | ((this->unit & 0x7) << 5) | (this->timervalue & 0x1f);
   return encoded;
 };
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIMEISVRequest.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIMEISVRequest.cpp
@@ -26,8 +26,7 @@ namespace magma5g {
 ImeisvRequestMsg::ImeisvRequestMsg(){};
 ImeisvRequestMsg::~ImeisvRequestMsg(){};
 
-int ImeisvRequestMsg::DecodeImeisvRequestMsg(ImeisvRequestMsg* imeisv_request,
-                                             uint8_t iei, uint8_t* buffer,
+int ImeisvRequestMsg::DecodeImeisvRequestMsg(uint8_t iei, uint8_t* buffer,
                                              uint32_t len) {
   int decoded = 0;
 
@@ -38,20 +37,18 @@ int ImeisvRequestMsg::DecodeImeisvRequestMsg(ImeisvRequestMsg* imeisv_request,
     CHECK_IEI_DECODER((unsigned char)(*buffer & 0xf0), iei);
   }
 
-  imeisv_request->spare = (*(buffer + decoded) >> 7) & 0x1;
-  imeisv_request->imeisv_request = (*(buffer + decoded) >> 4) & 0x7;
+  this->spare = (*(buffer + decoded) >> 7) & 0x1;
+  this->imeisv_request = (*(buffer + decoded) >> 4) & 0x7;
   decoded++;
   return decoded;
 };
 
-int ImeisvRequestMsg::EncodeImeisvRequestMsg(ImeisvRequestMsg* imeisv_request,
-                                             uint8_t iei, uint8_t* buffer,
+int ImeisvRequestMsg::EncodeImeisvRequestMsg(uint8_t iei, uint8_t* buffer,
                                              uint32_t len) {
   uint32_t encoded = 0;
 
-  *(buffer + encoded) = 0xe0 | (imeisv_request->spare & 0x1) << 3 |
-                        (imeisv_request->imeisv_request & 0x7);
-  encoded++;
+  *(buffer + encoded++) =
+      0xe0 | (this->spare & 0x1) << 3 | (this->imeisv_request & 0x7);
 
   return encoded;
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIntegrityProtMaxDataRate.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GIntegrityProtMaxDataRate.cpp
@@ -20,27 +20,21 @@ IntegrityProtMaxDataRateMsg::~IntegrityProtMaxDataRateMsg(){};
 
 // Decode IntegrityProtMaxDataRate IE
 int IntegrityProtMaxDataRateMsg::DecodeIntegrityProtMaxDataRateMsg(
-    IntegrityProtMaxDataRateMsg* integrity_prot_max_data_rate, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t decoded = 0;
 
-  integrity_prot_max_data_rate->max_uplink = *(buffer + decoded);
-  decoded++;
-  integrity_prot_max_data_rate->max_downlink = *(buffer + decoded);
-  decoded++;
+  this->max_uplink = *(buffer + decoded++);
+  this->max_downlink = *(buffer + decoded++);
   return (decoded);
 };
 
 // Encode IntegrityProtMaxDataRate IE
 int IntegrityProtMaxDataRateMsg::EncodeIntegrityProtMaxDataRateMsg(
-    IntegrityProtMaxDataRateMsg* integrity_prot_max_data_rate, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   int encoded = 0;
 
-  *(buffer + encoded) = integrity_prot_max_data_rate->max_uplink;
-  encoded++;
-  *(buffer + encoded) = integrity_prot_max_data_rate->max_downlink;
-  encoded++;
+  *(buffer + encoded++) = this->max_uplink;
+  *(buffer + encoded++) = this->max_downlink;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMMCause.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMMCause.cpp
@@ -26,34 +26,30 @@ M5GMMCauseMsg::M5GMMCauseMsg(){};
 M5GMMCauseMsg::~M5GMMCauseMsg(){};
 
 // Decode 5GMMCause IE
-int M5GMMCauseMsg::DecodeM5GMMCauseMsg(M5GMMCauseMsg* m5gmm_cause, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int M5GMMCauseMsg::DecodeM5GMMCauseMsg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   uint8_t decoded = 0;
 
   if (iei > 0) {
-    m5gmm_cause->iei = *(buffer + decoded);
-    CHECK_IEI_DECODER((unsigned char)iei, m5gmm_cause->iei);
-    decoded++;
+    this->iei = *(buffer + decoded++);
+    CHECK_IEI_DECODER((unsigned char)iei, this->iei);
   }
 
-  m5gmm_cause->m5gmm_cause = *(buffer + decoded);
-  decoded++;
+  this->m5gmm_cause = *(buffer + decoded++);
   return (decoded);
 };
 
 // Encode 5GMMCause IE
-int M5GMMCauseMsg::EncodeM5GMMCauseMsg(M5GMMCauseMsg* m5gmm_cause, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int M5GMMCauseMsg::EncodeM5GMMCauseMsg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   int encoded = 0;
 
   if (iei > 0) {
-    *(buffer + encoded) = m5gmm_cause->iei;
-    CHECK_IEI_ENCODER((unsigned char)iei, m5gmm_cause->iei);
-    encoded++;
+    *(buffer + encoded++) = this->iei;
+    CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
   }
 
-  *(buffer + encoded) = m5gmm_cause->m5gmm_cause;
-  encoded++;
+  *(buffer + encoded++) = this->m5gmm_cause;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMaxNumOfSupportedPacketFilters.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMaxNumOfSupportedPacketFilters.cpp
@@ -21,36 +21,25 @@ M5GMaxNumOfSupportedPacketFilters::M5GMaxNumOfSupportedPacketFilters() {}
 M5GMaxNumOfSupportedPacketFilters::~M5GMaxNumOfSupportedPacketFilters() {}
 
 int M5GMaxNumOfSupportedPacketFilters::EncodeMaxNumOfSupportedPacketFilters(
-    M5GMaxNumOfSupportedPacketFilters* maxNumOfSuppPktFilters, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   int encoded = 0;
-  if (maxNumOfSuppPktFilters->iei) {
-    *(buffer + encoded) = maxNumOfSuppPktFilters->iei;
-    encoded++;
-    *(buffer + encoded) =
-        (uint8_t)(maxNumOfSuppPktFilters->maxNumOfSuppPktFilters & 0xFF);
-    encoded++;
-    *(buffer + encoded) =
-        (uint8_t)((maxNumOfSuppPktFilters->maxNumOfSuppPktFilters & 0xE0));
-    encoded++;
+  if (this->iei) {
+    *(buffer + encoded++) = this->iei;
+    *(buffer + encoded++) = (uint8_t)(this->maxNumOfSuppPktFilters & 0xFF);
+    *(buffer + encoded++) = (uint8_t)((this->maxNumOfSuppPktFilters & 0xE0));
   }
 
   return encoded;
 }
 
 int M5GMaxNumOfSupportedPacketFilters::DecodeMaxNumOfSupportedPacketFilters(
-    M5GMaxNumOfSupportedPacketFilters* maxNumOfSuppPktFilters, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   int decoded = 0;
   if (iei > 0) {
-    maxNumOfSuppPktFilters->iei = *buffer;
-    decoded++;
+    this->iei = *(buffer + decoded++);
 
-    maxNumOfSuppPktFilters->maxNumOfSuppPktFilters = (*(buffer + decoded) << 8);
-    decoded++;
-    maxNumOfSuppPktFilters->maxNumOfSuppPktFilters |=
-        (*(buffer + decoded) & 0xE0);
-    decoded++;
+    this->maxNumOfSuppPktFilters = (*(buffer + decoded++) << 8);
+    this->maxNumOfSuppPktFilters |= (*(buffer + decoded++) & 0xE0);
   }
 
   return decoded;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMessageType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMessageType.cpp
@@ -20,24 +20,18 @@ MessageTypeMsg::MessageTypeMsg(){};
 MessageTypeMsg::~MessageTypeMsg(){};
 
 // Decode MessageType IE
-int MessageTypeMsg::DecodeMessageTypeMsg(MessageTypeMsg* message_type,
-                                         uint8_t iei, uint8_t* buffer,
+int MessageTypeMsg::DecodeMessageTypeMsg(uint8_t iei, uint8_t* buffer,
                                          uint32_t len) {
   uint8_t decoded = 0;
-
-  message_type->msg_type = *(buffer + decoded);
-  decoded++;
+  this->msg_type = *(buffer + decoded++);
   return (decoded);
 };
 
 // Encode MessageType IE
-int MessageTypeMsg::EncodeMessageTypeMsg(MessageTypeMsg* message_type,
-                                         uint8_t iei, uint8_t* buffer,
+int MessageTypeMsg::EncodeMessageTypeMsg(uint8_t iei, uint8_t* buffer,
                                          uint32_t len) {
   uint8_t encoded = 0;
-
-  *(buffer + encoded) = message_type->msg_type;
-  encoded++;
+  *(buffer + encoded++) = this->msg_type;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNASSecurityAlgorithms.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNASSecurityAlgorithms.cpp
@@ -26,9 +26,9 @@ NASSecurityAlgorithmsMsg::NASSecurityAlgorithmsMsg(){};
 NASSecurityAlgorithmsMsg::~NASSecurityAlgorithmsMsg(){};
 
 // Decode NASSecurityAlgorithms IE
-int NASSecurityAlgorithmsMsg::DecodeNASSecurityAlgorithmsMsg(
-    NASSecurityAlgorithmsMsg* nas_sec_algorithms, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int NASSecurityAlgorithmsMsg::DecodeNASSecurityAlgorithmsMsg(uint8_t iei,
+                                                             uint8_t* buffer,
+                                                             uint32_t len) {
   uint8_t decoded = 0;
 
   // Checking IEI
@@ -37,16 +37,16 @@ int NASSecurityAlgorithmsMsg::DecodeNASSecurityAlgorithmsMsg(
     decoded++;
   }
 
-  nas_sec_algorithms->tca = (*(buffer + decoded) >> 4) & 0x7;
-  nas_sec_algorithms->tia = *(buffer + decoded) & 0x7;
+  this->tca = (*(buffer + decoded) >> 4) & 0x7;
+  this->tia = *(buffer + decoded) & 0x7;
   decoded++;
   return (decoded);
 };
 
 // Encode NASSecurityAlgorithms IE
-int NASSecurityAlgorithmsMsg::EncodeNASSecurityAlgorithmsMsg(
-    NASSecurityAlgorithmsMsg* nas_sec_algorithms, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int NASSecurityAlgorithmsMsg::EncodeNASSecurityAlgorithmsMsg(uint8_t iei,
+                                                             uint8_t* buffer,
+                                                             uint32_t len) {
   int encoded = 0;
 
   // Checking IEI and pointer
@@ -54,14 +54,11 @@ int NASSecurityAlgorithmsMsg::EncodeNASSecurityAlgorithmsMsg(
       buffer, NAS_SECURITY_ALGORITHMS_MINIMUM_LENGTH, len);
 
   if (iei > 0) {
-    *buffer = iei;
-    encoded++;
+    *(buffer + encoded++) = iei;
   }
 
-  *(buffer + encoded) = 0x00 | ((nas_sec_algorithms->tca & 0x7) << 4) |
-                        (nas_sec_algorithms->tia & 0x7);
+  *(buffer + encoded++) = 0x00 | ((this->tca & 0x7) << 4) | (this->tia & 0x7);
 
-  encoded++;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNSSAI.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNSSAI.cpp
@@ -25,54 +25,53 @@ NSSAIMsg::NSSAIMsg(){};
 
 NSSAIMsg::~NSSAIMsg(){};
 
-int NSSAIMsg::EncodeNSSAIMsg(NSSAIMsg* NSSAI, uint8_t iei, uint8_t* buffer,
-                             uint32_t len) {
+int NSSAIMsg::EncodeNSSAIMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t encoded = 0;
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER(iei, (unsigned char)NSSAI->iei);
+    CHECK_IEI_ENCODER(iei, (unsigned char)this->iei);
     ENCODE_U8(buffer, iei, encoded);
   }
 
-  ENCODE_U8(buffer + encoded, NSSAI->len, encoded);
+  ENCODE_U8(buffer + encoded, this->len, encoded);
 
-  switch (NSSAI->len) {
+  switch (this->len) {
     case 0b00000001:  // SST
-      ENCODE_U8(buffer + encoded, NSSAI->sst, encoded);
+      ENCODE_U8(buffer + encoded, this->sst, encoded);
       break;
     case 0b00000010:  // SST and mapped HPLMN SST
-      ENCODE_U8(buffer + encoded, NSSAI->sst, encoded);
+      ENCODE_U8(buffer + encoded, this->sst, encoded);
 
-      ENCODE_U8(buffer + encoded, NSSAI->hplmn_sst, encoded);
+      ENCODE_U8(buffer + encoded, this->hplmn_sst, encoded);
       break;
     case 0b00000100:  // SST and SD
-      ENCODE_U8(buffer + encoded, NSSAI->sst, encoded);
+      ENCODE_U8(buffer + encoded, this->sst, encoded);
 
-      ENCODE_U8(buffer + encoded, NSSAI->sd[0], encoded);
-      ENCODE_U8(buffer + encoded, NSSAI->sd[1], encoded);
-      ENCODE_U8(buffer + encoded, NSSAI->sd[2], encoded);
+      ENCODE_U8(buffer + encoded, this->sd[0], encoded);
+      ENCODE_U8(buffer + encoded, this->sd[1], encoded);
+      ENCODE_U8(buffer + encoded, this->sd[2], encoded);
       break;
     case 0b00000101:  // SST, SD and mapped HPLMN SST
-      ENCODE_U8(buffer + encoded, NSSAI->sst, encoded);
+      ENCODE_U8(buffer + encoded, this->sst, encoded);
 
-      ENCODE_U8(buffer + encoded, NSSAI->sd[0], encoded);
-      ENCODE_U8(buffer + encoded, NSSAI->sd[1], encoded);
-      ENCODE_U8(buffer + encoded, NSSAI->sd[2], encoded);
+      ENCODE_U8(buffer + encoded, this->sd[0], encoded);
+      ENCODE_U8(buffer + encoded, this->sd[1], encoded);
+      ENCODE_U8(buffer + encoded, this->sd[2], encoded);
 
-      ENCODE_U8(buffer + encoded, NSSAI->hplmn_sst, encoded);
+      ENCODE_U8(buffer + encoded, this->hplmn_sst, encoded);
       break;
     case 0b00001000:  // SST, SD, mapped HPLMN SST and mapped HPLMN SD
-      ENCODE_U8(buffer + encoded, NSSAI->sst, encoded);
+      ENCODE_U8(buffer + encoded, this->sst, encoded);
 
-      ENCODE_U8(buffer + encoded, NSSAI->sd[0], encoded);
-      ENCODE_U8(buffer + encoded, NSSAI->sd[1], encoded);
-      ENCODE_U8(buffer + encoded, NSSAI->sd[2], encoded);
+      ENCODE_U8(buffer + encoded, this->sd[0], encoded);
+      ENCODE_U8(buffer + encoded, this->sd[1], encoded);
+      ENCODE_U8(buffer + encoded, this->sd[2], encoded);
 
-      ENCODE_U8(buffer + encoded, NSSAI->hplmn_sst, encoded);
+      ENCODE_U8(buffer + encoded, this->hplmn_sst, encoded);
 
-      ENCODE_U8(buffer + encoded, NSSAI->hplmn_sd[0], encoded);
-      ENCODE_U8(buffer + encoded, NSSAI->hplmn_sd[1], encoded);
-      ENCODE_U8(buffer + encoded, NSSAI->hplmn_sd[2], encoded);
+      ENCODE_U8(buffer + encoded, this->hplmn_sd[0], encoded);
+      ENCODE_U8(buffer + encoded, this->hplmn_sd[1], encoded);
+      ENCODE_U8(buffer + encoded, this->hplmn_sd[2], encoded);
       break;
     default:  // All other values are reserved
       break;
@@ -80,54 +79,53 @@ int NSSAIMsg::EncodeNSSAIMsg(NSSAIMsg* NSSAI, uint8_t iei, uint8_t* buffer,
   return (encoded);
 };
 
-int NSSAIMsg::DecodeNSSAIMsg(NSSAIMsg* NSSAI, uint8_t iei, uint8_t* buffer,
-                             uint32_t len) {
+int NSSAIMsg::DecodeNSSAIMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   int decoded = 0;
 
   if (iei > 0) {
     CHECK_IEI_DECODER(iei, (unsigned char)*buffer);
-    NSSAI->iei = *(buffer + decoded);
+    this->iei = *(buffer + decoded);
     decoded++;
   }
-  DECODE_U8(buffer + decoded, NSSAI->len, decoded);
-  CHECK_LENGTH_DECODER(len - decoded, NSSAI->len);
+  DECODE_U8(buffer + decoded, this->len, decoded);
+  CHECK_LENGTH_DECODER(len - decoded, this->len);
 
-  switch (NSSAI->len) {
+  switch (this->len) {
     case 0b00000001:  // SST
-      DECODE_U8(buffer + decoded, NSSAI->sst, decoded);
+      DECODE_U8(buffer + decoded, this->sst, decoded);
       break;
     case 0b00000010:  // SST and mapped HPLMN SST
-      DECODE_U8(buffer + decoded, NSSAI->sst, decoded);
-      DECODE_U8(buffer + decoded, NSSAI->hplmn_sst, decoded);
+      DECODE_U8(buffer + decoded, this->sst, decoded);
+      DECODE_U8(buffer + decoded, this->hplmn_sst, decoded);
       break;
     case 0b00000100:  // SST and SD
-      DECODE_U8(buffer + decoded, NSSAI->sst, decoded);
+      DECODE_U8(buffer + decoded, this->sst, decoded);
 
-      DECODE_U8(buffer + decoded, NSSAI->sd[0], decoded);
-      DECODE_U8(buffer + decoded, NSSAI->sd[1], decoded);
-      DECODE_U8(buffer + decoded, NSSAI->sd[2], decoded);
+      DECODE_U8(buffer + decoded, this->sd[0], decoded);
+      DECODE_U8(buffer + decoded, this->sd[1], decoded);
+      DECODE_U8(buffer + decoded, this->sd[2], decoded);
       break;
     case 0b00000101:  // SST, SD and mapped HPLMN SST
-      DECODE_U8(buffer + decoded, NSSAI->sst, decoded);
+      DECODE_U8(buffer + decoded, this->sst, decoded);
 
-      DECODE_U8(buffer + decoded, NSSAI->sd[0], decoded);
-      DECODE_U8(buffer + decoded, NSSAI->sd[1], decoded);
-      DECODE_U8(buffer + decoded, NSSAI->sd[2], decoded);
+      DECODE_U8(buffer + decoded, this->sd[0], decoded);
+      DECODE_U8(buffer + decoded, this->sd[1], decoded);
+      DECODE_U8(buffer + decoded, this->sd[2], decoded);
 
-      DECODE_U8(buffer + decoded, NSSAI->hplmn_sst, decoded);
+      DECODE_U8(buffer + decoded, this->hplmn_sst, decoded);
       break;
     case 0b00001000:  // SST, SD, mapped HPLMN SST and mapped HPLMN SD
-      DECODE_U8(buffer + decoded, NSSAI->sst, decoded);
+      DECODE_U8(buffer + decoded, this->sst, decoded);
 
-      DECODE_U8(buffer + decoded, NSSAI->sd[0], decoded);
-      DECODE_U8(buffer + decoded, NSSAI->sd[1], decoded);
-      DECODE_U8(buffer + decoded, NSSAI->sd[2], decoded);
+      DECODE_U8(buffer + decoded, this->sd[0], decoded);
+      DECODE_U8(buffer + decoded, this->sd[1], decoded);
+      DECODE_U8(buffer + decoded, this->sd[2], decoded);
 
-      DECODE_U8(buffer + decoded, NSSAI->hplmn_sst, decoded);
+      DECODE_U8(buffer + decoded, this->hplmn_sst, decoded);
 
-      DECODE_U8(buffer + decoded, NSSAI->hplmn_sd[0], decoded);
-      DECODE_U8(buffer + decoded, NSSAI->hplmn_sd[1], decoded);
-      DECODE_U8(buffer + decoded, NSSAI->hplmn_sd[2], decoded);
+      DECODE_U8(buffer + decoded, this->hplmn_sd[0], decoded);
+      DECODE_U8(buffer + decoded, this->hplmn_sd[1], decoded);
+      DECODE_U8(buffer + decoded, this->hplmn_sd[2], decoded);
       break;
     default:  // All other values are reserved
       break;
@@ -140,19 +138,18 @@ NSSAIMsgList::NSSAIMsgList() {}
 
 NSSAIMsgList::~NSSAIMsgList() {}
 
-int NSSAIMsgList::EncodeNSSAIMsgList(NSSAIMsgList* NSSAI_list, uint8_t iei,
-                                     uint8_t* buffer, uint32_t len) {
+int NSSAIMsgList::EncodeNSSAIMsgList(uint8_t iei, uint8_t* buffer,
+                                     uint32_t len) {
   uint8_t encoded = 0;
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER(iei, (unsigned char)NSSAI_list->iei);
+    CHECK_IEI_ENCODER(iei, (unsigned char)this->iei);
     ENCODE_U8(buffer, iei, encoded);
   }
 
-  ENCODE_U8(buffer + encoded, NSSAI_list->len, encoded);
+  ENCODE_U8(buffer + encoded, this->len, encoded);
 
-  encoded +=
-      nssai.EncodeNSSAIMsg(&nssai, 0, (buffer + encoded), (len - encoded));
+  encoded += nssai.EncodeNSSAIMsg(0, (buffer + encoded), (len - encoded));
 
   return (encoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNasKeySetIdentifier.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNasKeySetIdentifier.cpp
@@ -27,9 +27,9 @@ NASKeySetIdentifierMsg::NASKeySetIdentifierMsg(){};
 NASKeySetIdentifierMsg::~NASKeySetIdentifierMsg(){};
 
 // Decode NASKeySetIdentifier IE
-int NASKeySetIdentifierMsg::DecodeNASKeySetIdentifierMsg(
-    NASKeySetIdentifierMsg* nas_key_set_identifier, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+int NASKeySetIdentifierMsg::DecodeNASKeySetIdentifierMsg(uint8_t iei,
+                                                         uint8_t* buffer,
+                                                         uint32_t len) {
   int decoded = 0;
 
   // Checking IEI and pointer
@@ -40,17 +40,15 @@ int NASKeySetIdentifierMsg::DecodeNASKeySetIdentifierMsg(
     CHECK_IEI_DECODER((unsigned char)(*buffer & 0xf0), iei);
   }
 
-  nas_key_set_identifier->tsc = (*(buffer + decoded) >> 7) & 0x1;
-  nas_key_set_identifier->nas_key_set_identifier =
-      (*(buffer + decoded) >> 4) & 0x7;
-  decoded++;
+  this->tsc = (*(buffer + decoded) >> 7) & 0x1;
+  this->nas_key_set_identifier = (*(buffer + decoded++) >> 4) & 0x7;
   return decoded;
 };
 
 // Encode NASKeySetIdentifier IE
-int NASKeySetIdentifierMsg::EncodeNASKeySetIdentifierMsg(
-    NASKeySetIdentifierMsg* nas_key_set_identifier, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+int NASKeySetIdentifierMsg::EncodeNASKeySetIdentifierMsg(uint8_t iei,
+                                                         uint8_t* buffer,
+                                                         uint32_t len) {
   uint32_t encoded = 0;
 
   // Checking IEI and pointer
@@ -58,14 +56,12 @@ int NASKeySetIdentifierMsg::EncodeNASKeySetIdentifierMsg(
                                        NAS_KEY_SET_IDENTIFIER_MIN_LENGTH, len);
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER((unsigned char)iei, nas_key_set_identifier->iei);
-    *buffer = iei;
-    encoded++;
+    CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
+    *(buffer + encoded++) = iei;
   }
 
-  *(buffer + encoded) = 0x00 | (nas_key_set_identifier->tsc & 0x1) << 3 |
-                        (nas_key_set_identifier->nas_key_set_identifier & 0x7);
-  encoded++;
+  *(buffer + encoded++) =
+      0x00 | (this->tsc & 0x1) << 3 | (this->nas_key_set_identifier & 0x7);
 
   return encoded;
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNetworkFeatureSupport.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNetworkFeatureSupport.cpp
@@ -28,37 +28,35 @@ namespace magma5g {
 NetworkFeatureSupportMsg::NetworkFeatureSupportMsg() {}
 NetworkFeatureSupportMsg::~NetworkFeatureSupportMsg() {}
 
-int NetworkFeatureSupportMsg::DecodeNetworkFeatureSupportMsg(
-    NetworkFeatureSupportMsg* networkfeature, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int NetworkFeatureSupportMsg::DecodeNetworkFeatureSupportMsg(uint8_t iei,
+                                                             uint8_t* buffer,
+                                                             uint32_t len) {
   int decoded = 0;
 
   if (iei > 0) {
     CHECK_IEI_DECODER(iei, *buffer);
-    networkfeature->iei = *buffer;
-    decoded++;
+    this->iei = *(buffer + decoded++);
   }
-  networkfeature->len = *(buffer + decoded);
+  this->len = *(buffer + decoded++);
+
+  this->MPSI = (*(buffer + decoded) >> 7) & 0x01;
+  this->IWK_N26 = (*(buffer + decoded) >> 6) & 0x01;
+  this->EMF = (*(buffer + decoded) >> 4) & 0x03;
+  this->EMC = (*(buffer + decoded) >> 2) & 0x03;
+  this->IMS_VoPS_N3GPP = (*(buffer + decoded) >> 1) & 0x01;
+  this->IMS_VoPS_3GPP = *(buffer + decoded) & 0x01;
   decoded++;
 
-  networkfeature->MPSI = (*(buffer + decoded) >> 7) & 0x01;
-  networkfeature->IWK_N26 = (*(buffer + decoded) >> 6) & 0x01;
-  networkfeature->EMF = (*(buffer + decoded) >> 4) & 0x03;
-  networkfeature->EMC = (*(buffer + decoded) >> 2) & 0x03;
-  networkfeature->IMS_VoPS_N3GPP = (*(buffer + decoded) >> 1) & 0x01;
-  networkfeature->IMS_VoPS_3GPP = *(buffer + decoded) & 0x01;
-  decoded++;
-
-  networkfeature->MCSI = (*(buffer + decoded) >> 1) & 0x01;
-  networkfeature->EMCN3 = (*(buffer + decoded)) & 0x01;
+  this->MCSI = (*(buffer + decoded) >> 1) & 0x01;
+  this->EMCN3 = (*(buffer + decoded)) & 0x01;
   decoded++;
 
   return decoded;
 }
 
-int NetworkFeatureSupportMsg::EncodeNetworkFeatureSupportMsg(
-    NetworkFeatureSupportMsg* networkfeature, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int NetworkFeatureSupportMsg::EncodeNetworkFeatureSupportMsg(uint8_t iei,
+                                                             uint8_t* buffer,
+                                                             uint32_t len) {
   uint32_t encoded = 0;
 
   // Checking IEI and pointer
@@ -66,23 +64,17 @@ int NetworkFeatureSupportMsg::EncodeNetworkFeatureSupportMsg(
                                        len);
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER(iei, (unsigned char)networkfeature->iei);
-    *buffer = iei;
-    encoded++;
+    CHECK_IEI_ENCODER(iei, (unsigned char)this->iei);
+    *(buffer + encoded++) = iei;
   }
 
-  *(buffer + encoded) = networkfeature->len;
-  encoded++;
-  *(buffer + encoded) = 0x00 | ((networkfeature->MPSI & 0x01) << 7) |
-                        ((networkfeature->IWK_N26 & 0x01) << 6) |
-                        ((networkfeature->EMF & 0x03) << 4) |
-                        ((networkfeature->EMC & 0x03) << 2) |
-                        ((networkfeature->IMS_VoPS_N3GPP & 0x01) << 1) |
-                        (networkfeature->IMS_VoPS_3GPP & 0x01);
-  encoded++;
-  *(buffer + encoded) = 0x00 | ((networkfeature->MCSI & 0x01) << 1) |
-                        (networkfeature->EMCN3 & 0x01);
-  encoded++;
+  *(buffer + encoded++) = this->len;
+  *(buffer + encoded++) =
+      0x00 | ((this->MPSI & 0x01) << 7) | ((this->IWK_N26 & 0x01) << 6) |
+      ((this->EMF & 0x03) << 4) | ((this->EMC & 0x03) << 2) |
+      ((this->IMS_VoPS_N3GPP & 0x01) << 1) | (this->IMS_VoPS_3GPP & 0x01);
+  *(buffer + encoded++) =
+      0x00 | ((this->MCSI & 0x01) << 1) | (this->EMCN3 & 0x01);
   return encoded;
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUAddress.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUAddress.cpp
@@ -29,44 +29,44 @@ PDUAddressMsg::PDUAddressMsg(){};
 PDUAddressMsg::~PDUAddressMsg(){};
 
 // Decode PDUAddress IE
-int PDUAddressMsg::DecodePDUAddressMsg(PDUAddressMsg* pdu_address, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int PDUAddressMsg::DecodePDUAddressMsg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   uint8_t decoded = 0;
   // CHECKING IEI
   if (iei > 0) {
-    IES_DECODE_U8(buffer, decoded, pdu_address->iei);
-    CHECK_IEI_DECODER(iei, (unsigned char)pdu_address->iei);
+    IES_DECODE_U8(buffer, decoded, this->iei);
+    CHECK_IEI_DECODER(iei, (unsigned char)this->iei);
   }
 
-  IES_DECODE_U8(buffer, decoded, pdu_address->length);
+  IES_DECODE_U8(buffer, decoded, this->length);
 
-  pdu_address->type_val = *(buffer + decoded) && 0x07;
-  memset(pdu_address->address_info, 0, sizeof(pdu_address->address_info));
+  this->type_val = *(buffer + decoded) && 0x07;
+  memset(this->address_info, 0, sizeof(this->address_info));
   decoded++;
-  memcpy(buffer + decoded, pdu_address->address_info, pdu_address->length - 1);
-  decoded += pdu_address->length - 1;
+  memcpy(buffer + decoded, this->address_info, this->length - 1);
+  decoded += this->length - 1;
 
   return (decoded);
 };
 
 // Encode PDUAddress IE
-int PDUAddressMsg::EncodePDUAddressMsg(PDUAddressMsg* pdu_address, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int PDUAddressMsg::EncodePDUAddressMsg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   int encoded = 0;
 
   // CHECKING IEI
   if (iei > 0) {
-    pdu_address->iei = iei;
-    CHECK_IEI_DECODER(iei, (unsigned char)pdu_address->iei);
+    this->iei = iei;
+    CHECK_IEI_DECODER(iei, (unsigned char)this->iei);
     *(buffer + encoded) = iei;
     encoded++;
   }
 
   // Sizeof type_val + address length
-  IES_ENCODE_U8(buffer, encoded, sizeof(uint8_t) + pdu_address->length);
-  IES_ENCODE_U8(buffer, encoded, (0x00 | (pdu_address->type_val & 0x07)));
-  memcpy(buffer + encoded, pdu_address->address_info, pdu_address->length);
-  encoded = encoded + pdu_address->length;
+  IES_ENCODE_U8(buffer, encoded, sizeof(uint8_t) + this->length);
+  IES_ENCODE_U8(buffer, encoded, (0x00 | (this->type_val & 0x07)));
+  memcpy(buffer + encoded, this->address_info, this->length);
+  encoded = encoded + this->length;
 
   return (encoded);
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionIdentity.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionIdentity.cpp
@@ -9,6 +9,7 @@
    limitations under the License.
  */
 
+#include <cstring>
 #include <sstream>
 #include <cstdint>
 #ifdef __cplusplus
@@ -23,31 +24,33 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5gNasMessage.h"
 
 namespace magma5g {
-PDUSessionIdentityMsg::PDUSessionIdentityMsg(){};
+PDUSessionIdentityMsg::PDUSessionIdentityMsg() {
+  memset(this, 0, sizeof(PDUSessionIdentityMsg));
+};
 PDUSessionIdentityMsg::~PDUSessionIdentityMsg(){};
 
 // Decode PDUSessionIdentity IE
-int PDUSessionIdentityMsg::DecodePDUSessionIdentityMsg(
-    PDUSessionIdentityMsg* pdu_session_identity, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int PDUSessionIdentityMsg::DecodePDUSessionIdentityMsg(uint8_t iei,
+                                                       uint8_t* buffer,
+                                                       uint32_t len) {
   uint8_t decoded = 0;
 
   if (iei > 0) {
-    pdu_session_identity->iei = *(buffer + decoded);
-    CHECK_IEI_DECODER((unsigned char)iei, pdu_session_identity->iei);
+    this->iei = *(buffer + decoded);
+    CHECK_IEI_DECODER((unsigned char)iei, this->iei);
     decoded++;
   }
 
-  pdu_session_identity->pdu_session_id = *(buffer + decoded);
+  this->pdu_session_id = *(buffer + decoded);
   decoded++;
 
   return (decoded);
 };
 
 // Encode PDUSessionIdentity IE
-int PDUSessionIdentityMsg::EncodePDUSessionIdentityMsg(
-    PDUSessionIdentityMsg* pdu_session_identity, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int PDUSessionIdentityMsg::EncodePDUSessionIdentityMsg(uint8_t iei,
+                                                       uint8_t* buffer,
+                                                       uint32_t len) {
   int encoded = 0;
 
   // Checking IEI and pointer
@@ -58,7 +61,7 @@ int PDUSessionIdentityMsg::EncodePDUSessionIdentityMsg(
     encoded++;
   }
 
-  *(buffer + encoded) = pdu_session_identity->pdu_session_id;
+  *(buffer + encoded) = this->pdu_session_id;
   encoded++;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionReActivationResult.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionReActivationResult.cpp
@@ -21,44 +21,27 @@ M5GPDUSessionReActivationResult::M5GPDUSessionReActivationResult(){};
 M5GPDUSessionReActivationResult::~M5GPDUSessionReActivationResult(){};
 
 int M5GPDUSessionReActivationResult::EncodePDUSessionReActivationResult(
-    M5GPDUSessionReActivationResult* pduSessionReActivationStatus, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   int encoded = 0;
-  if (pduSessionReActivationStatus->iei) {
-    *(buffer + encoded) = pduSessionReActivationStatus->iei;
-    encoded++;
-    *(buffer + encoded) = pduSessionReActivationStatus->len;
-    encoded++;
-    *(buffer + encoded) =
-        (pduSessionReActivationStatus->pduSessionReActivationResult & 0xFF);
-    encoded++;
-    *(buffer + encoded) =
-        ((pduSessionReActivationStatus->pduSessionReActivationResult >> 8) &
-         0xFF);
-    encoded++;
+  if (this->iei) {
+    *(buffer + encoded++) = this->iei;
+    *(buffer + encoded++) = this->len;
+    *(buffer + encoded++) = (this->pduSessionReActivationResult & 0xFF);
+    *(buffer + encoded++) = ((this->pduSessionReActivationResult >> 8) & 0xFF);
   }
 
   return encoded;
 }
 
 int M5GPDUSessionReActivationResult::DecodePDUSessionReActivationResult(
-    M5GPDUSessionReActivationResult* pduSessionReActivationStatus, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+    uint8_t iei, uint8_t* buffer, uint32_t len) {
   int decoded = 0;
 
   if (iei > 0) {
-    pduSessionReActivationStatus->iei = *buffer;
-    decoded++;
-
-    pduSessionReActivationStatus->len = *(buffer + decoded);
-    decoded++;
-
-    pduSessionReActivationStatus->pduSessionReActivationResult =
-        *(buffer + decoded);
-    decoded++;
-    pduSessionReActivationStatus->pduSessionReActivationResult |=
-        (*(buffer + decoded) << 8);
-    decoded++;
+    this->iei = *(buffer + decoded++);
+    this->len = *(buffer + decoded++);
+    this->pduSessionReActivationResult = *(buffer + decoded++);
+    this->pduSessionReActivationResult |= (*(buffer + decoded++) << 8);
   }
 
   return decoded;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionStatus.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionStatus.cpp
@@ -20,41 +20,28 @@ namespace magma5g {
 M5GPDUSessionStatus::M5GPDUSessionStatus(){};
 M5GPDUSessionStatus::~M5GPDUSessionStatus(){};
 
-int M5GPDUSessionStatus::EncodePDUSessionStatus(
-    M5GPDUSessionStatus* pduSessionStatus, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GPDUSessionStatus::EncodePDUSessionStatus(uint8_t iei, uint8_t* buffer,
+                                                uint32_t len) {
   int encoded = 0;
-  if (pduSessionStatus->iei) {
-    *(buffer + encoded) = pduSessionStatus->iei;
-    encoded++;
-    *(buffer + encoded) = pduSessionStatus->len;
-    encoded++;
-    *(buffer + encoded) = (uint8_t)(pduSessionStatus->pduSessionStatus & 0xFF);
-    encoded++;
-    *(buffer + encoded) =
-        (uint8_t)(((pduSessionStatus->pduSessionStatus >> 8) & 0xFF));
-    encoded++;
+  if (this->iei) {
+    *(buffer + encoded++) = this->iei;
+    *(buffer + encoded++) = this->len;
+    *(buffer + encoded++) = (uint8_t)(this->pduSessionStatus & 0xFF);
+    *(buffer + encoded++) = (uint8_t)(((this->pduSessionStatus >> 8) & 0xFF));
   }
 
   return encoded;
 }
 
-int M5GPDUSessionStatus::DecodePDUSessionStatus(
-    M5GPDUSessionStatus* pduSessionStatus, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GPDUSessionStatus::DecodePDUSessionStatus(uint8_t iei, uint8_t* buffer,
+                                                uint32_t len) {
   int decoded = 0;
 
   if (iei > 0) {
-    pduSessionStatus->iei = *buffer;
-    decoded++;
-
-    pduSessionStatus->len = *(buffer + decoded);
-    decoded++;
-
-    pduSessionStatus->pduSessionStatus = *(buffer + decoded);
-    decoded++;
-    pduSessionStatus->pduSessionStatus |= (*(buffer + decoded) << 8);
-    decoded++;
+    this->iei = *(buffer + decoded++);
+    this->len = *(buffer + decoded++);
+    this->pduSessionStatus = *(buffer + decoded++);
+    this->pduSessionStatus |= (*(buffer + decoded++) << 8);
   }
 
   return decoded;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionType.cpp
@@ -28,36 +28,33 @@ PDUSessionTypeMsg::PDUSessionTypeMsg(){};
 PDUSessionTypeMsg::~PDUSessionTypeMsg(){};
 
 // Decode PDUSessionType IE
-int PDUSessionTypeMsg::DecodePDUSessionTypeMsg(
-    PDUSessionTypeMsg* pdu_session_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int PDUSessionTypeMsg::DecodePDUSessionTypeMsg(uint8_t iei, uint8_t* buffer,
+                                               uint32_t len) {
   int decoded = 0;
 
   // Store the IEI Information
   if (iei > 0) {
-    pdu_session_type->iei = (*buffer & 0xf0) >> 4;
+    this->iei = (*buffer & 0xf0) >> 4;
     decoded++;
   }
 
-  pdu_session_type->type_val = (*buffer & 0x07);
+  this->type_val = (*buffer & 0x07);
 
   return (decoded);
 };
 
 // Encode PDUSessionType IE
-int PDUSessionTypeMsg::EncodePDUSessionTypeMsg(
-    PDUSessionTypeMsg* pdu_session_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int PDUSessionTypeMsg::EncodePDUSessionTypeMsg(uint8_t iei, uint8_t* buffer,
+                                               uint32_t len) {
   int encoded = 0;
 
   // CHECKING IEI
   if (iei > 0) {
-    *buffer = (pdu_session_type->iei & 0x0f) << 4;
-    CHECK_IEI_ENCODER((uint8_t)iei,
-                      (uint8_t)((pdu_session_type->iei & 0x0f) << 4));
+    *buffer = (this->iei & 0x0f) << 4;
+    CHECK_IEI_ENCODER((uint8_t)iei, (uint8_t)((this->iei & 0x0f) << 4));
   }
 
-  *buffer = 0x00 | (*buffer & 0xf0) | (pdu_session_type->type_val & 0x07);
+  *buffer = 0x00 | (*buffer & 0xf0) | (this->type_val & 0x07);
   encoded++;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPTI.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPTI.cpp
@@ -19,24 +19,16 @@ PTIMsg::PTIMsg(){};
 PTIMsg::~PTIMsg(){};
 
 // Decode PTI IE
-int PTIMsg::DecodePTIMsg(PTIMsg* pti, uint8_t iei, uint8_t* buffer,
-                         uint32_t len) {
+int PTIMsg::DecodePTIMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t decoded = 0;
-
-  pti->pti = *(buffer + decoded);
-  decoded++;
-
+  this->pti = *(buffer + decoded++);
   return (decoded);
 };
 
 // Encode PTI IE
-int PTIMsg::EncodePTIMsg(PTIMsg* pti, uint8_t iei, uint8_t* buffer,
-                         uint32_t len) {
+int PTIMsg::EncodePTIMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   int encoded = 0;
-
-  *(buffer + encoded) = pti->pti;
-  encoded++;
-
+  *(buffer + encoded++) = this->pti;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainerType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPayloadContainerType.cpp
@@ -21,26 +21,20 @@ PayloadContainerTypeMsg::PayloadContainerTypeMsg(){};
 PayloadContainerTypeMsg::~PayloadContainerTypeMsg(){};
 
 // Decode PayloadContainerType IE
-int PayloadContainerTypeMsg::DecodePayloadContainerTypeMsg(
-    PayloadContainerTypeMsg* payload_container_type, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+int PayloadContainerTypeMsg::DecodePayloadContainerTypeMsg(uint8_t iei,
+                                                           uint8_t* buffer,
+                                                           uint32_t len) {
   int decoded = 0;
-
-  payload_container_type->type_val = (*buffer & 0x0f);
-  decoded++;
-
+  this->type_val = (*(buffer + decoded++) & 0x0f);
   return (decoded);
 };
 
 // Encode PayloadContainerType IE
-int PayloadContainerTypeMsg::EncodePayloadContainerTypeMsg(
-    PayloadContainerTypeMsg* payload_container_type, uint8_t iei,
-    uint8_t* buffer, uint32_t len) {
+int PayloadContainerTypeMsg::EncodePayloadContainerTypeMsg(uint8_t iei,
+                                                           uint8_t* buffer,
+                                                           uint32_t len) {
   int encoded = 0;
-
-  *buffer = payload_container_type->type_val & 0x0f;
-  encoded++;
-
+  *(buffer + encoded++) = this->type_val & 0x0f;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQOSRules.cpp
@@ -31,142 +31,118 @@ QOSRulesMsg::QOSRulesMsg() {}
 QOSRulesMsg::~QOSRulesMsg() {}
 
 // Decode QOSRules IE
-uint8_t QOSRulesMsg::DecodeQOSRulesMsgData(QOSRulesMsg* qos_rules,
-                                           uint8_t* buffer, uint32_t len) {
+uint8_t QOSRulesMsg::DecodeQOSRulesMsgData(uint8_t* buffer, uint32_t len) {
   uint8_t decoded = 0;
   uint8_t i = 0;
 
-  while (decoded < qos_rules->length) {
-    IES_DECODE_U8(buffer, decoded, qos_rules->qos_rule[i].qos_rule_id);
+  while (decoded < this->length) {
+    IES_DECODE_U8(buffer, decoded, this->qos_rule[i].qos_rule_id);
 
-    IES_DECODE_U16(buffer, decoded, qos_rules->qos_rule[i].len);
+    IES_DECODE_U16(buffer, decoded, this->qos_rule[i].len);
 
     uint8_t data = 0;
     IES_DECODE_U8(buffer, decoded, data);
-    qos_rules->qos_rule[i].rule_oper_code = (data >> 5);
-    qos_rules->qos_rule[i].dqr_bit = (data >> 4) & 0x01;
-    qos_rules->qos_rule[i].no_of_pkt_filters = (data & 0x0f);
+    this->qos_rule[i].rule_oper_code = (data >> 5);
+    this->qos_rule[i].dqr_bit = (data >> 4) & 0x01;
+    this->qos_rule[i].no_of_pkt_filters = (data & 0x0f);
 
-    for (uint8_t j = 0; j < qos_rules->qos_rule[i].no_of_pkt_filters; ++j) {
+    for (uint8_t j = 0; j < this->qos_rule[i].no_of_pkt_filters; ++j) {
       data = 0;
       IES_DECODE_U8(buffer, decoded, data);
-      qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].spare = data >> 6;
-      qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].pkt_filter_dir =
+      this->qos_rule[i].new_qos_rule_pkt_filter[j].spare = data >> 6;
+      this->qos_rule[i].new_qos_rule_pkt_filter[j].pkt_filter_dir =
           (data >> 4) & 0x03;
-      qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].pkt_filter_id =
+      this->qos_rule[i].new_qos_rule_pkt_filter[j].pkt_filter_id =
           (data & 0x0f);
 
       IES_DECODE_U8(buffer, decoded,
-                    qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len);
-      memcpy(qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents,
+                    this->qos_rule[i].new_qos_rule_pkt_filter[j].len);
+      memcpy(this->qos_rule[i].new_qos_rule_pkt_filter[j].contents,
              buffer + decoded,
-             qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len);
-      decoded += qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
+             this->qos_rule[i].new_qos_rule_pkt_filter[j].len);
+      decoded += this->qos_rule[i].new_qos_rule_pkt_filter[j].len;
     }
-    IES_DECODE_U8(buffer, decoded, qos_rules->qos_rule[i].qos_rule_precedence);
+    IES_DECODE_U8(buffer, decoded, this->qos_rule[i].qos_rule_precedence);
 
     data = 0;
     IES_DECODE_U8(buffer, decoded, data);
-    qos_rules->qos_rule[i].spare = (data >> 7) & 0x01;
-    qos_rules->qos_rule[i].segregation = (data >> 6) & 0x01;
-    qos_rules->qos_rule[i].qfi = (data & 0x3f);
+    this->qos_rule[i].spare = (data >> 7) & 0x01;
+    this->qos_rule[i].segregation = (data >> 6) & 0x01;
+    this->qos_rule[i].qfi = (data & 0x3f);
   }
 
   return decoded;
 }
 
 // Decode QOSRules IE
-int QOSRulesMsg::DecodeQOSRulesMsg(QOSRulesMsg* qos_rules, uint8_t iei,
-                                   uint8_t* buffer, uint32_t len) {
+int QOSRulesMsg::DecodeQOSRulesMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t decoded = 0;
 
   if (iei > 0) {
-    qos_rules->iei = *buffer;
-    CHECK_IEI_DECODER((unsigned char)iei, qos_rules->iei);
-    decoded++;
+    this->iei = *(buffer + decoded++);
+    CHECK_IEI_DECODER((unsigned char)iei, this->iei);
   }
 
-  IES_DECODE_U16(buffer, decoded, qos_rules->length);
+  IES_DECODE_U16(buffer, decoded, this->length);
 
-  if (!qos_rules) {
-    OAILOG_ERROR(LOG_NAS5G, "No QOS Rules found while Decoding");
-    return -1;
-  }
-
-  decoded += DecodeQOSRulesMsgData(qos_rules, buffer + decoded, len);
+  decoded += DecodeQOSRulesMsgData(buffer + decoded, len);
   return decoded;
 }
 
-uint16_t QOSRulesMsg::EncodeQOSRulesMsgData(QOSRulesMsg* qos_rules,
-                                            uint8_t* buffer, uint32_t len) {
+uint16_t QOSRulesMsg::EncodeQOSRulesMsgData(uint8_t* buffer, uint32_t len) {
   uint16_t encoded = 0;
   uint8_t i = 0;
   uint8_t j = 0;
 
-  while (encoded < (qos_rules->length) && i <= 255) {
-    *(buffer + encoded) = qos_rules->qos_rule[i].qos_rule_id;
-    encoded++;
-    IES_ENCODE_U16(buffer, encoded, qos_rules->qos_rule[i].len);
-    *(buffer + encoded) =
-        0x00 | ((qos_rules->qos_rule[i].rule_oper_code & 0x07) << 5) |
-        ((qos_rules->qos_rule[i].dqr_bit & 0x01) << 4) |
-        (qos_rules->qos_rule[i].no_of_pkt_filters & 0x0f);
-    encoded++;
-    for (j = 0; j < qos_rules->qos_rule[i].no_of_pkt_filters; j++) {
-      *(buffer + encoded) =
+  for (i = 0; ((encoded < (this->length)) && (i <= 255)); i++) {
+    *(buffer + encoded++) = this->qos_rule[i].qos_rule_id;
+    IES_ENCODE_U16(buffer, encoded, this->qos_rule[i].len);
+    *(buffer + encoded++) = 0x00 |
+                            ((this->qos_rule[i].rule_oper_code & 0x07) << 5) |
+                            ((this->qos_rule[i].dqr_bit & 0x01) << 4) |
+                            (this->qos_rule[i].no_of_pkt_filters & 0x0f);
+    for (j = 0; j < this->qos_rule[i].no_of_pkt_filters; j++) {
+      *(buffer + encoded++) =
           0x00 |
-          ((qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].spare & 0x03)
-           << 6) |
-          ((qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].pkt_filter_dir &
-            0x03)
+          ((this->qos_rule[i].new_qos_rule_pkt_filter[j].spare & 0x03) << 6) |
+          ((this->qos_rule[i].new_qos_rule_pkt_filter[j].pkt_filter_dir & 0x03)
            << 4) |
-          (qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].pkt_filter_id &
-           0x0f);
-      encoded++;
-      *(buffer + encoded) =
-          qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
-      encoded++;
+          (this->qos_rule[i].new_qos_rule_pkt_filter[j].pkt_filter_id & 0x0f);
+      *(buffer + encoded++) = this->qos_rule[i].new_qos_rule_pkt_filter[j].len;
       memcpy(buffer + encoded,
-             qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].contents,
-             qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len);
-      encoded = encoded + qos_rules->qos_rule[i].new_qos_rule_pkt_filter[j].len;
+             this->qos_rule[i].new_qos_rule_pkt_filter[j].contents,
+             this->qos_rule[i].new_qos_rule_pkt_filter[j].len);
+      encoded += this->qos_rule[i].new_qos_rule_pkt_filter[j].len;
     }
 
     // Needed only for add operation
-    if (qos_rules->qos_rule[i].rule_oper_code ==
+    if (this->qos_rule[i].rule_oper_code ==
         TRAFFIC_FLOW_TEMPLATE_OPCODE_CREATE_NEW_TFT) {
-      *(buffer + encoded) = qos_rules->qos_rule[i].qos_rule_precedence;
-      encoded++;
-      *(buffer + encoded) = 0x00 |
-                            ((qos_rules->qos_rule[i].spare & 0x01) << 7) |
-                            ((qos_rules->qos_rule[i].segregation & 0x01) << 6) |
-                            (qos_rules->qos_rule[i].qfi & 0x3f);
-      encoded++;
+      *(buffer + encoded++) = this->qos_rule[i].qos_rule_precedence;
+      *(buffer + encoded++) = 0x00 | ((this->qos_rule[i].spare & 0x01) << 7) |
+                              ((this->qos_rule[i].segregation & 0x01) << 6) |
+                              (this->qos_rule[i].qfi & 0x3f);
     }
-
-    i++;
   }
 
   return encoded;
 }
 
 // Encode QOSRules IE
-int QOSRulesMsg::EncodeQOSRulesMsg(QOSRulesMsg* qos_rules, uint8_t iei,
-                                   uint8_t* buffer, uint32_t len) {
+int QOSRulesMsg::EncodeQOSRulesMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint16_t encoded = 0;
 
   // Checking IEI and pointer
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, QOS_RULES_MSG_MIN_LEN, len);
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER((unsigned char)iei, qos_rules->iei);
-    *buffer = iei;
-    encoded++;
+    CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
+    *(buffer + encoded++) = iei;
   }
 
-  IES_ENCODE_U16(buffer, encoded, qos_rules->length);
+  IES_ENCODE_U16(buffer, encoded, this->length);
 
-  encoded += EncodeQOSRulesMsgData(qos_rules, buffer + encoded, len);
+  encoded += EncodeQOSRulesMsgData(buffer + encoded, len);
   return encoded;
 }
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQosFlowDescriptor.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GQosFlowDescriptor.cpp
@@ -26,27 +26,25 @@ namespace magma5g {
 M5GQosFlowDescription::M5GQosFlowDescription() {}
 M5GQosFlowDescription::~M5GQosFlowDescription() {}
 
-int M5GQosFlowDescription::EncodeM5GQosFlowDescription(
-    M5GQosFlowDescription* qosFlowDesc, uint8_t* buffer, uint32_t len) {
+int M5GQosFlowDescription::EncodeM5GQosFlowDescription(uint8_t* buffer,
+                                                       uint32_t len) {
   int encoded = 0;
 
   OAILOG_DEBUG(LOG_NAS5G, " EncodeQosFlowDescriptor : ");
-  *(buffer + encoded) = qosFlowDesc->qfi;
+  *(buffer + encoded++) = this->qfi;
   OAILOG_DEBUG(LOG_NAS5G, "QFI = 0x%X", static_cast<int>(*(buffer + encoded)));
-  encoded++;
 
-  *(buffer + encoded) = qosFlowDesc->operationCode;
+  *(buffer + encoded++) = this->operationCode;
   OAILOG_DEBUG(LOG_NAS5G, "OperationCode = 0x%x",
                static_cast<int>(*(buffer + encoded)));
-  encoded++;
 
-  *(buffer + encoded) = qosFlowDesc->Ebit << 6;
-  *(buffer + encoded) |= qosFlowDesc->numOfParams & 0x3f;
+  *(buffer + encoded) = this->Ebit << 6;
+  *(buffer + encoded) |= this->numOfParams & 0x3f;
   OAILOG_DEBUG(LOG_NAS5G, "NumOfParams = 0X%x",
                static_cast<int>(*(buffer + encoded)));
   encoded++;
-  for (uint8_t i = 0; i < qosFlowDesc->numOfParams; i++) {
-    M5GQosFlowParam* qosParams = &qosFlowDesc->paramList[i];
+  for (uint8_t i = 0; i < this->numOfParams; i++) {
+    M5GQosFlowParam* qosParams = &this->paramList[i];
     encoded +=
         qosParams->EncodeM5GQosFlowParam(qosParams, (buffer + encoded), len);
   }
@@ -54,28 +52,26 @@ int M5GQosFlowDescription::EncodeM5GQosFlowDescription(
   return encoded;
 }
 
-int M5GQosFlowDescription::DecodeM5GQosFlowDescription(
-    M5GQosFlowDescription* qosFlowDesc, uint8_t* buffer, uint32_t len) {
+int M5GQosFlowDescription::DecodeM5GQosFlowDescription(uint8_t* buffer,
+                                                       uint32_t len) {
   int decoded = 0;
 
   OAILOG_DEBUG(LOG_NAS5G, " DecodeQosFlowDescriptor : ");
-  qosFlowDesc->qfi = (*(buffer + decoded)) & 0x3F;
-  OAILOG_DEBUG(LOG_NAS5G, "QFI = 0x%x", static_cast<int>(qosFlowDesc->qfi));
-  decoded++;
-  qosFlowDesc->operationCode = (*(buffer + decoded) & 0xE0);
+  this->qfi = (*(buffer + decoded++)) & 0x3F;
+  OAILOG_DEBUG(LOG_NAS5G, "QFI = 0x%x", static_cast<int>(this->qfi));
+  this->operationCode = (*(buffer + decoded++) & 0xE0);
   OAILOG_DEBUG(LOG_NAS5G, "OperationCode = 0x%x",
-               static_cast<int>(qosFlowDesc->operationCode));
-  decoded++;
-  qosFlowDesc->numOfParams = ((*(buffer + decoded) & 0x3F));
+               static_cast<int>(this->operationCode));
+  this->numOfParams = ((*(buffer + decoded) & 0x3F));
   OAILOG_DEBUG(LOG_NAS5G, "NumOfParams = 0x%x",
-               static_cast<int>(qosFlowDesc->numOfParams));
+               static_cast<int>(this->numOfParams));
 
-  qosFlowDesc->Ebit = ((*(buffer + decoded) & 0x40) >> 6);
-  OAILOG_DEBUG(LOG_NAS5G, "Ebit = 0x%x", static_cast<int>(qosFlowDesc->Ebit));
+  this->Ebit = ((*(buffer + decoded) & 0x40) >> 6);
+  OAILOG_DEBUG(LOG_NAS5G, "Ebit = 0x%x", static_cast<int>(this->Ebit));
   decoded++;
 
-  for (uint8_t i = 0; i < qosFlowDesc->numOfParams; i++) {
-    M5GQosFlowParam* qosParams = &qosFlowDesc->paramList[i];
+  for (uint8_t i = 0; i < this->numOfParams; i++) {
+    M5GQosFlowParam* qosParams = &this->paramList[i];
     decoded +=
         qosParams->DecodeM5GQosFlowParam(qosParams, (buffer + decoded), len);
   }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GRequestType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GRequestType.cpp
@@ -28,33 +28,31 @@ RequestType::RequestType() {}
 RequestType::~RequestType() {}
 
 // Decode RequestType IE
-int RequestType::DecodeRequestType(RequestType* reqest_type, uint8_t iei,
-                                   uint8_t* buffer, uint32_t len) {
+int RequestType::DecodeRequestType(uint8_t iei, uint8_t* buffer, uint32_t len) {
   int decoded = 0;
 
   // Store the IEI Information
   if (iei > 0) {
-    reqest_type->iei = (*buffer & 0xf0) >> 4;
+    this->iei = (*buffer & 0xf0) >> 4;
     decoded++;
   }
 
-  reqest_type->type_val = (*buffer & 0x07);
+  this->type_val = (*buffer & 0x07);
 
   return (decoded);
 }
 
 // Encode RequestType IE
-int RequestType::EncodeRequestType(RequestType* reqest_type, uint8_t iei,
-                                   uint8_t* buffer, uint32_t len) {
+int RequestType::EncodeRequestType(uint8_t iei, uint8_t* buffer, uint32_t len) {
   int encoded = 0;
 
   // CHECKING IEI
   if (iei > 0) {
-    *buffer = (reqest_type->iei & 0x0f) << 4;
-    CHECK_IEI_ENCODER((uint8_t)iei, (uint8_t)((reqest_type->iei & 0x0f) << 4));
+    *buffer = (this->iei & 0x0f) << 4;
+    CHECK_IEI_ENCODER((uint8_t)iei, (uint8_t)((this->iei & 0x0f) << 4));
   }
 
-  *buffer = 0x00 | (*buffer & 0xf0) | (reqest_type->type_val & 0x07);
+  *buffer = 0x00 | (*buffer & 0xf0) | (this->type_val & 0x07);
   encoded++;
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSDeRegistrationType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSDeRegistrationType.cpp
@@ -19,26 +19,23 @@ namespace magma5g {
 M5GSDeRegistrationTypeMsg::M5GSDeRegistrationTypeMsg(){};
 M5GSDeRegistrationTypeMsg::~M5GSDeRegistrationTypeMsg(){};
 
-int M5GSDeRegistrationTypeMsg::DecodeM5GSDeRegistrationTypeMsg(
-    M5GSDeRegistrationTypeMsg* de_reg_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSDeRegistrationTypeMsg::DecodeM5GSDeRegistrationTypeMsg(uint8_t iei,
+                                                               uint8_t* buffer,
+                                                               uint32_t len) {
   uint8_t decoded = 0;
-
-  de_reg_type->switchoff = (*(buffer + decoded) >> 3) & 0x01;
-  de_reg_type->re_reg_required = (*(buffer + decoded) >> 2) & 0x01;
-  de_reg_type->access_type = *(buffer + decoded) & 0x03;
+  this->switchoff = (*(buffer + decoded) >> 3) & 0x01;
+  this->re_reg_required = (*(buffer + decoded) >> 2) & 0x01;
+  this->access_type = *(buffer + decoded) & 0x03;
   return (decoded);
 };
 
-int M5GSDeRegistrationTypeMsg::EncodeM5GSDeRegistrationTypeMsg(
-    M5GSDeRegistrationTypeMsg* de_reg_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSDeRegistrationTypeMsg::EncodeM5GSDeRegistrationTypeMsg(uint8_t iei,
+                                                               uint8_t* buffer,
+                                                               uint32_t len) {
   uint8_t encoded = 0;
-
-  *(buffer + encoded) = 0x00 | ((de_reg_type->switchoff << 3) & 0x08) |
-                        ((de_reg_type->re_reg_required << 2) & 0x04) |
-                        (de_reg_type->access_type & 0x03);
-  encoded++;
+  *(buffer + encoded++) = 0x00 | ((this->switchoff << 3) & 0x08) |
+                          ((this->re_reg_required << 2) & 0x04) |
+                          (this->access_type & 0x03);
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSIdentityType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSIdentityType.cpp
@@ -19,24 +19,18 @@ M5GSIdentityTypeMsg::M5GSIdentityTypeMsg(){};
 M5GSIdentityTypeMsg::~M5GSIdentityTypeMsg(){};
 
 // Decode M5GSIdentityType IE
-int M5GSIdentityTypeMsg::DecodeM5GSIdentityTypeMsg(
-    M5GSIdentityTypeMsg* m5gs_identity_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSIdentityTypeMsg::DecodeM5GSIdentityTypeMsg(uint8_t iei, uint8_t* buffer,
+                                                   uint32_t len) {
   uint8_t decoded = 0;
-
-  m5gs_identity_type->toi = *(buffer + decoded) & 0x7;
-  decoded++;
+  this->toi = *(buffer + decoded++) & 0x7;
   return (decoded);
 };
 
 // Encode M5GSIdentityType IE
-int M5GSIdentityTypeMsg::EncodeM5GSIdentityTypeMsg(
-    M5GSIdentityTypeMsg* m5gs_identity_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSIdentityTypeMsg::EncodeM5GSIdentityTypeMsg(uint8_t iei, uint8_t* buffer,
+                                                   uint32_t len) {
   int encoded = 0;
-
-  *(buffer + encoded) = (m5gs_identity_type->toi) & 0x7;
-  encoded++;
+  *(buffer + encoded++) = (this->toi) & 0x7;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMCause.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMCause.cpp
@@ -28,37 +28,33 @@ M5GSMCauseMsg::M5GSMCauseMsg() {}
 M5GSMCauseMsg::~M5GSMCauseMsg() {}
 
 // Decode M5GSMCause IE
-int M5GSMCauseMsg::DecodeM5GSMCauseMsg(M5GSMCauseMsg* m5gsm_cause, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int M5GSMCauseMsg::DecodeM5GSMCauseMsg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   int decoded = 0;
 
   // CHECKING IEI
   if (iei > 0) {
-    m5gsm_cause->iei = *buffer;
-    CHECK_IEI_DECODER(iei, (unsigned char)m5gsm_cause->iei);
-    decoded++;
+    this->iei = *(buffer + decoded++);
+    CHECK_IEI_DECODER(iei, (unsigned char)this->iei);
   }
 
-  m5gsm_cause->cause_value = *(buffer + decoded);
-  decoded++;
+  this->cause_value = *(buffer + decoded++);
 
   return decoded;
 }
 
 // Encode M5GSMCause IE
-int M5GSMCauseMsg::EncodeM5GSMCauseMsg(M5GSMCauseMsg* m5gsm_cause, uint8_t iei,
-                                       uint8_t* buffer, uint32_t len) {
+int M5GSMCauseMsg::EncodeM5GSMCauseMsg(uint8_t iei, uint8_t* buffer,
+                                       uint32_t len) {
   int encoded = 0;
 
   // CHECKING IEI
   if (iei > 0) {
-    *buffer = m5gsm_cause->iei;
-    CHECK_IEI_DECODER(iei, (unsigned char)m5gsm_cause->iei);
-    encoded++;
+    *(buffer + encoded++) = this->iei;
+    CHECK_IEI_DECODER(iei, (unsigned char)this->iei);
   }
 
-  *(buffer + encoded) = m5gsm_cause->cause_value;
-  encoded++;
+  *(buffer + encoded++) = this->cause_value;
 
   return encoded;
 }

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMobileIdentity.cpp
@@ -41,8 +41,9 @@ M5GSMobileIdentityIe::M5GSMobileIdentityIe(){};
 M5GSMobileIdentityIe::~M5GSMobileIdentityIe(){};
 
 // Decode GutiMobileIdentity IE Message
-int M5GSMobileIdentityMsg::DecodeGutiMobileIdentityMsg(
-    GutiM5GSMobileIdentity* guti, uint8_t* buffer, uint8_t ielen) {
+int M5GSMobileIdentityMsg::DecodeGutiMobileIdentityMsg(uint8_t* buffer,
+                                                       uint8_t ielen) {
+  GutiM5GSMobileIdentity* guti = &this->mobile_identity.guti;
   int decoded = 0;
   uint16_t setid;
 
@@ -56,13 +57,13 @@ int M5GSMobileIdentityMsg::DecodeGutiMobileIdentityMsg(
 
   guti->odd_even = (*(buffer + decoded) >> 3) & 0x1;
   guti->type_of_identity = *(buffer + decoded) & 0x7;
+  decoded++;
 
   if (guti->type_of_identity != M5GSMobileIdentityMsg_GUTI) {
     OAILOG_ERROR(LOG_NAS5G, "Error: %d", TLV_VALUE_DOESNT_MATCH);
     return (TLV_VALUE_DOESNT_MATCH);
   }
 
-  decoded++;
   guti->mcc_digit2 = (*(buffer + decoded) >> 4) & 0xf;
   guti->mcc_digit1 = *(buffer + decoded) & 0xf;
   decoded++;
@@ -72,28 +73,23 @@ int M5GSMobileIdentityMsg::DecodeGutiMobileIdentityMsg(
   guti->mnc_digit2 = (*(buffer + decoded) >> 4) & 0xf;
   guti->mnc_digit1 = *(buffer + decoded) & 0xf;
   decoded++;
-  guti->amf_regionid = *(buffer + decoded);
-  decoded++;
-  setid = *(buffer + decoded);
-  decoded++;
+  guti->amf_regionid = *(buffer + decoded++);
+  setid = *(buffer + decoded++);
   guti->amf_setid =
       0x0000 | ((setid & 0xff) << 2) | ((*(buffer + decoded) >> 6) & 0x3);
   guti->amf_pointer = *(buffer + decoded) & 0x3f;
   decoded++;
-  guti->tmsi1 = *(buffer + decoded);
-  decoded++;
-  guti->tmsi2 = *(buffer + decoded);
-  decoded++;
-  guti->tmsi3 = *(buffer + decoded);
-  decoded++;
-  guti->tmsi4 = *(buffer + decoded);
-  decoded++;
+  guti->tmsi1 = *(buffer + decoded++);
+  guti->tmsi2 = *(buffer + decoded++);
+  guti->tmsi3 = *(buffer + decoded++);
+  guti->tmsi4 = *(buffer + decoded++);
   return (decoded);
 }
 
 // Decode ImeiMobileIdentity IE
-int M5GSMobileIdentityMsg::DecodeImeiMobileIdentityMsg(
-    ImeiM5GSMobileIdentity* imei, uint8_t* buffer, uint8_t ielen) {
+int M5GSMobileIdentityMsg::DecodeImeiMobileIdentityMsg(uint8_t* buffer,
+                                                       uint8_t ielen) {
+  ImeiM5GSMobileIdentity* imei = &this->mobile_identity.imei;
   int decoded = 0;
 
   imei->identity_digit1 = (*(buffer + decoded) >> 4) & 0xf;
@@ -105,13 +101,13 @@ int M5GSMobileIdentityMsg::DecodeImeiMobileIdentityMsg(
 
   imei->odd_even = (*(buffer + decoded) >> 3) & 0x1;
   imei->type_of_identity = *(buffer + decoded) & 0x7;
+  decoded++;
 
   if (imei->type_of_identity != M5GSMobileIdentityMsg_IMEI) {
     OAILOG_ERROR(LOG_NAS5G, "Error : %d", TLV_VALUE_DOESNT_MATCH);
     return (TLV_VALUE_DOESNT_MATCH);
   }
 
-  decoded++;
   imei->identity_digit3 = (*(buffer + decoded) >> 4) & 0xf;
   imei->identity_digit2 = *(buffer + decoded) & 0xf;
   decoded++;
@@ -120,8 +116,9 @@ int M5GSMobileIdentityMsg::DecodeImeiMobileIdentityMsg(
 };
 
 // Decode ImsiMobileIdentity IE
-int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(
-    ImsiM5GSMobileIdentity* imsi, uint8_t* buffer, uint8_t ielen) {
+int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(uint8_t* buffer,
+                                                       uint8_t ielen) {
+  ImsiM5GSMobileIdentity* imsi = &this->mobile_identity.imsi;
   int decoded = 0;
   /* 5GS mobile identity comprises of
      1  byte  for spare bits, supi format and type of identity
@@ -140,13 +137,13 @@ int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(
   imsi->supi_format = (*(buffer + decoded) >> 4) & 0x7;
   imsi->spare1 = (*(buffer + decoded) >> 3) & 0x1;
   imsi->type_of_identity = *(buffer + decoded) & 0x7;
+  decoded++;
 
   if (imsi->type_of_identity != M5GSMobileIdentityMsg_SUCI_IMSI) {
     OAILOG_ERROR(LOG_NAS5G, "Error : %d", TLV_VALUE_DOESNT_MATCH);
     return (TLV_VALUE_DOESNT_MATCH);
   }
 
-  decoded++;
   imsi->mcc_digit2 = (*(buffer + decoded) >> 4) & 0xf;
   imsi->mcc_digit1 = *(buffer + decoded) & 0xf;
   decoded++;
@@ -179,8 +176,7 @@ int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(
   imsi->spare3 = (*(buffer + decoded) >> 4) & 0x1;
   imsi->protect_schm_id = *(buffer + decoded) & 0xf;
   decoded++;
-  imsi->home_nw_id = *(buffer + decoded);
-  decoded++;
+  imsi->home_nw_id = *(buffer + decoded++);
 
   memcpy(&imsi->scheme_output, buffer + decoded, ielen - decoded);
 
@@ -236,32 +232,33 @@ int M5GSMobileIdentityMsg::DecodeImsiMobileIdentityMsg(
 
 // Will be supported POST MVC
 // Decode SuciMobileIdentity IE
-int M5GSMobileIdentityMsg::DecodeSuciMobileIdentityMsg(
-    SuciM5GSMobileIdentity* suci, uint8_t* buffer, uint8_t ielen) {
+int M5GSMobileIdentityMsg::DecodeSuciMobileIdentityMsg(uint8_t* buffer,
+                                                       uint8_t ielen) {
+  SuciM5GSMobileIdentity* suci = &this->mobile_identity.suci;
   int decoded = 0;
 
   suci->spare2 = (*(buffer + decoded) >> 7) & 0x1;
   suci->supi_format = (*(buffer + decoded) >> 4) & 0x7;
   suci->spare1 = (*(buffer + decoded) >> 3) & 0x1;
   suci->type_of_identity = *(buffer + decoded) & 0x7;
+  decoded++;
 
   if (suci->type_of_identity != M5GSMobileIdentityMsg_IMEISV) {
     OAILOG_ERROR(LOG_NAS5G, "TLV_VALUE_DOESNT_MATCH error");
     return (TLV_VALUE_DOESNT_MATCH);
   }
-  decoded++;
 
   // Will be supported POST MVC
-  suci->suci_nai = *(buffer + decoded);
-  decoded++;
+  suci->suci_nai = *(buffer + decoded++);
   decoded++;
 
   return (decoded);
 };
 
 // Decode TmsiMobileIdentity IE
-int M5GSMobileIdentityMsg::DecodeTmsiMobileIdentityMsg(
-    TmsiM5GSMobileIdentity* tmsi, uint8_t* buffer, uint8_t ielen) {
+int M5GSMobileIdentityMsg::DecodeTmsiMobileIdentityMsg(uint8_t* buffer,
+                                                       uint8_t ielen) {
+  TmsiM5GSMobileIdentity* tmsi = &this->mobile_identity.tmsi;
   int decoded = 0;
 
   tmsi->spare = (*(buffer + decoded) >> 4) & 0xf;
@@ -274,16 +271,15 @@ int M5GSMobileIdentityMsg::DecodeTmsiMobileIdentityMsg(
 
   tmsi->odd_even = (*(buffer + decoded) >> 3) & 0x1;
   tmsi->type_of_identity = *(buffer + decoded) & 0x7;
+  decoded++;
 
   if (tmsi->type_of_identity != M5GSMobileIdentityMsg_TMSI) {
     OAILOG_ERROR(LOG_NAS5G, "Error : %d",
                  static_cast<int>(TLV_VALUE_DOESNT_MATCH));
     return (TLV_VALUE_DOESNT_MATCH);
   }
-  decoded++;
   uint8_t setid;
-  setid = *(buffer + decoded);
-  decoded++;
+  setid = *(buffer + decoded++);
   tmsi->amf_setid =
       0x0000 | ((setid & 0xff) << 2) | ((*(buffer + decoded) >> 6) & 0x3);
   tmsi->amf_pointer = *(buffer + decoded) & 0x3f;
@@ -294,16 +290,15 @@ int M5GSMobileIdentityMsg::DecodeTmsiMobileIdentityMsg(
 };
 
 // Decode M5GSMobileIdentity IE
-int M5GSMobileIdentityMsg::DecodeM5GSMobileIdentityMsg(
-    M5GSMobileIdentityMsg* mg5smobile_identity, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSMobileIdentityMsg::DecodeM5GSMobileIdentityMsg(uint8_t iei,
+                                                       uint8_t* buffer,
+                                                       uint32_t len) {
   int decoded_rc = TLV_VALUE_DOESNT_MATCH;
   int decoded = 0;
   uint16_t ielen = 0;
 
   if (iei > 0) {
-    CHECK_IEI_DECODER(iei, (unsigned char)*buffer);
-    decoded++;
+    CHECK_IEI_DECODER(iei, (unsigned char)*(buffer + decoded++));
   }
 
   IES_DECODE_U16(buffer, decoded, ielen);
@@ -311,20 +306,15 @@ int M5GSMobileIdentityMsg::DecodeM5GSMobileIdentityMsg(
   unsigned char type_of_identity = *(buffer + decoded) & 0x7;
 
   if (type_of_identity == M5GSMobileIdentityMsg_IMEISV) {
-    decoded_rc = DecodeSuciMobileIdentityMsg(
-        &mg5smobile_identity->mobile_identity.suci, buffer, ielen);
+    decoded_rc = DecodeSuciMobileIdentityMsg(buffer, ielen);
   } else if (type_of_identity == M5GSMobileIdentityMsg_GUTI) {
-    decoded_rc = DecodeGutiMobileIdentityMsg(
-        &mg5smobile_identity->mobile_identity.guti, buffer + decoded, ielen);
+    decoded_rc = DecodeGutiMobileIdentityMsg(buffer + decoded, ielen);
   } else if (type_of_identity == M5GSMobileIdentityMsg_IMEI) {
-    decoded_rc = DecodeImeiMobileIdentityMsg(
-        &mg5smobile_identity->mobile_identity.imei, buffer + decoded, ielen);
+    decoded_rc = DecodeImeiMobileIdentityMsg(buffer + decoded, ielen);
   } else if (type_of_identity == M5GSMobileIdentityMsg_TMSI) {
-    decoded_rc = DecodeTmsiMobileIdentityMsg(
-        &mg5smobile_identity->mobile_identity.tmsi, buffer + decoded, ielen);
+    decoded_rc = DecodeTmsiMobileIdentityMsg(buffer + decoded, ielen);
   } else if (type_of_identity == M5GSMobileIdentityMsg_SUCI_IMSI) {
-    decoded_rc = DecodeImsiMobileIdentityMsg(
-        &mg5smobile_identity->mobile_identity.imsi, buffer + decoded, ielen);
+    decoded_rc = DecodeImsiMobileIdentityMsg(buffer + decoded, ielen);
   } else if (type_of_identity == M5GSMobileIdentityMsg_NO_IDENTITY) {
     decoded_rc = 1;
   }
@@ -336,88 +326,68 @@ int M5GSMobileIdentityMsg::DecodeM5GSMobileIdentityMsg(
 };
 
 // Encode GutiMobileIdentity IE
-int M5GSMobileIdentityMsg::EncodeGutiMobileIdentityMsg(
-    GutiM5GSMobileIdentity* guti, uint8_t* buffer) {
+int M5GSMobileIdentityMsg::EncodeGutiMobileIdentityMsg(uint8_t* buffer) {
+  GutiM5GSMobileIdentity* guti = &this->mobile_identity.guti;
   uint32_t encoded = 0;
 
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0xf0 | ((guti->odd_even & 0x01) << 3) | (guti->type_of_identity & 0x7);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((guti->mcc_digit2 & 0x0f) << 4) | (guti->mcc_digit1 & 0x0f);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((guti->mnc_digit3 & 0x0f) << 4) | (guti->mcc_digit3 & 0x0f);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((guti->mnc_digit2 & 0x0f) << 4) | (guti->mnc_digit1 & 0x0f);
-  encoded++;
-  *(buffer + encoded) = 0x00 | guti->amf_regionid;
-  encoded++;
-  *(buffer + encoded) = 0x00 | ((guti->amf_setid >> 2) & 0xFF);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) = 0x00 | guti->amf_regionid;
+  *(buffer + encoded++) = 0x00 | ((guti->amf_setid >> 2) & 0xFF);
+  *(buffer + encoded++) =
       0x00 | ((guti->amf_setid & 0xF3) << 6) | (guti->amf_pointer & 0x3f);
-  encoded++;
-  *(buffer + encoded) = 0x00 | guti->tmsi1;
-  encoded++;
-  *(buffer + encoded) = 0x00 | guti->tmsi2;
-  encoded++;
-  *(buffer + encoded) = 0x00 | guti->tmsi3;
-  encoded++;
-  *(buffer + encoded) = 0x00 | guti->tmsi4;
-  encoded++;
+  *(buffer + encoded++) = 0x00 | guti->tmsi1;
+  *(buffer + encoded++) = 0x00 | guti->tmsi2;
+  *(buffer + encoded++) = 0x00 | guti->tmsi3;
+  *(buffer + encoded++) = 0x00 | guti->tmsi4;
 
   return encoded;
 };
 
 // Will be supported POST MVC
 // Encode ImeiMobileIdentity IE
-int M5GSMobileIdentityMsg::EncodeImeiMobileIdentityMsg(
-    ImeiM5GSMobileIdentity* imei, uint8_t* buffer) {
+int M5GSMobileIdentityMsg::EncodeImeiMobileIdentityMsg(uint8_t* buffer) {
+  ImeiM5GSMobileIdentity* imei = &this->mobile_identity.imei;
   uint32_t encoded = 0;
 
-  *(buffer + encoded) = 0x00 | ((imei->identity_digit1 & 0xf0) << 4) |
-                        ((imei->odd_even & 0x1) << 3) |
-                        (imei->type_of_identity & 0x7);
-  encoded++;
-  *(buffer + encoded) = 0x00 | ((imei->identity_digit2 & 0xf0) << 4) |
-                        (imei->identity_digit3 & 0x0f);
-  encoded++;
+  *(buffer + encoded++) = 0x00 | ((imei->identity_digit1 & 0xf0) << 4) |
+                          ((imei->odd_even & 0x1) << 3) |
+                          (imei->type_of_identity & 0x7);
+  *(buffer + encoded++) = 0x00 | ((imei->identity_digit2 & 0xf0) << 4) |
+                          (imei->identity_digit3 & 0x0f);
 
   return encoded;
 };
 
 // Will be supported POST MVC
 // Encode ImsiMobileIdentity IE
-int M5GSMobileIdentityMsg::EncodeImsiMobileIdentityMsg(
-    ImsiM5GSMobileIdentity* imsi, uint8_t* buffer) {
+int M5GSMobileIdentityMsg::EncodeImsiMobileIdentityMsg(uint8_t* buffer) {
+  ImsiM5GSMobileIdentity* imsi = &this->mobile_identity.imsi;
   uint32_t encoded = 0;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((imsi->spare2 & 0x80) << 7) | ((imsi->supi_format & 0x07) << 4) |
       ((imsi->spare1 & 0x01) << 3) | (imsi->type_of_identity & 0x7);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((imsi->mcc_digit2 & 0x0f) << 4) | (imsi->mcc_digit1 & 0x0f);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((imsi->mnc_digit3 & 0x0f) << 4) | (imsi->mcc_digit3 & 0x0f);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((imsi->mnc_digit2 & 0x0f) << 4) | (imsi->mnc_digit1 & 0x0f);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((imsi->rout_ind_digit_2) << 4) | (imsi->rout_ind_digit_1);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((imsi->rout_ind_digit_3) << 4) | (imsi->rout_ind_digit_4);
-  encoded++;
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((imsi->spare6 & 0x01) << 7) | ((imsi->spare5 & 0x01) << 6) |
       ((imsi->spare4 & 0x01) << 5) | ((imsi->spare3 & 0x01) << 4) |
       (imsi->protect_schm_id & 0x0f);
-  *(buffer + encoded) = imsi->home_nw_id;
-  encoded++;
+  *(buffer + encoded++) = imsi->home_nw_id;
 
   memcpy(buffer + encoded, &imsi->scheme_output, imsi->scheme_len);
   encoded = encoded + imsi->scheme_len;
@@ -426,16 +396,14 @@ int M5GSMobileIdentityMsg::EncodeImsiMobileIdentityMsg(
 };
 
 // Will be supported POST MVC
-int M5GSMobileIdentityMsg::EncodeTmsiMobileIdentityMsg(
-    TmsiM5GSMobileIdentity* tmsi, uint8_t* buffer) {
+int M5GSMobileIdentityMsg::EncodeTmsiMobileIdentityMsg(uint8_t* buffer) {
+  TmsiM5GSMobileIdentity* tmsi = &this->mobile_identity.tmsi;
   uint32_t encoded = 0;
 
-  *(buffer + encoded) = 0x00 | ((tmsi->spare & 0x0f) << 4) |
-                        ((tmsi->odd_even & 0x01) << 3) |
-                        (tmsi->type_of_identity & 0x7);
-  encoded++;
-  *(buffer + encoded) = 0x00 | tmsi->amf_setid;
-  encoded++;
+  *(buffer + encoded++) = 0x00 | ((tmsi->spare & 0x0f) << 4) |
+                          ((tmsi->odd_even & 0x01) << 3) |
+                          (tmsi->type_of_identity & 0x7);
+  *(buffer + encoded++) = 0x00 | tmsi->amf_setid;
   *(buffer + encoded) = 0x00 | ((tmsi->amf_setid & 0xc0) << 6);
   *(buffer + encoded) = 0x00 | (tmsi->amf_pointer & 0x3f);
   encoded++;
@@ -443,23 +411,22 @@ int M5GSMobileIdentityMsg::EncodeTmsiMobileIdentityMsg(
 };
 
 // Encode SuciMobileIdentity IE
-int M5GSMobileIdentityMsg::EncodeSuciMobileIdentityMsg(
-    SuciM5GSMobileIdentity* suci, uint8_t* buffer) {
+int M5GSMobileIdentityMsg::EncodeSuciMobileIdentityMsg(uint8_t* buffer) {
+  SuciM5GSMobileIdentity* suci = &this->mobile_identity.suci;
   uint32_t encoded = 0;
 
-  *(buffer + encoded) =
+  *(buffer + encoded++) =
       0x00 | ((suci->spare2 & 0x80) << 7) | ((suci->supi_format & 0x07) << 4) |
       ((suci->spare1 & 0x01) << 3) | (suci->type_of_identity & 0x7);
-  encoded++;
   suci->suci_nai.assign((const char*)(buffer + encoded), suci->suci_nai.size());
 
   return encoded;
 };
 
 // Encode M5GSMobileIdentity IE
-int M5GSMobileIdentityMsg::EncodeM5GSMobileIdentityMsg(
-    M5GSMobileIdentityMsg* m5gs_mobile_identity, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSMobileIdentityMsg::EncodeM5GSMobileIdentityMsg(uint8_t iei,
+                                                       uint8_t* buffer,
+                                                       uint32_t len) {
   uint16_t* lenPtr;
   int encoded_rc = TLV_VALUE_DOESNT_MATCH;
   uint32_t encoded = 0;
@@ -467,32 +434,24 @@ int M5GSMobileIdentityMsg::EncodeM5GSMobileIdentityMsg(
   // Checking IEI and pointer
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, MOBILE_IDENTITY_MIN_LENGTH, len);
 
-  if (m5gs_mobile_identity->iei > 0) {
-    CHECK_IEI_ENCODER((unsigned char)iei, m5gs_mobile_identity->iei);
-    *buffer = iei;
-    encoded++;
-  } else
-    return 0;
+  if (this->iei <= 0) return 0;
+
+  CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
+  *(buffer + encoded++) = iei;
 
   lenPtr = (uint16_t*)(buffer + encoded);
   encoded += 2;
-  m5gs_mobile_identity->toi =
-      m5gs_mobile_identity->mobile_identity.guti.type_of_identity;
-  if (m5gs_mobile_identity->toi == M5GSMobileIdentityMsg_SUCI_IMSI) {
-    encoded_rc = EncodeImsiMobileIdentityMsg(
-        &m5gs_mobile_identity->mobile_identity.imsi, buffer + encoded);
-  } else if (m5gs_mobile_identity->toi == M5GSMobileIdentityMsg_IMEI) {
-    encoded_rc = EncodeImeiMobileIdentityMsg(
-        &m5gs_mobile_identity->mobile_identity.imei, buffer + encoded);
-  } else if (m5gs_mobile_identity->toi == M5GSMobileIdentityMsg_GUTI) {
-    encoded_rc = EncodeGutiMobileIdentityMsg(
-        &m5gs_mobile_identity->mobile_identity.guti, buffer + encoded);
-  } else if (m5gs_mobile_identity->toi == M5GSMobileIdentityMsg_TMSI) {
-    encoded_rc = EncodeTmsiMobileIdentityMsg(
-        &m5gs_mobile_identity->mobile_identity.tmsi, buffer + encoded);
-  } else if (m5gs_mobile_identity->toi == M5GSMobileIdentityMsg_IMEISV) {
-    encoded_rc = EncodeSuciMobileIdentityMsg(
-        &m5gs_mobile_identity->mobile_identity.suci, buffer + encoded);
+  this->toi = this->mobile_identity.guti.type_of_identity;
+  if (this->toi == M5GSMobileIdentityMsg_SUCI_IMSI) {
+    encoded_rc = EncodeImsiMobileIdentityMsg(buffer + encoded);
+  } else if (this->toi == M5GSMobileIdentityMsg_IMEI) {
+    encoded_rc = EncodeImeiMobileIdentityMsg(buffer + encoded);
+  } else if (this->toi == M5GSMobileIdentityMsg_GUTI) {
+    encoded_rc = EncodeGutiMobileIdentityMsg(buffer + encoded);
+  } else if (this->toi == M5GSMobileIdentityMsg_TMSI) {
+    encoded_rc = EncodeTmsiMobileIdentityMsg(buffer + encoded);
+  } else if (this->toi == M5GSMobileIdentityMsg_IMEISV) {
+    encoded_rc = EncodeSuciMobileIdentityMsg(buffer + encoded);
   }
 
   if (encoded_rc < 0) {

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSRegistrationResult.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSRegistrationResult.cpp
@@ -28,24 +28,24 @@ M5GSRegistrationResultMsg::M5GSRegistrationResultMsg(){};
 M5GSRegistrationResultMsg::~M5GSRegistrationResultMsg(){};
 
 // Decode 5GS Registration Result message and its IEs
-int M5GSRegistrationResultMsg::DecodeM5GSRegistrationResultMsg(
-    M5GSRegistrationResultMsg* m5gs_reg_result, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSRegistrationResultMsg::DecodeM5GSRegistrationResultMsg(uint8_t iei,
+                                                               uint8_t* buffer,
+                                                               uint32_t len) {
   // Not yet implemented, Will be supported POST MVC
   return 0;
 };
 
 // Encode 5GS Registration Result message and its IEs
-int M5GSRegistrationResultMsg::EncodeM5GSRegistrationResultMsg(
-    M5GSRegistrationResultMsg* m5gs_reg_result, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSRegistrationResultMsg::EncodeM5GSRegistrationResultMsg(uint8_t iei,
+                                                               uint8_t* buffer,
+                                                               uint32_t len) {
   uint8_t* lenPtr;
   uint32_t encoded = 0;
 
   /*
    * Checking IEI and pointer
    */
-  if (buffer == NULL) {
+  if (buffer == nullptr) {
     return TLV_BUFFER_NULL;
   }
 
@@ -54,17 +54,14 @@ int M5GSRegistrationResultMsg::EncodeM5GSRegistrationResultMsg(
   }
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER(iei, (unsigned char)m5gs_reg_result->iei);
-    *buffer = iei;
-    encoded++;
+    CHECK_IEI_ENCODER(iei, (unsigned char)this->iei);
+    *(buffer + encoded++) = iei;
   }
 
-  lenPtr = (buffer + encoded);
-  encoded++;
-  *(buffer + encoded) = ((m5gs_reg_result->spare & 0xf) << 0x4) |
-                        ((m5gs_reg_result->sms_allowed & 0x1) << 3) |
-                        (m5gs_reg_result->reg_result_val & 0x7);
-  encoded++;
+  lenPtr = (buffer + encoded++);
+  *(buffer + encoded++) = ((this->spare & 0xf) << 0x4) |
+                          ((this->sms_allowed & 0x1) << 3) |
+                          (this->reg_result_val & 0x7);
   *lenPtr = encoded - 1 - ((iei > 0) ? 1 : 0);
   return encoded;
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSRegistrationType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSRegistrationType.cpp
@@ -28,9 +28,9 @@ M5GSRegistrationTypeMsg::M5GSRegistrationTypeMsg(){};
 M5GSRegistrationTypeMsg::~M5GSRegistrationTypeMsg(){};
 
 // Decode M5GSRegistrationType Message
-int M5GSRegistrationTypeMsg::DecodeM5GSRegistrationTypeMsg(
-    M5GSRegistrationTypeMsg* m5gs_reg_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSRegistrationTypeMsg::DecodeM5GSRegistrationTypeMsg(uint8_t iei,
+                                                           uint8_t* buffer,
+                                                           uint32_t len) {
   int decoded = 0;
 
   // CHECKING IEI
@@ -38,15 +38,15 @@ int M5GSRegistrationTypeMsg::DecodeM5GSRegistrationTypeMsg(
     CHECK_IEI_DECODER((*buffer & 0xf0), iei);
   }
 
-  m5gs_reg_type->FOR = (*(buffer + decoded) >> 3) & 0x1;
-  m5gs_reg_type->type_val = *(buffer + decoded) & 0x7;
+  this->FOR = (*(buffer + decoded) >> 3) & 0x1;
+  this->type_val = *(buffer + decoded) & 0x7;
   return decoded;
 };
 
 // Encode M5GSRegistrationType Message
-int M5GSRegistrationTypeMsg::EncodeM5GSRegistrationTypeMsg(
-    M5GSRegistrationTypeMsg* m5gs_reg_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GSRegistrationTypeMsg::EncodeM5GSRegistrationTypeMsg(uint8_t iei,
+                                                           uint8_t* buffer,
+                                                           uint32_t len) {
   // Will be supported POST MVC
   return 0;
 };

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSSCMode.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSSCMode.cpp
@@ -28,41 +28,38 @@ SSCModeMsg::SSCModeMsg(){};
 SSCModeMsg::~SSCModeMsg(){};
 
 // Decode SSCMode IE
-int SSCModeMsg::DecodeSSCModeMsg(SSCModeMsg* ssc_mode, uint8_t iei,
-                                 uint8_t* buffer, uint32_t len) {
+int SSCModeMsg::DecodeSSCModeMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   int decoded = 0;
 
   // Storing the IEI Information
   if (iei > 0) {
-    ssc_mode->iei = (*buffer & 0xf0) >> 4;
+    this->iei = (*buffer & 0xf0) >> 4;
     decoded++;
   }
 
   if (iei > 0) {
-    ssc_mode->mode_val = (*buffer & 0x07);
+    this->mode_val = (*buffer & 0x07);
   } else {
-    ssc_mode->mode_val = (*buffer >> 4) & 0x07;
+    this->mode_val = (*buffer >> 4) & 0x07;
   }
 
   return decoded;
 };
 
 // Encode SSCMode IE
-int SSCModeMsg::EncodeSSCModeMsg(SSCModeMsg* ssc_mode, uint8_t iei,
-                                 uint8_t* buffer, uint32_t len) {
+int SSCModeMsg::EncodeSSCModeMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   int encoded = 0;
 
   // CHECKING IEI
   if (iei > 0) {
-    CHECK_IEI_ENCODER((uint8_t)iei,
-                      (uint8_t)(0x00 | (ssc_mode->iei & 0x0f) << 4));
-    *buffer = (ssc_mode->iei & 0x0f) << 4;
+    CHECK_IEI_ENCODER((uint8_t)iei, (uint8_t)(0x00 | (this->iei & 0x0f) << 4));
+    *buffer = (this->iei & 0x0f) << 4;
     encoded++;
   }
   if (iei > 0) {
-    *buffer = 0x00 | (*buffer & 0xf0) | (ssc_mode->mode_val & 0x07);
+    *buffer = 0x00 | (*buffer & 0xf0) | (this->mode_val & 0x07);
   } else {
-    *buffer = 0x00 | (*buffer & 0x0f) | ((ssc_mode->mode_val & 0x07) << 4);
+    *buffer = 0x00 | (*buffer & 0x0f) | ((this->mode_val & 0x07) << 4);
   }
 
   return (encoded);

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSecurityHeaderType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSecurityHeaderType.cpp
@@ -20,24 +20,20 @@ SecurityHeaderTypeMsg::SecurityHeaderTypeMsg(){};
 SecurityHeaderTypeMsg::~SecurityHeaderTypeMsg(){};
 
 // Decode SecurityHeaderType IE
-int SecurityHeaderTypeMsg::DecodeSecurityHeaderTypeMsg(
-    SecurityHeaderTypeMsg* sec_header_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int SecurityHeaderTypeMsg::DecodeSecurityHeaderTypeMsg(uint8_t iei,
+                                                       uint8_t* buffer,
+                                                       uint32_t len) {
   int decoded = 0;
-
-  sec_header_type->sec_hdr = *(buffer)&0xf;
-  decoded++;
+  this->sec_hdr = *(buffer + decoded++) & 0xf;
   return (decoded);
 };
 
 // Encode SecurityHeaderType IE
-int SecurityHeaderTypeMsg::EncodeSecurityHeaderTypeMsg(
-    SecurityHeaderTypeMsg* sec_header_type, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int SecurityHeaderTypeMsg::EncodeSecurityHeaderTypeMsg(uint8_t iei,
+                                                       uint8_t* buffer,
+                                                       uint32_t len) {
   int encoded = 0;
-
-  *(buffer) = sec_header_type->sec_hdr & 0xf;
-  encoded++;
+  *(buffer + encoded++) = this->sec_hdr & 0xf;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GServiceType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GServiceType.cpp
@@ -21,23 +21,18 @@ ServiceTypeMsg::ServiceTypeMsg(){};
 ServiceTypeMsg::~ServiceTypeMsg(){};
 
 // Decode ServiceType IE
-int ServiceTypeMsg::DecodeServiceTypeMsg(ServiceTypeMsg* svc_type, uint8_t iei,
-                                         uint8_t* buffer, uint32_t len) {
+int ServiceTypeMsg::DecodeServiceTypeMsg(uint8_t iei, uint8_t* buffer,
+                                         uint32_t len) {
   int decoded = 0;
-
-  svc_type->service_type_value = ((*buffer & 0xf0) >> 4);
-
+  this->service_type_value = ((*buffer & 0xf0) >> 4);
   return (decoded);
 };
 
 // Encode ServiceType IE
-int ServiceTypeMsg::EncodeServiceTypeMsg(ServiceTypeMsg* svc_type, uint8_t iei,
-                                         uint8_t* buffer, uint32_t len) {
+int ServiceTypeMsg::EncodeServiceTypeMsg(uint8_t iei, uint8_t* buffer,
+                                         uint32_t len) {
   int encoded = 0;
-
-  *buffer = svc_type->service_type_value & 0x0f;
-  encoded++;
-
+  *(buffer + encoded++) = this->service_type_value & 0x0f;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSessionAMBR.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSessionAMBR.cpp
@@ -26,29 +26,27 @@ SessionAMBRMsg::SessionAMBRMsg() {}
 SessionAMBRMsg::~SessionAMBRMsg() {}
 
 // Decode SessionAMBR IE
-int SessionAMBRMsg::DecodeSessionAMBRMsg(SessionAMBRMsg* session_ambr,
-                                         uint8_t iei, uint8_t* buffer,
+int SessionAMBRMsg::DecodeSessionAMBRMsg(uint8_t iei, uint8_t* buffer,
                                          uint32_t len) {
   int decoded = 0;
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer, AMBR_MIN_LEN, len);
 
   if (iei > 0) {
-    session_ambr->iei = *buffer;
-    CHECK_IEI_DECODER((unsigned char)iei, session_ambr->iei);
+    this->iei = *buffer;
+    CHECK_IEI_DECODER((unsigned char)iei, this->iei);
     decoded++;
   }
 
-  IES_DECODE_U8(buffer, decoded, session_ambr->length);
-  IES_DECODE_U8(buffer, decoded, session_ambr->dl_unit);
-  IES_DECODE_U16(buffer, decoded, session_ambr->dl_session_ambr);
-  IES_DECODE_U8(buffer, decoded, session_ambr->ul_unit);
-  IES_DECODE_U16(buffer, decoded, session_ambr->ul_session_ambr);
+  IES_DECODE_U8(buffer, decoded, this->length);
+  IES_DECODE_U8(buffer, decoded, this->dl_unit);
+  IES_DECODE_U16(buffer, decoded, this->dl_session_ambr);
+  IES_DECODE_U8(buffer, decoded, this->ul_unit);
+  IES_DECODE_U16(buffer, decoded, this->ul_session_ambr);
   return decoded;
 }
 
 // Encode SessionAMBR IE
-int SessionAMBRMsg::EncodeSessionAMBRMsg(SessionAMBRMsg* session_ambr,
-                                         uint8_t iei, uint8_t* buffer,
+int SessionAMBRMsg::EncodeSessionAMBRMsg(uint8_t iei, uint8_t* buffer,
                                          uint32_t len) {
   uint8_t* lenPtr;
   uint32_t encoded = 0;
@@ -57,24 +55,24 @@ int SessionAMBRMsg::EncodeSessionAMBRMsg(SessionAMBRMsg* session_ambr,
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, AMBR_MIN_LEN, len);
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER((unsigned char)iei, session_ambr->iei);
+    CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
     *buffer = iei;
     encoded++;
   }
 
   lenPtr = reinterpret_cast<uint8_t*>(buffer + encoded);
-  *(buffer + encoded) = session_ambr->length;
+  *(buffer + encoded) = this->length;
   encoded++;
 
-  *(buffer + encoded) = session_ambr->dl_unit;
+  *(buffer + encoded) = this->dl_unit;
   encoded++;
 
-  IES_ENCODE_U16(buffer, encoded, session_ambr->dl_session_ambr);
+  IES_ENCODE_U16(buffer, encoded, this->dl_session_ambr);
 
-  *(buffer + encoded) = session_ambr->ul_unit;
+  *(buffer + encoded) = this->ul_unit;
   encoded++;
 
-  IES_ENCODE_U16(buffer, encoded, session_ambr->ul_session_ambr);
+  IES_ENCODE_U16(buffer, encoded, this->ul_session_ambr);
   *lenPtr = encoded - 1 - ((iei > 0) ? 1 : 0);
 
   return encoded;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSpareHalfOctet.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSpareHalfOctet.cpp
@@ -16,26 +16,22 @@
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h"
 
 namespace magma5g {
-SpareHalfOctetMsg::SpareHalfOctetMsg(){};
+SpareHalfOctetMsg::SpareHalfOctetMsg() { this->spare = 0; };
 SpareHalfOctetMsg::~SpareHalfOctetMsg(){};
 
 // Decode SpareHalfOctet IE
-int SpareHalfOctetMsg::DecodeSpareHalfOctetMsg(
-    SpareHalfOctetMsg* spare_half_octet, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int SpareHalfOctetMsg::DecodeSpareHalfOctetMsg(uint8_t iei, uint8_t* buffer,
+                                               uint32_t len) {
   int decoded = 0;
-
-  spare_half_octet->spare = (*buffer & 0xf0) >> 4;
+  this->spare = (*buffer & 0xf0) >> 4;
   return (decoded);
 };
 
 // Encode SpareHalfOctet IE
-int SpareHalfOctetMsg::EncodeSpareHalfOctetMsg(
-    SpareHalfOctetMsg* spare_half_octet, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int SpareHalfOctetMsg::EncodeSpareHalfOctetMsg(uint8_t iei, uint8_t* buffer,
+                                               uint32_t len) {
   int encoded = 0;
-
-  *(buffer) = 0x00 | (spare_half_octet->spare & 0xf) << 4;
+  *(buffer) = 0x00 | (this->spare & 0xf) << 4;
   return (encoded);
 };
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GTAIList.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GTAIList.cpp
@@ -25,43 +25,32 @@ TAIListMsg::TAIListMsg(){};
 
 TAIListMsg::~TAIListMsg(){};
 
-int TAIListMsg::EncodeTAIListMsg(TAIListMsg* TAIList, uint8_t iei,
-                                 uint8_t* buffer, uint32_t len) {
+int TAIListMsg::EncodeTAIListMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   uint8_t encoded = 0;
 
   if (iei > 0) {
-    CHECK_IEI_ENCODER(iei, (unsigned char)TAIList->iei);
-    *buffer = iei;
-    encoded++;
+    CHECK_IEI_ENCODER(iei, (unsigned char)this->iei);
+    *(buffer + encoded++) = iei;
   }
-  *(buffer + encoded) = TAIList->len;
-  encoded++;
+  *(buffer + encoded++) = this->len;
 
-  *(buffer + encoded) = 0x00 | ((TAIList->list_type & 0x03) << 5) |
-                        (TAIList->num_elements & 0x1f);
-  encoded++;
-  *(buffer + encoded) =
-      0x00 | ((TAIList->mcc_digit2 & 0x0f) << 4) | (TAIList->mcc_digit1 & 0x0f);
-  encoded++;
-  *(buffer + encoded) =
-      0x00 | ((TAIList->mnc_digit3 & 0x0f) << 4) | (TAIList->mcc_digit3 & 0x0f);
-  encoded++;
-  *(buffer + encoded) =
-      0x00 | ((TAIList->mnc_digit2 & 0x0f) << 4) | (TAIList->mnc_digit1 & 0x0f);
-  encoded++;
+  *(buffer + encoded++) =
+      0x00 | ((this->list_type & 0x03) << 5) | (this->num_elements & 0x1f);
+  *(buffer + encoded++) =
+      0x00 | ((this->mcc_digit2 & 0x0f) << 4) | (this->mcc_digit1 & 0x0f);
+  *(buffer + encoded++) =
+      0x00 | ((this->mnc_digit3 & 0x0f) << 4) | (this->mcc_digit3 & 0x0f);
+  *(buffer + encoded++) =
+      0x00 | ((this->mnc_digit2 & 0x0f) << 4) | (this->mnc_digit1 & 0x0f);
 
-  *(buffer + encoded) = TAIList->tac[0];
-  encoded++;
-  *(buffer + encoded) = TAIList->tac[1];
-  encoded++;
-  *(buffer + encoded) = TAIList->tac[2];
-  encoded++;
+  *(buffer + encoded++) = this->tac[0];
+  *(buffer + encoded++) = this->tac[1];
+  *(buffer + encoded++) = this->tac[2];
 
   return (encoded);
 }
 
-int TAIListMsg::DecodeTAIListMsg(TAIListMsg* TAIList, uint8_t iei,
-                                 uint8_t* buffer, uint32_t len) {
+int TAIListMsg::DecodeTAIListMsg(uint8_t iei, uint8_t* buffer, uint32_t len) {
   return 0;
 }
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUESecurityCapability.cpp
@@ -28,9 +28,9 @@ namespace magma5g {
 UESecurityCapabilityMsg::UESecurityCapabilityMsg(){};
 UESecurityCapabilityMsg::~UESecurityCapabilityMsg(){};
 
-int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
-    UESecurityCapabilityMsg* ue_sec_capability, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(uint8_t iei,
+                                                           uint8_t* buffer,
+                                                           uint32_t len) {
   int decoded = 0;
   uint8_t type_len = sizeof(uint8_t);
   uint8_t length_len = sizeof(uint8_t);
@@ -38,75 +38,74 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
   // Checking IEI and pointer
   if (iei > 0) {
     CHECK_IEI_DECODER(iei, (unsigned char)*buffer);
-    ue_sec_capability->iei = iei;
+    this->iei = iei;
     decoded++;
   }
 
   CHECK_PDU_POINTER_AND_LENGTH_DECODER(buffer,
                                        UE_SECURITY_CAPABILITY_MIN_LENGTH, len);
 
-  ue_sec_capability->length = *(buffer + decoded);
-  decoded++;
+  this->length = *(buffer + decoded++);
 
-  if (ue_sec_capability->length <= 0) return (decoded);
+  if (this->length <= 0) return (decoded);
 
   // 5GS encryption algorithms
   ea = *(buffer + decoded);
-  ue_sec_capability->ea0 = (ea >> 7) & 0x1;
-  ue_sec_capability->ea1 = (ea >> 6) & 0x1;
-  ue_sec_capability->ea2 = (ea >> 5) & 0x1;
-  ue_sec_capability->ea3 = (ea >> 4) & 0x1;
-  ue_sec_capability->ea4 = (ea >> 3) & 0x1;
-  ue_sec_capability->ea5 = (ea >> 2) & 0x1;
-  ue_sec_capability->ea6 = (ea >> 1) & 0x1;
-  ue_sec_capability->ea7 = ea & 0x1;
+  this->ea0 = (ea >> 7) & 0x1;
+  this->ea1 = (ea >> 6) & 0x1;
+  this->ea2 = (ea >> 5) & 0x1;
+  this->ea3 = (ea >> 4) & 0x1;
+  this->ea4 = (ea >> 3) & 0x1;
+  this->ea5 = (ea >> 2) & 0x1;
+  this->ea6 = (ea >> 1) & 0x1;
+  this->ea7 = ea & 0x1;
   decoded++;
 
   // 5GS integrity algorithm
   ia = *(buffer + decoded);
-  ue_sec_capability->ia0 = (ia >> 7) & 0x1;
-  ue_sec_capability->ia1 = (ia >> 6) & 0x1;
-  ue_sec_capability->ia2 = (ia >> 5) & 0x1;
-  ue_sec_capability->ia3 = (ia >> 4) & 0x1;
-  ue_sec_capability->ia4 = (ia >> 3) & 0x1;
-  ue_sec_capability->ia5 = (ia >> 2) & 0x1;
-  ue_sec_capability->ia6 = (ia >> 1) & 0x1;
-  ue_sec_capability->ia7 = ia & 0x1;
+  this->ia0 = (ia >> 7) & 0x1;
+  this->ia1 = (ia >> 6) & 0x1;
+  this->ia2 = (ia >> 5) & 0x1;
+  this->ia3 = (ia >> 4) & 0x1;
+  this->ia4 = (ia >> 3) & 0x1;
+  this->ia5 = (ia >> 2) & 0x1;
+  this->ia6 = (ia >> 1) & 0x1;
+  this->ia7 = ia & 0x1;
   decoded++;
 
   // If any optional buffers are present skip it.
   // 2 = 1 Byte for type + 1 Byte for length
 
-  if (ue_sec_capability->length > (decoded - (type_len + length_len))) {
+  if (this->length > (decoded - (type_len + length_len))) {
     // 5GS encryption algorithms
-    ue_sec_capability->eea0 = (*(buffer + decoded) >> 7) & 0x1;
-    ue_sec_capability->ea1_128 = (*(buffer + decoded) >> 6) & 0x1;
-    ue_sec_capability->ea2_128 = (*(buffer + decoded) >> 5) & 0x1;
-    ue_sec_capability->ea3_128 = (*(buffer + decoded) >> 4) & 0x1;
-    ue_sec_capability->eea4 = (*(buffer + decoded) >> 3) & 0x1;
-    ue_sec_capability->eea5 = (*(buffer + decoded) >> 2) & 0x1;
-    ue_sec_capability->eea6 = (*(buffer + decoded) >> 1) & 0x1;
-    ue_sec_capability->eea7 = *(buffer + decoded) & 0x1;
+    this->eea0 = (*(buffer + decoded) >> 7) & 0x1;
+    this->ea1_128 = (*(buffer + decoded) >> 6) & 0x1;
+    this->ea2_128 = (*(buffer + decoded) >> 5) & 0x1;
+    this->ea3_128 = (*(buffer + decoded) >> 4) & 0x1;
+    this->eea4 = (*(buffer + decoded) >> 3) & 0x1;
+    this->eea5 = (*(buffer + decoded) >> 2) & 0x1;
+    this->eea6 = (*(buffer + decoded) >> 1) & 0x1;
+    this->eea7 = *(buffer + decoded) & 0x1;
     decoded++;
 
     // 5GS integrity algorithm
-    ue_sec_capability->eia0 = (*(buffer + decoded) >> 7) & 0x1;
-    ue_sec_capability->eia1_128 = (*(buffer + decoded) >> 6) & 0x1;
-    ue_sec_capability->eia2_128 = (*(buffer + decoded) >> 5) & 0x1;
-    ue_sec_capability->eia3_128 = (*(buffer + decoded) >> 4) & 0x1;
-    ue_sec_capability->eia4 = (*(buffer + decoded) >> 3) & 0x1;
-    ue_sec_capability->eia5 = (*(buffer + decoded) >> 2) & 0x1;
-    ue_sec_capability->eia6 = (*(buffer + decoded) >> 1) & 0x1;
-    ue_sec_capability->eia7 = *(buffer + decoded) & 0x1;
+    this->eia0 = (*(buffer + decoded) >> 7) & 0x1;
+    this->eia1_128 = (*(buffer + decoded) >> 6) & 0x1;
+    this->eia2_128 = (*(buffer + decoded) >> 5) & 0x1;
+    this->eia3_128 = (*(buffer + decoded) >> 4) & 0x1;
+    this->eia4 = (*(buffer + decoded) >> 3) & 0x1;
+    this->eia5 = (*(buffer + decoded) >> 2) & 0x1;
+    this->eia6 = (*(buffer + decoded) >> 1) & 0x1;
+    this->eia7 = *(buffer + decoded) & 0x1;
     decoded++;
 
     // Skipping the remaining bytes as not supported
-    if (ue_sec_capability->length > (decoded - (type_len + length_len))) {
+    if (this->length > (decoded - (type_len + length_len))) {
       // The length of the bytes skipped
       uint8_t additional_ue_sec_cap_length =
-          ue_sec_capability->length - (decoded - (type_len + length_len));
+          this->length - (decoded - (type_len + length_len));
       decoded += additional_ue_sec_cap_length;
-      ue_sec_capability->length -= additional_ue_sec_cap_length;
+      this->length -= additional_ue_sec_cap_length;
     }
   }
 
@@ -114,68 +113,50 @@ int UESecurityCapabilityMsg::DecodeUESecurityCapabilityMsg(
 };
 
 // Encode UE Security Capability
-int UESecurityCapabilityMsg::EncodeUESecurityCapabilityMsg(
-    UESecurityCapabilityMsg* ue_sec_capability, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int UESecurityCapabilityMsg::EncodeUESecurityCapabilityMsg(uint8_t iei,
+                                                           uint8_t* buffer,
+                                                           uint32_t len) {
   int encoded = 0;
 
   // Checking IEI and pointer
   if (iei > 0) {
-    CHECK_IEI_ENCODER((unsigned char)iei, ue_sec_capability->iei);
-    *buffer = iei;
-    encoded++;
+    CHECK_IEI_ENCODER((unsigned char)iei, this->iei);
+    *(buffer + encoded++) = iei;
   }
 
   CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer,
                                        UE_SECURITY_CAPABILITY_MIN_LENGTH, len);
 
-  *(buffer + encoded) = ue_sec_capability->length;
-  encoded++;
+  *(buffer + encoded++) = this->length;
 
   // 5GS encryption algorithms
-  *(buffer + encoded) = 0x00 | ((ue_sec_capability->ea0 & 0x1) << 7) |
-                        ((ue_sec_capability->ea1 & 0x1) << 6) |
-                        ((ue_sec_capability->ea2 & 0x1) << 5) |
-                        ((ue_sec_capability->ea3 & 0x1) << 4) |
-                        ((ue_sec_capability->ea4 & 0x1) << 3) |
-                        ((ue_sec_capability->ea5 & 0x1) << 2) |
-                        ((ue_sec_capability->ea6 & 0x1) << 1) |
-                        ((ue_sec_capability->ea7) & 0x1);
-  encoded++;
+  *(buffer + encoded++) = 0x00 | ((this->ea0 & 0x1) << 7) |
+                          ((this->ea1 & 0x1) << 6) | ((this->ea2 & 0x1) << 5) |
+                          ((this->ea3 & 0x1) << 4) | ((this->ea4 & 0x1) << 3) |
+                          ((this->ea5 & 0x1) << 2) | ((this->ea6 & 0x1) << 1) |
+                          ((this->ea7) & 0x1);
 
   // 5GS integrity algorithms
-  *(buffer + encoded) = 0x00 | ((ue_sec_capability->ia0 & 0x1) << 7) |
-                        ((ue_sec_capability->ia1 & 0x1) << 6) |
-                        ((ue_sec_capability->ia2 & 0x1) << 5) |
-                        ((ue_sec_capability->ia3 & 0x1) << 4) |
-                        ((ue_sec_capability->ia4 & 0x1) << 3) |
-                        ((ue_sec_capability->ia5 & 0x1) << 2) |
-                        ((ue_sec_capability->ia6 & 0x1) << 1) |
-                        ((ue_sec_capability->ia7) & 0x1);
-  encoded++;
+  *(buffer + encoded++) = 0x00 | ((this->ia0 & 0x1) << 7) |
+                          ((this->ia1 & 0x1) << 6) | ((this->ia2 & 0x1) << 5) |
+                          ((this->ia3 & 0x1) << 4) | ((this->ia4 & 0x1) << 3) |
+                          ((this->ia5 & 0x1) << 2) | ((this->ia6 & 0x1) << 1) |
+                          ((this->ia7) & 0x1);
 
-  if (ue_sec_capability->length > 2) {
+  if (this->length > 2) {
     // 5GS encryption algorithms
-    *(buffer + encoded) = 0x00 | ((ue_sec_capability->eea0 & 0x1) << 7) |
-                          ((ue_sec_capability->ea1_128 & 0x1) << 6) |
-                          ((ue_sec_capability->ea2_128 & 0x1) << 5) |
-                          ((ue_sec_capability->ea3_128 & 0x1) << 4) |
-                          ((ue_sec_capability->eea4 & 0x1) << 3) |
-                          ((ue_sec_capability->eea5 & 0x1) << 2) |
-                          ((ue_sec_capability->eea6 & 0x1) << 1) |
-                          ((ue_sec_capability->eea7) & 0x1);
-    encoded++;
+    *(buffer + encoded++) =
+        0x00 | ((this->eea0 & 0x1) << 7) | ((this->ea1_128 & 0x1) << 6) |
+        ((this->ea2_128 & 0x1) << 5) | ((this->ea3_128 & 0x1) << 4) |
+        ((this->eea4 & 0x1) << 3) | ((this->eea5 & 0x1) << 2) |
+        ((this->eea6 & 0x1) << 1) | ((this->eea7) & 0x1);
 
     // 5GS integrity algorithms
-    *(buffer + encoded) = 0x00 | ((ue_sec_capability->eia0 & 0x1) << 7) |
-                          ((ue_sec_capability->eia1_128 & 0x1) << 6) |
-                          ((ue_sec_capability->eia2_128 & 0x1) << 5) |
-                          ((ue_sec_capability->eia3_128 & 0x1) << 4) |
-                          ((ue_sec_capability->eia4 & 0x1) << 3) |
-                          ((ue_sec_capability->eia5 & 0x1) << 2) |
-                          ((ue_sec_capability->eia6 & 0x1) << 1) |
-                          ((ue_sec_capability->eia7) & 0x1);
-    encoded++;
+    *(buffer + encoded++) =
+        0x00 | ((this->eia0 & 0x1) << 7) | ((this->eia1_128 & 0x1) << 6) |
+        ((this->eia2_128 & 0x1) << 5) | ((this->eia3_128 & 0x1) << 4) |
+        ((this->eia4 & 0x1) << 3) | ((this->eia5 & 0x1) << 2) |
+        ((this->eia6 & 0x1) << 1) | ((this->eia7) & 0x1);
   }
 
   return encoded;

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUplinkDataStatus.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUplinkDataStatus.cpp
@@ -20,41 +20,28 @@ namespace magma5g {
 M5GUplinkDataStatus::M5GUplinkDataStatus(){};
 M5GUplinkDataStatus::~M5GUplinkDataStatus(){};
 
-int M5GUplinkDataStatus::EncodeUplinkDataStatus(
-    M5GUplinkDataStatus* uplinkDataStatus, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GUplinkDataStatus::EncodeUplinkDataStatus(uint8_t iei, uint8_t* buffer,
+                                                uint32_t len) {
   int encoded = 0;
-  if (uplinkDataStatus->iei) {
-    *(buffer + encoded) = uplinkDataStatus->iei;
-    encoded++;
-    *(buffer + encoded) = uplinkDataStatus->len;
-    encoded++;
-    *(buffer + encoded) = (uint8_t)(uplinkDataStatus->uplinkDataStatus & 0xFF);
-    encoded++;
-    *(buffer + encoded) =
-        (uint8_t)(((uplinkDataStatus->uplinkDataStatus >> 8) & 0xFF));
-    encoded++;
+  if (this->iei) {
+    *(buffer + encoded++) = this->iei;
+    *(buffer + encoded++) = this->len;
+    *(buffer + encoded++) = (uint8_t)(this->uplinkDataStatus & 0xFF);
+    *(buffer + encoded++) = (uint8_t)(((this->uplinkDataStatus >> 8) & 0xFF));
   }
 
   return encoded;
 }
 
-int M5GUplinkDataStatus::DecodeUplinkDataStatus(
-    M5GUplinkDataStatus* uplinkDataStatus, uint8_t iei, uint8_t* buffer,
-    uint32_t len) {
+int M5GUplinkDataStatus::DecodeUplinkDataStatus(uint8_t iei, uint8_t* buffer,
+                                                uint32_t len) {
   int decoded = 0;
 
   if (iei > 0) {
-    uplinkDataStatus->iei = *buffer;
-    decoded++;
-
-    uplinkDataStatus->len = *(buffer + decoded);
-    decoded++;
-
-    uplinkDataStatus->uplinkDataStatus = *(buffer + decoded);
-    decoded++;
-    uplinkDataStatus->uplinkDataStatus |= (*(buffer + decoded) << 8);
-    decoded++;
+    this->iei = *(buffer + decoded++);
+    this->len = *(buffer + decoded++);
+    this->uplinkDataStatus = *(buffer + decoded++);
+    this->uplinkDataStatus |= (*(buffer + decoded++) << 8);
   }
 
   return decoded;

--- a/lte/gateway/c/core/oai/test/amf/util_nas5g_auth_fail_pkt.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_nas5g_auth_fail_pkt.cpp
@@ -23,8 +23,8 @@ bool decode_auth_failure_decode_msg(AuthenticationFailureMsg* auth_fail_request,
   uint8_t* decode_auth_fail_buffer =
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer));
 
-  if (auth_fail_request->DecodeAuthenticationFailureMsg(
-          auth_fail_request, decode_auth_fail_buffer, len) < 0) {
+  if (auth_fail_request->DecodeAuthenticationFailureMsg(decode_auth_fail_buffer,
+                                                        len) < 0) {
     decode_success = false;
   }
 

--- a/lte/gateway/c/core/oai/test/amf/util_nas5g_registration_pkt.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_nas5g_registration_pkt.cpp
@@ -25,8 +25,7 @@ bool decode_registration_request_msg(RegistrationRequestMsg* reg_request,
   uint8_t* decode_reg_buffer =
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer));
 
-  if (reg_request->DecodeRegistrationRequestMsg(reg_request, decode_reg_buffer,
-                                                len) < 0) {
+  if (reg_request->DecodeRegistrationRequestMsg(decode_reg_buffer, len) < 0) {
     decode_success = false;
   }
 
@@ -40,8 +39,7 @@ bool encode_registration_reject_msg(RegistrationRejectMsg* reg_reject,
   uint8_t* encode_reg_buffer =
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer));
 
-  if (reg_reject->EncodeRegistrationRejectMsg(reg_reject, encode_reg_buffer,
-                                              len) < 0) {
+  if (reg_reject->EncodeRegistrationRejectMsg(encode_reg_buffer, len) < 0) {
     encode_success = false;
   }
 
@@ -55,8 +53,7 @@ bool decode_registration_reject_msg(RegistrationRejectMsg* reg_reject,
   uint8_t* decode_reg_buffer =
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer));
 
-  if (reg_reject->DecodeRegistrationRejectMsg(reg_reject, decode_reg_buffer,
-                                              len) < 0) {
+  if (reg_reject->DecodeRegistrationRejectMsg(decode_reg_buffer, len) < 0) {
     decode_success = false;
   }
 

--- a/lte/gateway/c/core/oai/test/amf/util_nas5g_security_mode_reject_pkt.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_nas5g_security_mode_reject_pkt.cpp
@@ -23,8 +23,8 @@ bool decode_security_mode_reject_msg(SecurityModeRejectMsg* sm_reject,
   uint8_t* decode_security_mode_reject =
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer));
 
-  if (sm_reject->DecodeSecurityModeRejectMsg(
-          sm_reject, decode_security_mode_reject, len) < 0) {
+  if (sm_reject->DecodeSecurityModeRejectMsg(decode_security_mode_reject, len) <
+      0) {
     decode_success = false;
   }
 

--- a/lte/gateway/c/core/oai/test/amf/util_nas5g_service_request_pkt.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_nas5g_service_request_pkt.cpp
@@ -19,16 +19,14 @@ namespace magma5g {
 //  API for testing decode registration request
 bool decode_service_request_msg(ServiceRequestMsg* reg_request,
                                 const uint8_t* buffer, uint32_t len) {
-  bool decode_success = true;
   uint8_t* decode_reg_buffer =
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer));
 
-  if (reg_request->DecodeServiceRequestMsg(reg_request, decode_reg_buffer,
-                                           len) < 0) {
-    decode_success = false;
+  if (reg_request->DecodeServiceRequestMsg(decode_reg_buffer, len) < 0) {
+    return false;
   }
 
-  return (decode_success);
+  return true;
 }
 
 }  // namespace magma5g

--- a/lte/gateway/c/core/oai/test/amf/util_nas5g_ul_nas_pdu_decode.cpp
+++ b/lte/gateway/c/core/oai/test/amf/util_nas5g_ul_nas_pdu_decode.cpp
@@ -23,8 +23,7 @@ bool decode_ul_nas_transport_msg(ULNASTransportMsg* ul_nas_pdu,
   uint8_t* decode_ul_nas_pdu_buffer =
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer));
 
-  if (ul_nas_pdu->DecodeULNASTransportMsg(ul_nas_pdu, decode_ul_nas_pdu_buffer,
-                                          len) < 0) {
+  if (ul_nas_pdu->DecodeULNASTransportMsg(decode_ul_nas_pdu_buffer, len) < 0) {
     decode_success = false;
   }
 
@@ -40,7 +39,7 @@ bool decode_ul_nas_deregister_request_msg(
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buffer));
 
   if (ul_nas_pdu->DecodeDeRegistrationRequestUEInitMsg(
-          ul_nas_pdu, decode_ul_nas_dereg_pdu_buffer, len) < 0) {
+          decode_ul_nas_dereg_pdu_buffer, len) < 0) {
     decode_success = false;
   }
 


### PR DESCRIPTION
Signed-off-by: Lucas Amaral <lucaaamaral@gmail.com>

refactor(amf): use 'this' instead of redundant object pointer in methods

## Summary

Removed redundant object pointers inside classes methods, replacing them with the `this` pointer.

## Test Plan

Tests were made by running the command below and checking the tests results.
```bash
bazel build lte/gateway/c/core:all && bazel test lte/gateway/c/core/oai/test/amf:all
[...]
INFO: Build completed successfully, 510 total actions
//lte/gateway/c/core/oai/test/amf:amf_algorithm_selection_test           PASSED in 0.7s
//lte/gateway/c/core/oai/test/amf:amf_common_utils_test                  PASSED in 0.7s
//lte/gateway/c/core/oai/test/amf:amf_encode_decode_test                 PASSED in 0.7s
//lte/gateway/c/core/oai/test/amf:amf_map_test                           PASSED in 0.7s
//lte/gateway/c/core/oai/test/amf:amf_procedures_test                    PASSED in 0.8s
//lte/gateway/c/core/oai/test/amf:amf_stateless_test                     PASSED in 0.7s
```

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations


