### PR TITLE
fix(orc8r): fix for error introduced in PR #15542 new ssl 

### DIFF
--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_nginx_proxy_ssl.conf.tpl
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_nginx_proxy_ssl.conf.tpl
@@ -1,7 +1,7 @@
 server {
   listen 443 ssl;
-  ssl_certificate /var/opt/magma/certs/nms/tls.crt;
-  ssl_certificate_key /var/opt/magma/certs/nms/tls.key;
+  ssl_certificate /etc/nginx/conf.d/nms_nginx.pem;
+  ssl_certificate_key /etc/nginx/conf.d/nms_nginx.key.pem;
   location / {
      proxy_pass http://magmalte:8081;
      proxy_set_header Host $http_host;


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

PR #15542 introduced an error into the file `orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_nginx_proxy_ssl.conf.tpl`. This PR reverses that error but maintains the `ssl directive` fix.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

The error caused the Orc8r `nms-nginx-proxy` pod to deploy with a certificate not found error. This problem was found, fixed, and tested during a deployment test of the v1.9 Orc8r. The output below shows the pod running with no errors.

```
kubectl get pods
NAME                                            READY   STATUS    RESTARTS   AGE
elasticsearch-master-0                          1/1     Running   0          41m
fluentd-7b5ffff8f8-n65r2                        1/1     Running   0          41m
haproxy-f9c95678b-h8b26                         1/1     Running   0          42m
nms-magmalte-69c86c4f4d-mnb4t                   1/1     Running   0          43m
nms-nginx-proxy-65bc67cd44-hqx9w                1/1     Running   0          43m
orc8r-accessd-7fd9544fbb-bkqbj                  1/1     Running   0          43m
orc8r-alertmanager-67c59fc8fd-2dj58             1/1     Running   0          43m
orc8r-alertmanager-configurer-b47b95b69-jstrf   1/1     Running   0          43m
orc8r-analytics-54976c7fb8-mhtkz                1/1     Running   0          43m
orc8r-base-acct-76b846d9bb-hcnc9                1/1     Running   0          42m
orc8r-bootstrapper-c68cf7b85-2xgkz              1/1     Running   0          43m
orc8r-certifier-69487b66c5-vswxw                1/1     Running   0          43m
orc8r-configurator-6ccdc6f7f9-6c5fj             1/1     Running   0          43m
orc8r-ctraced-6dc87dc598-m2zm7                  1/1     Running   0          43m
orc8r-cwf-587df88fc7-fqfw4                      1/1     Running   0          42m
orc8r-device-65fc669d49-6trv7                   1/1     Running   0          43m
orc8r-directoryd-5b6869f44d-6nfxc               1/1     Running   0          43m
orc8r-dispatcher-7474c948dd-jrr6b               1/1     Running   0          43m
orc8r-eventd-56b6cf6f48-s4p69                   1/1     Running   0          43m
orc8r-feg-97bb486c8-qtq26                       1/1     Running   0          42m
orc8r-feg-relay-5ff9d4c65c-b7nk7                1/1     Running   0          42m
orc8r-ha-6797774bc4-f9lts                       1/1     Running   0          42m
orc8r-health-7cc6bdcd7b-s9hsl                   1/1     Running   0          42m
orc8r-lte-774984f554-8cz6l                      1/1     Running   0          42m
orc8r-metricsd-77555b945f-8t2rg                 1/1     Running   0          43m
orc8r-nginx-5c8fcd9d-nrwh9                      1/1     Running   0          43m
orc8r-nprobe-58db6cbbfb-mrjnr                   1/1     Running   0          42m
orc8r-obsidian-7d8df5ddd7-8jh9p                 1/1     Running   0          43m
orc8r-orc8r-worker-857c76f669-qgmts             1/1     Running   0          43m
orc8r-orchestrator-6cc997f546-kk4px             1/1     Running   0          43m
orc8r-policydb-c6fb59c6f-ngcbr                  1/1     Running   0          42m
orc8r-prometheus-6d77968679-pck5l               1/1     Running   0          43m
orc8r-prometheus-cache-5d679b8847-jwhw7         1/1     Running   0          43m
orc8r-prometheus-configurer-5d54d6556-pp2bq     1/1     Running   0          43m
orc8r-service-registry-7579fd85f-z44x9          1/1     Running   0          43m
orc8r-smsd-59fdd45fc-7whxg                      1/1     Running   0          42m
orc8r-state-86ccd88f5b-nd9hx                    1/1     Running   0          43m
orc8r-streamer-5ccfd68897-jtczl                 1/1     Running   0          43m
orc8r-subscriberdb-86675bf755-s756p             1/1     Running   0          42m
orc8r-subscriberdb-cache-78f8d9698c-46vlm       1/1     Running   0          42m
orc8r-tenants-588585f955-59b7t                  1/1     Running   0          43m
orc8r-user-grafana-597dfff79-9zbqq              1/1     Running   0          43m
postgresql-0                                    1/1     Running   0          44m
```

Note that in order to realize this fix, the orc8r helm charts must be repackaged and pushed to an appropriate helm repository and pointed to in `magma/orc8r/cloud/helm/orc8r/Chart.yaml`  as in:

```
apiVersion: v2
appVersion: "1.9.0"
description: Helm chart for the Magma Orchestrator
name: orc8r
version: 1.9.0
home: https://linuxfoundation.jfrog.io/magma-docker-test
sources:
  - https://jblakley.github.io/magma-charts/
 ...
```


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
Helm repackaging can be done, for example, with this method:
```
export GITHUB_REPO=magma-charts
export GITHUB_REPO_URL=https://github.com
export GITHUB_USERNAME=<user-name>
export MAGMA_ROOT=~/magma
read -s -p "Enter Github Access Token: " GITHUB_ACCESS_TOKEN
export GITHUB_ACCESS_TOKEN
${MAGMA_ROOT}/orc8r/tools/helm/package.sh -d all
```



## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

