### PR TITLE
fix(nms): code scanning alert no. 141: DOM text reinterpreted as HTML

### DIFF
--- a/nms/app/components/admin/Networks.tsx
+++ b/nms/app/components/admin/Networks.tsx
@@ -220,7 +220,9 @@ function Networks() {
                 });
                 closeDialog();
                 if (!selectedNetworkId) {
-                  window.location.replace(`/nms/${networkID}/admin/networks`);
+                  window.location.replace(
+                    `/nms/${encodeURIComponent(networkID)}/admin/networks`,
+                  );
                 }
               }}
             />


### PR DESCRIPTION
Potential fix for [https://github.com/magma/magma/security/code-scanning/141](https://github.com/magma/magma/security/code-scanning/141)

To fix the problem, we need to ensure that the `networkID` is properly sanitized before being used in the URL. This can be achieved by using a library like `encodeURIComponent` to escape any potentially harmful characters in the `networkID`.

- In general terms, the problem can be fixed by encoding the `networkID` before using it in the URL.
- Specifically, we will use the `encodeURIComponent` function to encode the `networkID` in the `Networks.tsx` file.
- The change will be made on line 223 of `Networks.tsx` where the URL is constructed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
