### PR TITLE
fix(agw): download valid signing key

### DIFF
--- a/lte/gateway/deploy/roles/agw_docker/vars/all.yaml
+++ b/lte/gateway/deploy/roles/agw_docker/vars/all.yaml
@@ -17,7 +17,7 @@ magma_pkgrepo_dist: focal-1.8.0
 magma_pkgrepo_component: main
 magma_pkgrepo_name: "magma"
 
-magma_pkgrepo_key: "https://artifactory.magmacore.org:443/artifactory/api/gpg/key/public"
+magma_pkgrepo_key: "https://raw.githubusercontent.com/magma/magma/refs/heads/master/keys/linux_foundation_registry_key.asc"
 magma_pkgrepo_key_fingerprint: ""
 magma_use_pkgrepo: yes
 

--- a/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_deploy/tasks/main.yml
@@ -57,23 +57,12 @@
     - agwc
     - base
 
-- name: Add unvalidated Apt signing key.
+- name: Download Magma Certificate key
   when: magma_pkgrepo_key_fingerprint == ""
   become: true
-  block:
-    - name: Download key
-      apt_key:
-        url: "{{ magma_pkgrepo_key }}"
-        state: present
-        validate_certs: no
-    - name: Ignore server ssl cert
-      copy:
-        dest: /etc/apt/apt.conf.d/99insecurehttpsrepo
-        content: |
-          Acquire::https::{{ magma_pkgrepo_host }} {
-          Verify-Peer "false";
-          Verify-Host "false";
-          };
+  ansible.builtin.get_url:
+    url: "{{ magma_pkgrepo_key }}"
+    dest: /etc/apt/trusted.gpg.d/magma.asc
   tags:
     - agwc
     - base

--- a/lte/gateway/deploy/roles/magma_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma_deploy/vars/all.yaml
@@ -18,6 +18,6 @@ magma_pkgrepo_dist: focal-1.8.0
 magma_pkgrepo_component: main
 magma_pkgrepo_name: "magma"
 
-magma_pkgrepo_key: "https://linuxfoundation.jfrog.io/artifactory/api/security/keypair/magmaci/public"
+magma_pkgrepo_key: "https://raw.githubusercontent.com/magma/magma/refs/heads/master/keys/linux_foundation_registry_key.asc"
 magma_pkgrepo_key_fingerprint: ""
 magma_use_pkgrepo: yes


### PR DESCRIPTION
## Summary

Reported issues https://github.com/magma/magma/issues/15650 and https://github.com/magma/magma/issues/15651 fails on downloading the signing key and signature of necessary packages. Constant comments on https://github.com/magma/magma/issues/15572 suggests this is a reoccurring issue.
Changed the default signing key source & method of downloading and installation.

## Test Plan

Execute one of the following and wait for success:
- `su - magma -c "ansible-playbook -e \"MAGMA_ROOT='/home/magma/magma' OUTPUT_DIR='/tmp'\" -i /home/magma/magma/lte/gateway/deploy/agw_hosts magma/magma_deploy.yml"` 
  - (taken from `lte/gateway/deploy/agw_install_ubuntu.sh` with default values)
- `su - ubuntu -c "sudo ansible-playbook -v -e \"MAGMA_ROOT='/opt/magma' OUTPUT_DIR='/tmp'\" -i /opt/magma/lte/gateway/deploy/agw_hosts --tags agwc /opt/magma/lte/gateway/deploy/magma_docker.yml"` 
  - (taken from `lte/gateway/deploy/agw_install_docker.sh` with default values)

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

