### PR TITLE
fix(ci): Pin artifact download action version and configure Git details in workflow

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -152,6 +152,8 @@ jobs:
         run: |
          echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}" 
          RELEASE_TAG="${GITHUB_REF_NAME}"
+         git config --global user.email "magma@users.noreply.github.com"
+         git config --global user.name "magma"
          echo "Creating release tag for version ${RELEASE_TAG}"
          git tag -a "${RELEASE_TAG}" -m "Release version ${RELEASE_TAG}" 
          git push origin refs/tags/"${RELEASE_TAG}" 

--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -247,35 +247,35 @@ jobs:
         run: mkdir -p lte/gateway/test_results
 
       - name: Download test results of precommit tests
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # pin@v4.2.1
         with:
           name: test_results_precommit
           path: "${{ github.workspace }}/lte/gateway/test_results"
 
       - name: Download final status of precommit tests
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # pin@v4.2.1
         with:
           name: test-status-precommit
 
       - name: Download test results of extended tests
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # pin@v4.2.1
         with:
           name: test_results_extended_tests
           path: "${{ github.workspace }}/lte/gateway/test_results"
 
       - name: Download final status of of extended tests
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # pin@v4.2.1
         with:
           name: test-status-extended_tests
 
       - name: Download test results of long extended tests
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # pin@v4.2.1
         with:
           name: test_results_extended_tests_long
           path: "${{ github.workspace }}/lte/gateway/test_results"
 
       - name: Download final status of of long extended tests
-        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # pin@v3.0.1
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # pin@v4.2.1
         with:
           name: test-status-extended_tests_long
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

This MR,

- Pins `actions/download-artifact` to a specific commit SHA (`95815c38cf2ff2164869cbab79da8d1f422bc89e`) 
- Configures Git user details (`user.name` and `user.email`) to ensure proper commit attribution during workflow execution.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

