### PR TITLE
chore(deps): update devcontainer golang version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -82,9 +82,9 @@ RUN gem install dotenv -v 2.8.1 && \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.24.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
-    && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
+    && curl https://go.dev/dl/${GO_TARBALL} --remote-name --location \
     && tar -xzf ${GO_TARBALL} \
     && rm ${GO_TARBALL}
 ENV PATH=${PATH}:/usr/local/go/bin

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,10 @@
 		"ryuta46.multi-command",
 		"coolchyni.beyond-debug"
 	],
-	"image": "ghcr.io/magma/magma/devcontainer:sha-84cfceb",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
 	"settings": {
 		"search.followSymlinks": false,
 		"terminal.integrated.profiles.linux": {


### PR DESCRIPTION
chore(devcontainer): update devcontainer golang version

## Summary

While executing go tests, golang was complaining about the installed version (1.19.4), while some files required updated version (1.20.1). The image being pulled was `ghcr.io/magma/magma/devcontainer:sha-84cfceb` from two years ago. 

The proposed change allows quicker updates, avoiding the forgetfulness of the update of this tag, and release the Magma project to build and serve the devcontainer image.

- Update golang package version from 1.20.1 to 1.24.1
- Fix Dockerfile path to `library-scripts`
- Switch devcontainer.json to build the image instead of pull

## Test Plan

Open the repository in devcontainer and execute `go version`

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

## Other considerations

Since the devcontainer image is not being pulled from `ghcr.io/magma/magma/devcontainer`, this change allows discontinuation of building and hosting the image by Magma.
The build process should still happen in order to keep sanity of the file.