### PR TITLE
fix(nms): data plan bitrate information inverted

### DIFF
--- a/nms/app/views/traffic/DataPlanOverview.tsx
+++ b/nms/app/views/traffic/DataPlanOverview.tsx
@@ -81,15 +81,15 @@ function DataPlanOverview(props: WithAlert) {
         return {
           id: id,
           maxUploadBitRate:
-            profile.max_dl_bit_rate ===
-            DATA_PLAN_UNLIMITED_RATES.max_dl_bit_rate
-              ? 'Unlimited'
-              : `${profile.max_dl_bit_rate / BITRATE_MULTIPLIER} Mbps`,
-          maxDownloadBitRate:
             profile.max_ul_bit_rate ===
             DATA_PLAN_UNLIMITED_RATES.max_ul_bit_rate
               ? 'Unlimited'
               : `${profile.max_ul_bit_rate / BITRATE_MULTIPLIER} Mbps`,
+          maxDownloadBitRate:
+            profile.max_dl_bit_rate ===
+            DATA_PLAN_UNLIMITED_RATES.max_dl_bit_rate
+              ? 'Unlimited'
+              : `${profile.max_dl_bit_rate / BITRATE_MULTIPLIER} Mbps`,
         };
       })
     : [];
@@ -146,16 +146,22 @@ function DataPlanOverview(props: WithAlert) {
                   {currRow.id}
                 </Link>
               ),
+              cellStyle: { textAlign: 'center' },
+              headerStyle: { textAlign: 'center' },
             },
             {
               title: 'Max Upload Bit Rate',
               field: 'maxUploadBitRate',
               type: 'numeric',
+              cellStyle: { textAlign: 'center' },
+              headerStyle: { textAlign: 'center' },
             },
             {
               title: 'Max Download Bit Rate',
               field: 'maxDownloadBitRate',
               type: 'numeric',
+              cellStyle: { textAlign: 'center' },
+              headerStyle: { textAlign: 'center' },
             },
           ]}
           handleCurrRow={(row: DataPlanRowType) => setCurrRow(row)}

--- a/nms/app/views/traffic/DataPlanOverview.tsx
+++ b/nms/app/views/traffic/DataPlanOverview.tsx
@@ -146,22 +146,16 @@ function DataPlanOverview(props: WithAlert) {
                   {currRow.id}
                 </Link>
               ),
-              cellStyle: { textAlign: 'center' },
-              headerStyle: { textAlign: 'center' },
             },
             {
               title: 'Max Upload Bit Rate',
               field: 'maxUploadBitRate',
               type: 'numeric',
-              cellStyle: { textAlign: 'center' },
-              headerStyle: { textAlign: 'center' },
             },
             {
               title: 'Max Download Bit Rate',
               field: 'maxDownloadBitRate',
               type: 'numeric',
-              cellStyle: { textAlign: 'center' },
-              headerStyle: { textAlign: 'center' },
             },
           ]}
           handleCurrRow={(row: DataPlanRowType) => setCurrRow(row)}


### PR DESCRIPTION
fix(nms): data plan bitrate information inverted

## Summary

Under "Traffic -> Data Plans" in the NMS UI, the Download Bitrate is incorrectly displayed under the Upload Bitrate column, and vice versa.

This change inverts the profile call so that the information is displayed correctly.

## Test Plan

The changes were tested by building the NMS and starting the containers using the following commands:
```
$ cd ~/magma/nms
$ COMPOSE_PROJECT_NAME=magmalte docker-compose build magmalte
$ docker-compose up -d
```

Additionally, I tested by connecting a subscriber with a defined data plan. I then retrieved the subscriber information from the AGW and confirmed that the DL and UL rates were defined correctly.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations
