### PR TITLE
fix(orc8r): fluentd build dockerfile

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -13,6 +13,7 @@ FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
 RUN gem install \
     elasticsearch:7.13.0 \
+    excon:1.2.5 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \
     --no-document

--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -13,8 +13,8 @@ FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
 RUN gem install \
     elasticsearch:7.13.0 \
-    multi_json:1.15.0 \
     excon:1.2.5 \
+    multi_json:1.15.0 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \
     --no-document

--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -13,6 +13,7 @@ FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
 RUN gem install \
     elasticsearch:7.13.0 \
+    multi_json:1.15.0 \
     excon:1.2.5 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \


### PR DESCRIPTION
fix(orc8r): fluentd build dockerfile

## Summary

The `excon` package is a dependency of `fluent-plugin-elasticsearch`, despite the latter having a pinned version, the `gem install`, when installing dependencies, does not pins the dependencies, installing the newest version available. 
The below error log shows what happens when building the fluentd container:
```
78.99 ERROR:  Error installing fluent-plugin-elasticsearch:
78.99   The last version of excon (>= 0) to support your Ruby & RubyGems was 1.2.5. Try installing it with `gem install excon -v 1.2.5` and then running the current command again
78.99   excon requires Ruby version >= 3.1.0. The current ruby version is 2.7.5.203.
99.21 Successfully installed multi_json-1.15.0 99.21 Successfully installed elasticsearch-api-7.13.0
99.21 Successfully installed ruby2_keywords-0.0.5 99.21 Successfully installed faraday-retry-1.0.3
99.21 Successfully installed faraday-rack-1.0.0 99.21 Successfully installed faraday-patron-1.0.0
99.21 Successfully installed faraday-net_http_persistent-1.2.0 99.21 Successfully installed faraday-net_http-1.0.2
99.21 Successfully installed multipart-post-2.4.1 99.21 Successfully installed faraday-multipart-1.1.0
99.21 Successfully installed faraday-httpclient-1.0.1 99.21 Successfully installed faraday-excon-1.1.0
99.21 Successfully installed faraday-em_synchrony-1.0.0 99.21 Successfully installed faraday-em_http-1.0.0
99.21 Successfully installed faraday-1.10.4 99.21 Successfully installed elasticsearch-transport-7.13.0
99.21 Successfully installed elasticsearch-7.13.0 99.21 Successfully installed fluent-plugin-multi-format-parser-1.0.0
99.21 18 gems installed  
```

This PR pins the `excon` package version to `1.2.5`, as suggested from error logs.

## Test Plan

```
cd orc8r/cloud/docker/fluentd
docker build .
```
## Additional Information

- [ ] This change is backwards-breaking


## Security Considerations

Outdated packages may have known vulnerabilities.