### PR TITLE
fix(ci): Fixing fatal error: detected dubious ownership

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -118,6 +118,7 @@ jobs:
 
             # Required for bazel-diff to perform git checkout.
             git config --global --add safe.directory /workspaces/magma
+            git config --global --add safe.directory /workspaces/magma/.git
 
             printf '\r%s\r' '###############################' 1>&2
             printf '\r%s\r' 'Bazel-diff.' 1>&2


### PR DESCRIPTION
## Summary

The runner is pulling the git repo with "runner" user while the process runds in docker container with "root" as user which causes issue with the ownership of the local repo.

The fix is instructing git tool to ignore this error


## Test Plan

Execute the workflows related to the fix

## Additional Information

- [ ] This change is modifying CI/CD

## Security Considerations
The approach is already used by the CI/CD, so the fix is only addend additional subfolder in the working space explicitly.
The ownership change is inside of the container and limited to the checks only. The container is already running with the "root" credentials. The file ownership of the files is not relevant for the actions that are performed, so allowing the git tool to use different user will not create any security issue.