### PR TITLE
fix(magmad): restart options

### DIFF
--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -25,16 +25,21 @@ magma_services:
   - enodebd
   - sessiond
   - mme
+  - oai_mme
   - pipelined
-  - envoy_controller
+  - envoy_controller # not found in a docker install
   - redis
-  - dnsd
+  - dnsd # not found in a docker install
   - policydb
   - state
   - eventd
   - smsd
   - ctraced
   - health
+  - redirectd
+  - sctpd
+  - monitord
+  - connectiond
 #  - kernsnoopd
 # - liagentd
 

--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -66,6 +66,9 @@ services:
       DOCKER_REGISTRY: ${DOCKER_REGISTRY}
       DOCKER_USERNAME: ${DOCKER_USERNAME}
       DOCKER_PASSWORD: ${DOCKER_PASSWORD}
+    security_opt:
+      - apparmor=unconfined
+      - systempaths=unconfined
     command: >
       /bin/bash -c "
         /usr/bin/env python3 /usr/local/bin/generate_oai_config.py &&

--- a/lte/gateway/docker/docker-compose.yaml
+++ b/lte/gateway/docker/docker-compose.yaml
@@ -1,3 +1,4 @@
+---
 version: "3.7"
 
 # Standard logging for each service
@@ -56,7 +57,7 @@ services:
     <<: *pyservice
     container_name: magmad
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50052"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50052" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -78,7 +79,7 @@ services:
     <<: *pyservice
     container_name: redis
     healthcheck:
-      test: ["CMD", "redis-cli", "-p", "6380", "ping"]
+      test: [ "CMD", "redis-cli", "-p", "6380", "ping" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -93,7 +94,7 @@ services:
     depends_on:
       - redis
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50067"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50067" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -105,7 +106,7 @@ services:
     <<: *pyservice
     container_name: subscriberdb
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50051"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50051" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -117,12 +118,12 @@ services:
     <<: *pyservice
     container_name: enodebd
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "60055"]
+      test: [ "CMD", "nc", "-zv", "localhost", "60055" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
     cap_add:
-      - NET_ADMIN  # The container is invoking iptables and needs NET_ADMIN for that
+      - NET_ADMIN # The container is invoking iptables and needs NET_ADMIN for that
     environment:
       MAGMA_DEV_MODE: ${MAGMA_DEV_MODE}
     command: /usr/bin/env python3 -m magma.enodebd.main
@@ -131,7 +132,7 @@ services:
     <<: *pyservice
     container_name: state
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50074"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50074" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -147,7 +148,7 @@ services:
     depends_on:
       - redis
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50068"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50068" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -159,7 +160,7 @@ services:
     <<: *pyservice
     container_name: health
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50080"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50080" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -171,7 +172,7 @@ services:
     <<: *pyservice
     container_name: monitord
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50076"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50076" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -185,7 +186,7 @@ services:
     <<: *pyservice
     container_name: redirectd
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50071"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50071" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -195,7 +196,7 @@ services:
     <<: *pyservice
     container_name: smsd
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50078"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50078" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -207,7 +208,7 @@ services:
     <<: *pyservice
     container_name: control_proxy
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "8443"]
+      test: [ "CMD", "nc", "-zv", "localhost", "8443" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -222,7 +223,7 @@ services:
     <<: *pyservice
     container_name: ctraced
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50079"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50079" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -236,7 +237,7 @@ services:
     ulimits:
       core: -1
     healthcheck:
-      test: ["CMD", "test", "-S", "/tmp/sctpd_downstream.sock"]
+      test: [ "CMD", "test", "-S", "/tmp/sctpd_downstream.sock" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -251,7 +252,7 @@ services:
     <<: *cservice
     container_name: oai_mme
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50073"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50073" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -287,7 +288,7 @@ services:
       - NET_RAW
       - SYS_NICE
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50063"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50063" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -309,7 +310,7 @@ services:
     depends_on:
       - directoryd
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50065"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50065" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -324,20 +325,19 @@ services:
     <<: *pyservice
     container_name: mobilityd
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "60051"]
+      test: [ "CMD", "nc", "-zv", "localhost", "60051" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
     environment:
       MAGMA_DEV_MODE: ${MAGMA_DEV_MODE}
-    command:
-      sh -c "sleep 5 && /usr/bin/env python3 -m magma.mobilityd.main"
+    command: sh -c "sleep 5 && /usr/bin/env python3 -m magma.mobilityd.main"
 
   td-agent-bit:
     <<: *pyservice
     container_name: td-agent-bit
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "5140"]
+      test: [ "CMD", "nc", "-zv", "localhost", "5140" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -346,14 +346,13 @@ services:
     environment:
       MAGMA_DEV_MODE: ${MAGMA_DEV_MODE}
     command: >
-        /bin/bash -c "/usr/local/bin/generate_fluent_bit_config.py &&
-        /opt/td-agent-bit/bin/td-agent-bit -c /var/opt/magma/tmp/td-agent-bit.conf"
+      /bin/bash -c "/usr/local/bin/generate_fluent_bit_config.py && /opt/td-agent-bit/bin/td-agent-bit -c /var/opt/magma/tmp/td-agent-bit.conf"
 
   eventd:
     <<: *pyservice
     container_name: eventd
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50075"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50075" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -365,7 +364,7 @@ services:
     <<: *cservice
     container_name: connectiond
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50082"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50082" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -379,7 +378,7 @@ services:
     <<: *cservice
     container_name: liagentd
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50065"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50065" ]
       interval: "4s"
       timeout: "4s"
       retries: 3
@@ -393,7 +392,7 @@ services:
     image: ${DOCKER_REGISTRY}gateway_go${OPTIONAL_ARCH_POSTFIX}:${IMAGE_VERSION}
     container_name: envoy_controller
     healthcheck:
-      test: ["CMD", "nc", "-zv", "localhost", "50081"]
+      test: [ "CMD", "nc", "-zv", "localhost", "50081" ]
       interval: "4s"
       timeout: "4s"
       retries: 3

--- a/orc8r/gateway/python/magma/magmad/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/magmad/rpc_servicer.py
@@ -106,7 +106,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         """
         async def run_reboot():
             await asyncio.sleep(1)
-            os.system('echo b > /proc/sysrq-trigger')
+            os.system('/usr/bin/echo b > /proc/sysrq-trigger')
 
         logging.info("Remote reboot triggered! Rebooting gateway...")
         self._loop.create_task(run_reboot())

--- a/orc8r/gateway/python/magma/magmad/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/magmad/rpc_servicer.py
@@ -106,7 +106,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         """
         async def run_reboot():
             await asyncio.sleep(1)
-            os.system('reboot')
+            os.system('echo b > /proc/sysrq-trigger')
 
         logging.info("Remote reboot triggered! Rebooting gateway...")
         self._loop.create_task(run_reboot())


### PR DESCRIPTION
fix(magmad): restart options

## Summary

There were misbehaviors in the `Equipment -> Actions -> Restart services/Reboot`  from the nms:

- Restart AGW host machine is currently not working
- Restart AGW components is currently not working

During tests, it was found that:

- The “reboot” command was not available inside the docker container, hence the system not rebooting
- Six out of twenty-one components were not being restarted after the button was pressed

## Test Plan

Selecting for the **“restart“** option triggers a series of messages that results in the magmad component the below output:

```
INFO:root:Remote reboot triggered! Rebooting gateway...    
sh: 1: reboot: not found                                   
ERROR:root:GetServiceInfo Error for envoy_controller! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
```

This command is triggered by the `orc8r/gateway/python/magma/magmad/rpc_servicer.py:109` file which depends on the reboot command being installed in the magmad container.

Docker containers don't have the ability to restart the host system or control the host machine's processes, neither implement full OS.

The solution was to Replace the “reboot“ command to `echo b > /proc/sysrq-trigger` in the python script `orc8r/gateway/python/magma/magmad/rpc_servicer.py:109` and add the below lines to the magmad section on the compose file `lte/gateway/docker/docker-compose.yaml` or `/var/opt/magma/docker/docker-compose.yaml`:
```
    security_opt:
      - apparmor=unconfined
      - systempaths=unconfined
```
*Note: the command  `echo b > /proc/sysrq-trigger` might be too harsh on the machine, it might be interesting to examine for the advantages of other commands, such as  'echo _sub > /proc/sysrq-trigger'. I've tried using `_reisub` as commonly recommended, even `_sb` to assure the disks are being synchronized, but without success, so I left only with the `b` from reboot. Please let me know if this is enough or a better solution is needed.

Selecting for the **“restart services“** option triggers a series of messages that results in the magmad component the below output:

```
INFO:root:[SyncRPC] Got heartBeat from cloud                                                                          
ERROR:root:GetServiceInfo Error for envoy_controller! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
INFO:root:Checking for upgrade...                          
WARNING:root:magmad package_version config missing or set to default 0.0.0-0, skipping upgrade                        
INFO:root:Restarting following services: []                
Error response from daemon: No such container: mme         
Error response from daemon: No such container: envoy_controller                                                       
Error response from daemon: No such container: dnsd        
subscriberdb                                               
directoryd                                                 
enodebd                                                    
policydb                                                   
smsd                                                       
state                                                      
ctraced                                                    
eventd                                                     
health                                                     
ERROR:root:GetServiceInfo Error for subscriberdb! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for directoryd! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for enodebd! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for envoy_controller! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for policydb! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for state! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for eventd! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for smsd! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for ctraced! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for health! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
td-agent-bit                                               
pipelined                                                  
ERROR:root:[SyncRPC] Failing to forward request, err: Socket closed                                                   
WARNING:root:[SyncRPC] Transient gRPC error, retrying: Socket closed                                                  
control_proxy                                              
INFO:root:[SyncRPC] Opening stream to cloud                
INFO:root:[SyncRPC] Waiting for requests                   
ERROR:root:[SyncRPC] Failing to forward request, err: failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:[SyncRPC] gRPC error: failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused, reconnecting to cloud.
mobilityd                                                  
sessiond                                                   
redis                                                      
INFO:root:[SyncRPC] Opening stream to cloud                
INFO:root:[SyncRPC] Waiting for requests                   
ERROR:root:[SyncRPC] Failing to forward request, err: failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:[SyncRPC] gRPC error: failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused, reconnecting to cloud.
INFO:root:[SyncRPC] Opening stream to cloud                
INFO:root:[SyncRPC] Waiting for requests                   
ERROR:root:GetServiceInfo Error for mobilityd! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for envoy_controller! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetOperationalStates Error for mobilityd! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetOperationalStates Error for envoy_controller! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
INFO:root:Checkin Successful! Successfully sent states to the cloud!                                                  
INFO:root:Processing config update agw-001                 
WARNING:root:Orchestrator version:  not valid              
ERROR:root:GetServiceInfo Error for envoy_controller! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for envoy_controller! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
ERROR:root:GetServiceInfo Error for envoy_controller! [StatusCode.UNAVAILABLE] failed to connect to all addresses; last error: UNKNOWN: Failed to connect to remote host: Connection refused
 ```

It is possible to recognize the attempt to restart services from the lines:

```
INFO:root:Restarting following services: []                                                                                                                                                                                                 
Error response from daemon: No such container: mme         
Error response from daemon: No such container: envoy_controller                                                       
Error response from daemon: No such container: dnsd        
subscriberdb                                               
directoryd                                                 
enodebd                                                    
policydb                                                   
smsd                                                       
state                                                      
ctraced                                                    
eventd                                                     
health  
td-agent-bit                                               
pipelined  
control_proxy 
mobilityd                                                  
sessiond                                                   
redis  
```

It is possible to see that a couple of services failed to be found from the lines:

```
Error response from daemon: No such container: mme         
Error response from daemon: No such container: envoy_controller                                                       
Error response from daemon: No such container: dnsd   
```

And it is possible to confirm that some of the services has been restarted from the docker compose ps command:

```
connectiond     linuxfoundation.jfrog.io/magma-docker/agw_gateway_c:1.8.0        "/usr/local/bin/conn…"    connectiond     3 days ago   Up 22 hours (healthy)              
control_proxy   linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "sh -c '/usr/local/b…"    control_proxy   3 days ago   Up 19 seconds (health: starting)   
ctraced         linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    ctraced         3 days ago   Up 27 seconds (health: starting)   
directoryd      linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    directoryd      3 days ago   Up 29 seconds (health: starting)   
enodebd         linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    enodebd         3 days ago   Up 29 seconds (health: starting)   
eventd          linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    eventd          3 days ago   Up 27 seconds (health: starting)   
health          linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    health          3 days ago   Up 27 seconds (health: starting)   
magmad          linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/bin/bash -c '\n  /u…"   magmad          3 days ago   Up 22 hours                        
mobilityd       linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "sh -c 'sleep 5 && /…"    mobilityd       3 days ago   Up 19 seconds (health: starting)   
monitord        linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    monitord        3 days ago   Up 22 hours (healthy)              
oai_mme         linuxfoundation.jfrog.io/magma-docker/agw_gateway_c:1.8.0        "sh -c '/usr/local/b…"    oai_mme         3 days ago   Up 22 hours (healthy)              
pipelined       linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "bash -c '/usr/bin/o…"    pipelined       3 days ago   Up 23 seconds (health: starting)   
policydb        linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    policydb        3 days ago   Up 28 seconds (health: starting)   
redirectd       linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    redirectd       3 days ago   Up 22 hours (healthy)              
redis           linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/bin/bash -c '/usr/…"    redis           3 days ago   Up 18 seconds (health: starting)   
sctpd           linuxfoundation.jfrog.io/magma-docker/agw_gateway_c:1.8.0        "/usr/local/bin/sctpd"    sctpd           3 days ago   Up 22 hours                        
sessiond        linuxfoundation.jfrog.io/magma-docker/agw_gateway_c:1.8.0        "sh -c 'mkdir -p /va…"    sessiond        3 days ago   Up 19 seconds (health: starting)   
smsd            linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    smsd            3 days ago   Up 28 seconds (health: starting)   
state           linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    state           3 days ago   Up 27 seconds (health: starting)   
subscriberdb    linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    subscriberdb    3 days ago   Up 29 seconds (health: starting)   
td-agent-bit    linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/bin/bash -c '/usr/…"    td-agent-bit    3 days ago   Up 26 seconds (health: starting)
```
From that list, it is safe to assume that all containers had been restarted except for `connectiond`, `magmad`, `monitord`, `oai_mme`, `redirectd` and `sctpd`.

The function to restart the tasks is `RestartServices`, defined `orc8r/gateway/python/magma/magmad/rpc_servicer.py:115` and the services seems to be originated from an parse_args object, as from `orc8r/gateway/python/scripts/magmad_cli.py:42`. 

At the first inspection, I could not locate where the list is being generated.

The solution found was to add the remaining service names to the configuration file `lte/gateway/configs/magmad.yml` to resolve the issue of restarting the remaining items.

```
NAME            IMAGE                                                            COMMAND                   SERVICE         CREATED         STATUS                             PORTS
connectiond     linuxfoundation.jfrog.io/magma-docker/agw_gateway_c:1.8.0        "/usr/local/bin/conn…"    connectiond     3 minutes ago   Up 19 seconds (health: starting)   
control_proxy   linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "sh -c '/usr/local/b…"    control_proxy   3 minutes ago   Up 20 seconds (health: starting)   
ctraced         linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    ctraced         3 minutes ago   Up 29 seconds (health: starting)   
directoryd      linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    directoryd      3 minutes ago   Up 30 seconds (healthy)            
enodebd         linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    enodebd         3 minutes ago   Up 30 seconds (health: starting)   
eventd          linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    eventd          3 minutes ago   Up 29 seconds (health: starting)   
health          linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    health          3 minutes ago   Up 29 seconds (health: starting)   
magmad          linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/bin/bash -c '\n  /u…"   magmad          3 minutes ago   Up 28 seconds                      
mobilityd       linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "sh -c 'sleep 5 && /…"    mobilityd       3 minutes ago   Up 20 seconds (health: starting)   
monitord        linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    monitord        3 minutes ago   Up 29 seconds (health: starting)   
oai_mme         linuxfoundation.jfrog.io/magma-docker/agw_gateway_c:1.8.0        "sh -c '/usr/local/b…"    oai_mme         3 minutes ago   Up 20 seconds (health: starting)   
pipelined       linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "bash -c '/usr/bin/o…"    pipelined       3 minutes ago   Up 29 seconds (health: starting)   
policydb        linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    policydb        3 minutes ago   Up 30 seconds (health: starting)   
redirectd       linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    redirectd       3 minutes ago   Up 29 seconds (health: starting)   
redis           linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/bin/bash -c '/usr/…"    redis           3 minutes ago   Up 20 seconds (health: starting)   
sctpd           linuxfoundation.jfrog.io/magma-docker/agw_gateway_c:1.8.0        "/usr/local/bin/sctpd"    sctpd           3 minutes ago   Up 29 seconds                      
sessiond        linuxfoundation.jfrog.io/magma-docker/agw_gateway_c:1.8.0        "sh -c 'mkdir -p /va…"    sessiond        3 minutes ago   Up 20 seconds (health: starting)   
smsd            linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    smsd            3 minutes ago   Up 29 seconds (health: starting)   
state           linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    state           3 minutes ago   Up 30 seconds (health: starting)   
subscriberdb    linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/usr/bin/env python…"    subscriberdb    3 minutes ago   Up 30 seconds (healthy)            
td-agent-bit    linuxfoundation.jfrog.io/magma-docker/agw_gateway_python:1.8.0   "/bin/bash -c '/usr/…"    td-agent-bit    3 minutes ago   Up 27 seconds (health: starting) 
```

The “restart services” option is functional, although some services are not being targeted. A fix is to include the docker container names in the configuration file `lte/gateway/configs/magmad.yml`, under the `magma_services` section.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

Restarting the machine without proper caution might corrupt disk data. It might be interesting to look after a safest way to restart the host system.
