### PR TITLE
fix(subscriberdb): handle invalid curve point exceptions

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/crypto/EC.py
+++ b/lte/gateway/python/magma/subscriberdb/crypto/EC.py
@@ -185,8 +185,12 @@ class ECDH_SECP256R1(object):       # noqa: N801
         """
         generate_sharedkey - Generates shared key
         """
-        extpubkey = ec.EllipticCurvePublicKey.from_encoded_point(
-            curve=ec.SECP256R1(),
-            data=ext_pubkey,
-        )
+        try:
+            extpubkey = ec.EllipticCurvePublicKey.from_encoded_point(
+                curve=ec.SECP256R1(),
+                data=ext_pubkey,
+            )
+        except ValueError:
+            return None  # Invalid curve point received from UE
+
         return self.PrivKey.exchange(ec.ECDH(), extpubkey)

--- a/lte/gateway/python/magma/subscriberdb/crypto/ECIES.py
+++ b/lte/gateway/python/magma/subscriberdb/crypto/ECIES.py
@@ -159,7 +159,12 @@ class ECIES_HN(object):             # noqa: N801
         Returns:
             cleartext: decrypted mac
         """
-        shared_key = KDF(ue_pubkey, self.EC.generate_sharedkey(ue_pubkey))
+
+        ec_shared_key = self.EC.generate_sharedkey(ue_pubkey)
+        if ec_shared_key is None:
+            return None  # Invalid curve point detected
+
+        shared_key = KDF(ue_pubkey, ec_shared_key)
         aes_key, aes_nonce, aes_cnt, mac_key = (
             shared_key[:16],
             shared_key[16:24],


### PR DESCRIPTION
(cherry-picked from v1.9 patch)

When a "Profile B" SUCI (e.g., a SUCI using the secp256r1 EC algorithm) with an invalid curve point for its public key is passed to the subscriberdb, it passes the curve point to the `EllipticCurvePublicKey.from_encoded_point` function without checking the validity of the point. This function will raise a `ValueError` if a invalid curve point is received:

https://cryptography.io/en/latest/hazmat/primitives/asymmetric/ec/#cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point

...but this exception is not handled anywhere, so it will cause subscriberdb to crash.

This PR adds a try/except block to handle this case.

Note that this could be exploited by an adversary to carry out a remote, pre-auth denial of service attack against an entire cellular carrier network, as the subscriberdb could be repeatedly crashed by a user sending a malformed SUCI as part of their initial authentication.
