### PR TITLE
chore(deps): bump golang version to 1.24.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -82,9 +82,9 @@ RUN gem install dotenv -v 2.8.1 && \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.24.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
-    && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
+    && curl https://go.dev/dl/${GO_TARBALL} --remote-name --location \
     && tar -xzf ${GO_TARBALL} \
     && rm ${GO_TARBALL}
 ENV PATH=${PATH}:/usr/local/go/bin

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -119,7 +119,7 @@ jobs:
         if: always()
         id: gateway_test_init
         with:
-          go-version: '1.21.12'
+          go-version: '1.24.1'
       - name: Download dependencies
         if: always() && steps.gateway_test_init.outcome=='success'
         id: gateway_test_dep

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.21.12'
+          go-version: '1.24.1'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.20.1'
+          go-version: '1.24.1'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.20.1'
+          go-version: '1.24.1'
       - run: go version
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh

--- a/.github/workflows/magma-publish-go.yml
+++ b/.github/workflows/magma-publish-go.yml
@@ -20,7 +20,7 @@ on:
     inputs:
       version:
         description: Version to upload?
-        default: 1.20.1
+        default: 1.24.1
         required: true
 
 env:

--- a/.github/workflows/scripts/golang_check_version.sh
+++ b/.github/workflows/scripts/golang_check_version.sh
@@ -10,9 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-expected_version="1.20.1"
-second_expected_version="1.21.0"
-ternary_expected_version="1.21.12"
+expected_version="1.24.1"
+second_expected_version="1.24.1"
+ternary_expected_version="1.24.1"
 all_versions_good=true
 
 while IFS= read -r -d '' file

--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -38,7 +38,7 @@
     - role: ovs
     - role: golang
       vars:
-        golang_tar: go1.20.1.linux-amd64.tar.gz
+        golang_tar: go1.24.1.linux-amd64.tar.gz
         golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
     - role: cwag
 

--- a/cwf/gateway/deploy/cwag_dev_centos7.yml
+++ b/cwf/gateway/deploy/cwag_dev_centos7.yml
@@ -33,7 +33,7 @@
     - role: ovs
     - role: golang
       vars:
-        golang_tar: go1.20.1.linux-amd64.tar.gz
+        golang_tar: go1.24.1.linux-amd64.tar.gz
         golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
 #    - role: cwag
 

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -29,7 +29,7 @@
         override_nameserver: 8.8.8.8
     - role: golang
       vars:
-        golang_tar: go1.20.1.linux-amd64.tar.gz
+        golang_tar: go1.24.1.linux-amd64.tar.gz
         golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
     - role: cwag_test
   tasks:

--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -58,9 +58,9 @@ RUN apt-get update && apt-get install -y \
 
 # Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.21.12"
+ARG GOLANG_VERSION="1.24.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
-    && curl https://golang.org/dl/${GO_TARBALL} --remote-name --location \
+    && curl https://go.dev/dl//${GO_TARBALL} --remote-name --location \
     && tar -xzf ${GO_TARBALL} \
     && ln -s /usr/local/go/bin/go /usr/local/bin/go \
     && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt \

--- a/cwf/k8s/cwf_operator/docker/Dockerfile
+++ b/cwf/k8s/cwf_operator/docker/Dockerfile
@@ -20,9 +20,9 @@ RUN apt-get update && apt-get install -y bzr curl daemontools gcc
 
 # Install Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.21.12"
+ARG GOLANG_VERSION="1.24.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
-    && curl https://golang.org/dl/${GO_TARBALL} --remote-name --location \
+    && curl https://go.dev/dl//${GO_TARBALL} --remote-name --location \
     && tar -xzf ${GO_TARBALL} \
     && ln -s /usr/local/go/bin/go /usr/local/bin/go \
     && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt \

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -60,9 +60,9 @@ RUN apt-get update && apt-get install -y \
 
 # Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.21.0"
+ARG GOLANG_VERSION="1.24.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
- && curl https://golang.org/dl/${GO_TARBALL} --remote-name --location \
+ && curl https://go.dev/dl//${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \
  && ln -s /usr/local/go/bin/go /usr/local/bin/go \
  && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt \

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -360,7 +360,7 @@
 
 - name: Download golang tar
   get_url:
-    url: "https://linuxfoundation.jfrog.io/artifactory/magma-blob/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
+    url: "https://go.dev/dl//go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
     dest: "{{ all_vars.WORK_DIR }}"
     mode: 0440
   when: preburn

--- a/lte/gateway/deploy/roles/magma/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma/vars/all.yaml
@@ -1,2 +1,2 @@
 WORK_DIR: "~/"
-GO_VERSION: "1.20.1"
+GO_VERSION: "1.24.1"

--- a/lte/gateway/docker/ghz/Dockerfile
+++ b/lte/gateway/docker/ghz/Dockerfile
@@ -25,9 +25,9 @@ RUN apt-get update && apt-get install -y \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.24.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
- && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
+ && curl https://go.dev/dl//${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \
  && ln -s /usr/local/go/bin/go /usr/local/bin/go \
  && rm ${GO_TARBALL}
@@ -51,9 +51,9 @@ RUN apt-get update && apt-get install -y \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.24.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
- && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
+ && curl https://go.dev/dl//${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \
  && ln -s /usr/local/go/bin/go /usr/local/bin/go \
  && rm ${GO_TARBALL}

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
@@ -72,11 +72,11 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform
     rm -rf /root/download/*
 
 # Install go if we are building testframework image
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.24.1"
 RUN if [ "$ENV" = "testframework" ]; \
     then \
         GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
-     && wget --no-verbose https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} \
+        && curl https://go.dev/dl//${GO_TARBALL} --remote-name --location \
      && tar --strip-components=2 -C /usr/local/bin -xzf ${GO_TARBALL} go/bin/go go/bin/gofmt \
      && rm ${GO_TARBALL}; \
     fi

--- a/orc8r/cloud/deploy/roles/golang/defaults/main.yml
+++ b/orc8r/cloud/deploy/roles/golang/defaults/main.yml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-golang_tar: go1.20.1.linux-amd64.tar.gz
+golang_tar: go1.24.1.linux-amd64.tar.gz
 golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
 go_install_path: /usr/local
 gopath: '/home/{{ user }}/go'

--- a/orc8r/cloud/deploy/roles/golang/tasks/main.yml
+++ b/orc8r/cloud/deploy/roles/golang/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Download Golang
   get_url:
-    url: "https://linuxfoundation.jfrog.io/artifactory/magma-blob/{{ golang_tar }}"
+    url: "https://go.dev/dl//{{ golang_tar }}"
     dest: "/home/{{ user }}/{{ golang_tar }}"
     checksum: "{{ golang_tar_checksum }}"
   when: preburn

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -39,9 +39,9 @@ RUN apt-get update && apt-get install -y \
 
 # Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.24.1"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
- && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
+ && curl https://go.dev/dl//${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \
  && ln -s /usr/local/go/bin/go /usr/local/bin/go \
  && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt \

--- a/orc8r/tools/ansible/roles/golang/defaults/main.yml
+++ b/orc8r/tools/ansible/roles/golang/defaults/main.yml
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-golang_tar: go1.20.1.linux-amd64.tar.gz
+golang_tar: go1.24.1.linux-amd64.tar.gz
 golang_tar_checksum: 'sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
 go_install_path: /usr/local
 gopath: '/home/{{ user }}/go'

--- a/orc8r/tools/ansible/roles/golang/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/golang/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Download Golang
   get_url:
-    url: "https://linuxfoundation.jfrog.io/artifactory/magma-blob/{{ golang_tar }}"
+    url: "https://go.dev/dl/{{ golang_tar }}"
     dest: "/home/{{ user }}/{{ golang_tar }}"
     checksum: "{{ golang_tar_checksum }}"
   when: full_provision


### PR DESCRIPTION
chore(deps): bump golang version to 1.24.1

## Summary

 bump golang version to 1.24.1

## Test Plan

Full integration test

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations
