### PR TITLE
fix(ci): Dockerfile 'as' and 'FROM' keywords' casing do not match

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 ################################################################
 # Devcontainer Image (for local development and CI)
 ################################################################
-FROM ghcr.io/magma/magma/bazel-base:latest as devcontainer
+FROM ghcr.io/magma/magma/bazel-base:latest AS devcontainer
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/.devcontainer/bazel-base/Dockerfile
+++ b/.devcontainer/bazel-base/Dockerfile
@@ -12,7 +12,7 @@
 ################################################################
 # Builder Image (can also be used as developer's image)
 ################################################################
-FROM ubuntu:focal as bazel_builder
+FROM ubuntu:focal AS bazel_builder
 
 ARG DEB_PORT=amd64
 

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG OS_DIST=ubuntu OS_RELEASE=focal EXTRA_REPO=https://linuxfoundation.jfrog.io/artifactory/magma-packages-test
 
-FROM ghcr.io/magma/magma/bazel-cache-plain:latest as builder
+FROM ghcr.io/magma/magma/bazel-cache-plain:latest AS builder
 
 ENV MAGMA_ROOT /magma
 WORKDIR /magma

--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 ARG baseImage="ubuntu:focal"
-FROM ${baseImage} as base
+FROM ${baseImage} AS base
 
 # Add the magma apt repo
 RUN apt-get update && \
@@ -114,7 +114,7 @@ RUN ln -s /build/python/bin/generate_nghttpx_config.py /usr/local/bin/generate_n
 # -----------------------------------------------------------------------------
 # Builder image with binary
 # -----------------------------------------------------------------------------
-FROM base as builder
+FROM base AS builder
 
 # Build the code.
 COPY cwf $MAGMA_ROOT/cwf

--- a/cwf/k8s/cwf_operator/docker/Dockerfile
+++ b/cwf/k8s/cwf_operator/docker/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM ubuntu:bionic as builder
+FROM ubuntu:bionic AS builder
 
 # Add the magma apt repo
 RUN apt-get update && \
@@ -64,7 +64,7 @@ RUN go install ./cmd/manager/
 # -----------------------------------------------------------------------------
 # Production image
 # -----------------------------------------------------------------------------
-FROM ubuntu:bionic as cwf_operator
+FROM ubuntu:bionic AS cwf_operator
 
 ENV OPERATOR=/usr/local/bin/cwf-operator \
     USER_UID=1001 \

--- a/dp/cloud/docker/python/configuration_controller/Dockerfile
+++ b/dp/cloud/docker/python/configuration_controller/Dockerfile
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 ARG ENV=standard
-FROM python:3.9.2-slim-buster as protos-generator
+FROM python:3.9.2-slim-buster AS protos-generator
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl zip make unzip
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
@@ -35,7 +35,7 @@ WORKDIR /magma/dp
 RUN mkdir -p $PYTHON_BUILD && make protos
 
 ARG ENV=standard
-FROM python:3.9.2-slim-buster as standard-version
+FROM python:3.9.2-slim-buster AS standard-version
 
 ENV CC_DIRECTORY=dp/cloud/python/magma/configuration_controller
 ENV DB_DIRECTORY=dp/cloud/python/magma/db_service
@@ -47,13 +47,13 @@ COPY $CC_DIRECTORY/requirements.txt \
 WORKDIR /$CC_DIRECTORY
 RUN pip3 install --upgrade pip --no-cache-dir -r requirements.txt
 
-#FROM standard-version as tests-version
+#FROM standard-version AS tests-version
 #COPY $CC_DIRECTORY/tests/requirements.txt \
 #     /$CC_DIRECTORY/tests/requirements.txt
 #RUN pip3 install --upgrade pip --no-cache-dir -r tests/requirements.txt
 
 # hadolint ignore=DL3006
-FROM ${ENV}-version as final
+FROM ${ENV}-version AS final
 COPY $CC_DIRECTORY /$CC_DIRECTORY/
 COPY $DB_DIRECTORY /$DB_DIRECTORY/
 COPY $FC_DIRECTORY /$FC_DIRECTORY/

--- a/dp/cloud/docker/python/db_service/Dockerfile
+++ b/dp/cloud/docker/python/db_service/Dockerfile
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 ARG ENV=standard
-FROM python:3.9.2-slim-buster as builder
+FROM python:3.9.2-slim-buster AS builder
 
 COPY dp/cloud/python/magma/db_service/requirements.txt /dp/cloud/python/magma/db_service/requirements.txt
 WORKDIR /dp/cloud/python/magma/db_service/migrations
@@ -19,7 +19,7 @@ RUN pip3 install --upgrade pip --no-cache-dir -r ../requirements.txt
 COPY dp/cloud/python/magma/db_service /dp/cloud/python/magma/db_service/
 COPY dp/cloud/python/magma/mappings /dp/cloud/python/magma/mappings/
 
-FROM builder as final
+FROM builder AS final
 ENV PYTHONPATH=/:/dp/cloud/python
 ENV ALEMBIC_CONFIG=./alembic.ini
 

--- a/dp/cloud/docker/python/radio_controller/Dockerfile
+++ b/dp/cloud/docker/python/radio_controller/Dockerfile
@@ -11,6 +11,6 @@
 
 # TODO remove AMC from deployment scripts
 
-FROM python:3.9.2-slim-buster as protos-generator
+FROM python:3.9.2-slim-buster AS protos-generator
 
 CMD ["sleep", "infinity"]

--- a/dp/cloud/docker/python/test_runner/Dockerfile
+++ b/dp/cloud/docker/python/test_runner/Dockerfile
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 ARG ENV=standard
-FROM python:3.9.2-slim-buster as protos-generator
+FROM python:3.9.2-slim-buster AS protos-generator
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl zip make unzip
 RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip \
@@ -34,7 +34,7 @@ COPY ./dp $MAGMA_ROOT/dp/
 WORKDIR /magma/dp
 RUN mkdir -p $PYTHON_BUILD && make protos
 
-FROM python:3.9.2-slim-buster as standard-version
+FROM python:3.9.2-slim-buster AS standard-version
 
 COPY dp/cloud/python/magma/test_runner/requirements.txt /dp/cloud/python/magma/test_runner/requirements.txt
 RUN pip3 install --upgrade pip --no-cache-dir -r dp/cloud/python/magma/test_runner/requirements.txt

--- a/dp/tools/fake_crl/Dockerfile
+++ b/dp/tools/fake_crl/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:2.7.18-alpine3.11 as builder
+FROM python:2.7.18-alpine3.11 AS builder
 
 RUN apk add --no-cache \
 	gcc=9.3.0-r0 \

--- a/dp/tools/fake_sas/Dockerfile
+++ b/dp/tools/fake_sas/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:2.7.18-alpine3.11 as builder
+FROM python:2.7.18-alpine3.11 AS builder
 
 RUN apk add --no-cache \
 	gcc=9.3.0-r0 \

--- a/dp/tools/harness/Dockerfile
+++ b/dp/tools/harness/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:2.7.18-alpine3.11 as builder
+FROM python:2.7.18-alpine3.11 AS builder
 
 RUN apk add --no-cache \
         gcc=9.3.0-r0 \

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -13,7 +13,7 @@
 # Development image for test, precommit, etc.
 # -----------------------------------------------------------------------------
 ARG baseImage="ubuntu:focal"
-FROM ${baseImage} as base
+FROM ${baseImage} AS base
 
 # Add the magma apt repo
 RUN apt-get update && \
@@ -126,7 +126,7 @@ COPY orc8r/gateway/go $MAGMA_ROOT/orc8r/gateway/go
 # -----------------------------------------------------------------------------
 # Builder image with binaries
 # -----------------------------------------------------------------------------
-FROM base as builder
+FROM base AS builder
 # Enable make gen if proto gen is required
 # RUN make -C $MAGMA_ROOT/feg/gateway gen
 RUN make -C $MAGMA_ROOT/feg/gateway build
@@ -137,7 +137,7 @@ RUN ./run.sh build
 # -----------------------------------------------------------------------------
 # Go-cache base image
 # -----------------------------------------------------------------------------
-FROM ${baseImage} as gocache
+FROM ${baseImage} AS gocache
 COPY --from=builder /root/.cache /root/.cache
 
 # -----------------------------------------------------------------------------

--- a/feg/gateway/docker/radius/Dockerfile
+++ b/feg/gateway/docker/radius/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:alpine as builder
+FROM golang:alpine AS builder
 RUN apk add git gcc musl-dev bash protobuf netcat-openbsd
 
 RUN go get -d -u github.com/golang/protobuf/protoc-gen-go

--- a/feg/radius/src/Dockerfile
+++ b/feg/radius/src/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:alpine as builder
+FROM golang:alpine AS builder
 RUN apk add git gcc musl-dev bash protobuf
 
 ENV MAGMA_ROOT /magma

--- a/lte/gateway/docker/ghz/Dockerfile
+++ b/lte/gateway/docker/ghz/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR ${MAGMA_ROOT}/ghz
 
 RUN make build
 
-FROM ${REPO_LOCATION}/agw_gateway_python as python_builder
+FROM ${REPO_LOCATION}/agw_gateway_python AS python_builder
 
 ARG GHZ_REPO=https://github.com/bojand/ghz
 
@@ -68,13 +68,13 @@ WORKDIR ${MAGMA_ROOT}/ghz
 
 RUN make build
 
-FROM ${REPO_LOCATION}/agw_gateway_c as agw_c_ghz
+FROM ${REPO_LOCATION}/agw_gateway_c AS agw_c_ghz
 
 COPY --from=c_builder /magma/ghz/dist/ghz /usr/local/bin/
 
 WORKDIR ${MAGMA_ROOT}/lte/gateway/python/load_tests
 
-FROM ${REPO_LOCATION}/agw_gateway_python as agw_python_ghz
+FROM ${REPO_LOCATION}/agw_gateway_python AS agw_python_ghz
 
 COPY --from=python_builder /magma/ghz/dist/ghz /usr/local/bin/
 

--- a/nms/Dockerfile
+++ b/nms/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:16.14-alpine as builder
+FROM node:16.14-alpine AS builder
 
 RUN apk add python3 g++ make libx11 glew-dev libxi-dev ca-certificates
 

--- a/nms/mock/Dockerfile
+++ b/nms/mock/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:16.14-alpine as builder
+FROM node:16.14-alpine AS builder
 
 WORKDIR /usr/src/
 

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -14,7 +14,7 @@
 # ------------------------------------------------------------------------------
 ARG PLATFORM=linux/amd64
 
-FROM --platform=$PLATFORM ubuntu:focal as base
+FROM --platform=$PLATFORM ubuntu:focal AS base
 
 ENV GO111MODULE on
 ENV GOPATH ${USER}/go
@@ -64,7 +64,7 @@ RUN curl -Lfs https://github.com/protocolbuffers/protobuf/releases/download/v3.1
 # ------------------------------------------------------------------------------
 # Gocache: cache Go modules
 # ------------------------------------------------------------------------------
-FROM base as gocache
+FROM base AS gocache
 
 ARG MAGMA_MODULES="orc8r lte feg cwf dp"
 RUN echo "export GOCACHE_MODULES=\"$(for m in $MAGMA_MODULES ; do echo -n /gomod/src/magma/$m ; echo -n ' ' ; done)\"" >> /etc/profile.d/env.sh
@@ -76,7 +76,7 @@ RUN . /etc/profile.d/env.sh && for m in $GOCACHE_MODULES ; do cd ${m}/cloud/go &
 # ------------------------------------------------------------------------------
 # Src: different src depending on MAGMA_MODULES
 # ------------------------------------------------------------------------------
-FROM gocache as src
+FROM gocache AS src
 
 ARG MAGMA_MODULES="orc8r lte feg cwf dp"
 RUN echo "export MAGMA_MODULES=\"$(for m in $MAGMA_MODULES ; do echo -n /src/magma/$m ; echo -n ' ' ; done)\"" >> /etc/profile.d/env.sh
@@ -92,7 +92,7 @@ COPY configs /etc/magma/configs
 # ------------------------------------------------------------------------------
 # Builder: compile src
 # ------------------------------------------------------------------------------
-FROM src as builder
+FROM src AS builder
 
 RUN . /etc/profile.d/env.sh && make build
 


### PR DESCRIPTION
fix(ci): Dockerfile 'as' and 'FROM' keywords' casing do not match

## Summary

Fixed warnings docker gave when building an image.

https://docs.docker.com/reference/build-checks/from-as-casing/

## Test Plan

`docker build` on any affected images.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

No security considerations here.

