### PR TITLE
chore(py): removal of @asyncio.coroutine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,7 @@ orc8r/cloud/test-results/
 
 # VS Code
 .vscode/
-.venv/
+/venv
 
 # FB internal
 fb

--- a/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
+++ b/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
@@ -69,8 +69,8 @@ class GTPStatsCollector(Job):
         self._loop = service_loop
         logging.info("Running GTP stats collector...")
 
-    @asyncio.coroutine
-    def _ovsdb_dump_async(self, table: str, columns: List[str]):
+    
+    async def _ovsdb_dump_async(self, table: str, columns: List[str]):
         """
         Execute ovsdb-client dump command asynchronously and parse stdout
         results.

--- a/lte/gateway/python/magma/pipelined/ifaces.py
+++ b/lte/gateway/python/magma/pipelined/ifaces.py
@@ -18,8 +18,8 @@ from magma.pipelined.metrics import NETWORK_IFACE_STATUS
 POLL_INTERVAL_SECONDS = 3
 
 
-@asyncio.coroutine
-def monitor_ifaces(iface_names):
+
+async def monitor_ifaces(iface_names):
     """
     Call to poll the network interfaces and set the corresponding metric
     """
@@ -28,7 +28,7 @@ def monitor_ifaces(iface_names):
         for iface in iface_names:
             status = 1 if iface in active else 0
             NETWORK_IFACE_STATUS.labels(iface_name=iface).set(status)
-        yield from asyncio.sleep(POLL_INTERVAL_SECONDS)
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
 
 def get_mac_address_from_iface(interface_name: str) -> str:

--- a/orc8r/gateway/python/magma/common/cert_validity.py
+++ b/orc8r/gateway/python/magma/common/cert_validity.py
@@ -30,12 +30,12 @@ class TCPClientProtocol(asyncio.Protocol):
         transport.close()
 
 
-@asyncio.coroutine
-def create_tcp_connection(host, port, loop):
+
+async def create_tcp_connection(host, port, loop):
     """
     Creates tcp connection
     """
-    tcp_conn = yield from loop.create_connection(
+    tcp_conn = await loop.create_connection(
         TCPClientProtocol,
         host,
         port,
@@ -43,8 +43,8 @@ def create_tcp_connection(host, port, loop):
     return tcp_conn
 
 
-@asyncio.coroutine
-def create_ssl_connection(host, port, certfile, keyfile, loop):
+
+async def create_ssl_connection(host, port, certfile, keyfile, loop):
     """
     Creates ssl connection.
     """
@@ -54,7 +54,7 @@ def create_ssl_connection(host, port, certfile, keyfile, loop):
         keyfile=keyfile,
     )
 
-    ssl_conn = yield from loop.create_connection(
+    ssl_conn = await loop.create_connection(
         TCPClientProtocol,
         host,
         port,
@@ -63,8 +63,8 @@ def create_ssl_connection(host, port, certfile, keyfile, loop):
     return ssl_conn
 
 
-@asyncio.coroutine
-def cert_is_invalid(host, port, certfile, keyfile, loop):
+
+async def cert_is_invalid(host, port, certfile, keyfile, loop):
     """
     Asynchronously test if both a TCP and SSL connection can be made to host
     on port. If the TCP connection is successful, but the SSL connection fails,
@@ -86,7 +86,7 @@ def cert_is_invalid(host, port, certfile, keyfile, loop):
 
     coros = tcp_coro, ssl_coro
     asyncio.set_event_loop(loop)
-    res = yield from asyncio.gather(*coros, return_exceptions=True)
+    res = await asyncio.gather(*coros, return_exceptions=True)
     tcp_res, ssl_res = res
 
     if isinstance(tcp_res, Exception):

--- a/orc8r/gateway/python/magma/common/tests/cert_validity_tests.py
+++ b/orc8r/gateway/python/magma/common/tests/cert_validity_tests.py
@@ -47,9 +47,8 @@ class CertValidityTests(TestCase):
         """
         self.loop.create_connection = MagicMock()
 
-        @asyncio.coroutine
-        def go():
-            yield from cv.create_tcp_connection(
+        async def go():
+            await cv.create_tcp_connection(
                 self.host,
                 self.port,
                 self.loop,
@@ -70,9 +69,8 @@ class CertValidityTests(TestCase):
         """
         self.loop.create_connection = MagicMock()
 
-        @asyncio.coroutine
-        def go():
-            yield from cv.create_ssl_connection(
+        async def go():
+            await cv.create_ssl_connection(
                 self.host,
                 self.port,
                 self.certfile,
@@ -110,10 +108,9 @@ class CertValidityTests(TestCase):
         cert_is_invalid() == False when TCP and SSL succeed
         """
 
-        @asyncio.coroutine
-        def go():
+        async def go():
             return (
-                yield from cv.cert_is_invalid(
+                await cv.cert_is_invalid(
                     self.host,
                     self.port,
                     self.certfile,
@@ -151,10 +148,10 @@ class CertValidityTests(TestCase):
         mock_err.errno = errno.ETIMEDOUT
         mock_create_ssl.coro.side_effect = mock_err
 
-        @asyncio.coroutine
-        def go():
+        
+        async def go():
             return (
-                yield from cv.cert_is_invalid(
+                await cv.cert_is_invalid(
                     self.host,
                     self.port,
                     self.certfile,
@@ -179,10 +176,10 @@ class CertValidityTests(TestCase):
         mock_err.errno = None
         mock_create_ssl.coro.side_effect = mock_err
 
-        @asyncio.coroutine
-        def go():
+        
+        async def go():
             return (
-                yield from cv.cert_is_invalid(
+                await cv.cert_is_invalid(
                     self.host,
                     self.port,
                     self.certfile,
@@ -207,10 +204,10 @@ class CertValidityTests(TestCase):
         mock_err.errno = None
         mock_create_tcp.coro.side_effect = mock_err
 
-        @asyncio.coroutine
-        def go():
+        
+        async def go():
             return (
-                yield from cv.cert_is_invalid(
+                await cv.cert_is_invalid(
                     self.host,
                     self.port,
                     self.certfile,
@@ -235,10 +232,10 @@ class CertValidityTests(TestCase):
         mock_err.errno = errno.ETIMEDOUT
         mock_create_tcp.coro.side_effect = mock_err
 
-        @asyncio.coroutine
-        def go():
+        
+        async def go():
             return (
-                yield from cv.cert_is_invalid(
+                await cv.cert_is_invalid(
                     self.host,
                     self.port,
                     self.certfile,
@@ -270,10 +267,10 @@ class CertValidityTests(TestCase):
         mock_ssl_err.errno = errno.ETIMEDOUT
         mock_create_ssl.coro.side_effect = mock_ssl_err
 
-        @asyncio.coroutine
-        def go():
+        
+        async def go():
             return (
-                yield from cv.cert_is_invalid(
+                await cv.cert_is_invalid(
                     self.host,
                     self.port,
                     self.certfile,

--- a/orc8r/gateway/python/magma/magmad/check/kernel_check/kernel_versions.py
+++ b/orc8r/gateway/python/magma/magmad/check/kernel_check/kernel_versions.py
@@ -40,8 +40,8 @@ def get_kernel_versions():
     )
 
 
-@asyncio.coroutine
-def get_kernel_versions_async(loop=None):
+
+async def get_kernel_versions_async(loop=None):
     """
     Execute dpkg commands asynchronously.
 

--- a/orc8r/gateway/python/magma/magmad/check/network_check/ping.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/ping.py
@@ -81,8 +81,8 @@ def ping(ping_params):
     )
 
 
-@asyncio.coroutine
-def ping_async(ping_params, loop=None):
+
+async def ping_async(ping_params, loop=None):
     """
     Execute ping commands asynchronously.
 
@@ -101,8 +101,8 @@ def ping_async(ping_params, loop=None):
     )
 
 
-@asyncio.coroutine
-def ping_interface_async(ping_params, loop=None):
+
+async def ping_interface_async(ping_params, loop=None):
     """
     Execute ping commands asynchronously through specified interface.
 

--- a/orc8r/gateway/python/magma/magmad/check/network_check/traceroute.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/traceroute.py
@@ -59,8 +59,8 @@ def traceroute(params):
     )
 
 
-@asyncio.coroutine
-def traceroute_async(params, loop=None):
+
+async def traceroute_async(params, loop=None):
     """
     Execute some `traceroute` commands asynchronously and return results.
     Args:

--- a/orc8r/gateway/python/magma/magmad/check/subprocess_workflow.py
+++ b/orc8r/gateway/python/magma/magmad/check/subprocess_workflow.py
@@ -53,8 +53,8 @@ def exec_and_parse_subprocesses(params, arg_list_func, result_parser_func):
     return _parse_results(params, outputs, result_parser_func)
 
 
-@asyncio.coroutine
-def exec_and_parse_subprocesses_async(
+
+async def exec_and_parse_subprocesses_async(
     params, arg_list_func, result_parser_func,
     loop=None,
 ):
@@ -78,8 +78,8 @@ def exec_and_parse_subprocesses_async(
             stderr=asyncio.subprocess.PIPE,
         ) for param in params
     ]
-    subprocs = yield from asyncio.gather(*futures)
-    outputs = yield from asyncio.gather(
+    subprocs = await asyncio.gather(*futures)
+    outputs = await asyncio.gather(
         *[subproc.communicate() for subproc in subprocs],
     )
     return _parse_results(params, outputs, result_parser_func)

--- a/orc8r/gateway/python/magma/magmad/check/tests/subprocess_workflow_tests.py
+++ b/orc8r/gateway/python/magma/magmad/check/tests/subprocess_workflow_tests.py
@@ -41,14 +41,12 @@ class SubprocessWorkflowTests(unittest.TestCase):
     def _mock_arg_factory(param):
         return [param, 'a', 'b']
 
-    @asyncio.coroutine
     # pylint: disable=unused-argument
-    def _mock_process_communicate(self, *args, **kwargs):
+    async def _mock_process_communicate(self, *args, **kwargs):
         return 'stdout', 'stderr'
 
-    @asyncio.coroutine
     # pylint: disable=unused-argument
-    def _mock_async_subprocess(self, *args, **kwargs):
+    async def _mock_async_subprocess(self, *args, **kwargs):
         return self.process_mock
 
     @mock.patch('subprocess.Popen')
@@ -115,9 +113,9 @@ class SubprocessWorkflowTests(unittest.TestCase):
             ])
 
     def test_async_subprocess_exec_exception(self):
-        @asyncio.coroutine
+        
         # pylint: disable=unused-argument
-        def mock_subprocess_raises(*args, **kwargs):
+        async def mock_subprocess_raises(*args, **kwargs):
             raise ValueError('oops')
 
         with mock.patch.object(
@@ -136,9 +134,9 @@ class SubprocessWorkflowTests(unittest.TestCase):
             self.assertEqual('oops', e.exception.args[0])
 
     def test_async_subprocess_communicate_exception(self):
-        @asyncio.coroutine
+        
         # pylint: disable=unused-argument
-        def mock_communicate_raises(*args, **kwargs):
+        async def mock_communicate_raises(*args, **kwargs):
             raise ValueError('oops')
         self.process_mock.configure_mock(communicate=mock_communicate_raises)
 

--- a/orc8r/gateway/python/magma/magmad/metrics.py
+++ b/orc8r/gateway/python/magma/magmad/metrics.py
@@ -124,8 +124,8 @@ def _get_ping_params(config):
     return ping_params
 
 
-@asyncio.coroutine
-def metrics_collection_loop(service_config, loop=None):
+
+async def metrics_collection_loop(service_config, loop=None):
     if 'network_monitor_config' not in service_config:
         return
 
@@ -135,15 +135,14 @@ def metrics_collection_loop(service_config, loop=None):
     while True:
         logging.debug("Running metrics collections loop")
         if len(ping_params):
-            yield from _collect_ping_metrics(ping_params, loop=loop)
-        yield from _collect_load_metrics()
-        yield from _collect_service_restart_stats()
-        yield from _collect_service_metrics()
-        yield from asyncio.sleep(int(config['sampling_period']))
+            await _collect_ping_metrics(ping_params, loop=loop)
+        await _collect_load_metrics()
+        await _collect_service_restart_stats()
+        await _collect_service_metrics()
+        await asyncio.sleep(int(config['sampling_period']))
 
 
-@asyncio.coroutine
-def _collect_service_restart_stats():
+async def _collect_service_restart_stats():
     """
     Collect the success and failure restarts for services
     """
@@ -163,8 +162,8 @@ def _collect_service_restart_stats():
         ).set(status.num_clean_exits)
 
 
-@asyncio.coroutine
-def _collect_load_metrics():
+
+async def _collect_load_metrics():
     CPU_PERCENT.set(psutil.cpu_percent(interval=1))
 
     SWAP_MEMORY_PERCENT.set(psutil.swap_memory().percent)
@@ -194,9 +193,9 @@ def _collect_load_metrics():
         logging.warning("sensors_temperatures error: %s", ex)
 
 
-@asyncio.coroutine
-def _collect_ping_metrics(ping_params, loop=None):
-    ping_results = yield from ping.ping_async(ping_params, loop=loop)
+
+async def _collect_ping_metrics(ping_params, loop=None):
+    ping_results = await ping.ping_async(ping_params, loop=loop)
     ping_results_list = list(ping_results)
 
     def extract_metrics(ping_stats):
@@ -233,8 +232,7 @@ def _collect_ping_metrics(ping_params, loop=None):
     return ping_results_list
 
 
-@asyncio.coroutine
-def monitor_unattended_upgrade_status():
+async def monitor_unattended_upgrade_status():
     """
     Call to poll the unattended upgrade status and set the corresponding metric
     """
@@ -251,11 +249,11 @@ def monitor_unattended_upgrade_status():
                         break
         logging.debug('Unattended upgrade status is %d', status)
         UNATTENDED_UPGRADE_STATUS.set(status)
-        yield from asyncio.sleep(POLL_INTERVAL_SECONDS)
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
 
-@asyncio.coroutine
-def _collect_service_metrics():
+
+async def _collect_service_metrics():
     config = MagmaService('magmad', mconfigs_pb2.MagmaD()).config
     magma_services = ["magma@" + service for service in config['magma_services']]
     non_magma_services = ["sctpd", "openvswitch-switch"]

--- a/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
@@ -56,12 +56,12 @@ class ConfigManagerTest(TestCase):
             'magma_services': ['magmad', 'metricsd'],
         }
 
-        @asyncio.coroutine
-        def _mock_restart_services():
+        
+        async def _mock_restart_services():
             return "blah"
 
-        @asyncio.coroutine
-        def _mock_update_dynamic_services():
+        
+        async def _mock_update_dynamic_services():
             return "mockResponse"
 
         service_manager_mock = MagicMock()

--- a/orc8r/gateway/python/magma/magmad/upgrade/upgrader.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/upgrader.py
@@ -61,8 +61,8 @@ class UpgraderFactory(object):
         raise NotImplementedError('create_upgrader must be implemented')
 
 
-@asyncio.coroutine
-def start_upgrade_loop(magmad_service, upgrader):
+
+async def start_upgrade_loop(magmad_service, upgrader):
     """
     Check an Upgrader implementation in a loop and upgrade if the Upgrader
     indicates that the software needs to be upgraded.
@@ -79,7 +79,7 @@ def start_upgrade_loop(magmad_service, upgrader):
     # even the first checkin. Delay a little bit so the device can
     # record stats/checkin/give someone an opportunity to disable
     logging.info("Waiting before checking for updates for the first time...")
-    yield from asyncio.sleep(120)
+    await asyncio.sleep(120)
 
     while True:
         logging.info('Checking for upgrade...')
@@ -101,7 +101,7 @@ def start_upgrade_loop(magmad_service, upgrader):
                     'Error encountered while upgrading, '
                     'will try again after %s seconds', poll_interval,
                 )
-        yield from asyncio.sleep(poll_interval)
+        await asyncio.sleep(poll_interval)
 
 
 def _get_target_version(magmad_mconfig):


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->
chore(py): removal of depreceated @asyncio.coroutine  https://github.com/magma/magma/issues/15602
## Summary

<!-- Enumerate changes you made and why you made them -->
This pr resolves the use of the depreceated @asyncio.coroutine usage in the codebase with the new verison of async def/await syntax. But the code base still used the python 3.8.10 and this new syntax is not supported their. Need of migration of python 3.8.10 to ^3.10 .

## Test Plan

The changes made only affect the files at folder
orc8r/gateway/python/magma/common
orc8r/gateway/python/magma/magmad/check
lte/gateway/python/magma/pipelined

The code can be tested by running the pytest for the folder orc8r/gateway/python.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking
