### PR TITLE
fix(ci): error downloading liblfds

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -104,11 +104,11 @@ def cpp_repositories():
         sha256 = "a9fed73e13f06b06a4857d342bb30815fa8c359d00bd69547e567eecbbb4c3a1",
     )
 
-    http_archive(
+    new_git_repository(
         name = "liblfds",
-        urls = ["https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip"],
-        sha256 = "1b1938db2c6928cd8668087effcf4a1211585d24310ab2a82fe446442473c1c4",
         build_file = "//bazel/external:liblfds.BUILD",
+        remote = "git://liblfds.org/liblfds",
+        branch = "master",
     )
 
     new_git_repository(

--- a/third_party/build/bin/liblfds_build.sh
+++ b/third_party/build/bin/liblfds_build.sh
@@ -47,13 +47,7 @@ fi
 mkdir ${WORK_DIR}
 cd ${WORK_DIR}
 
-mkdir -p liblfds/liblfds
-wget --no-check-certificate https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip -P liblfds/liblfds
-
-unzip liblfds/liblfds/'liblfds release 7.1.0 source.zip' -d liblfds/
-# maybe want to edit a persistent copy...
-# rsync -ravP --delete "${SCRIPT_DIR}/liblfds/" liblfds/
-
+git clone git://liblfds.org/liblfds
 cd liblfds/liblfds/liblfds7.1.0/liblfds710/build/gcc_gnumake
 make so_vanilla
 LIB_DIR=/usr/local/lib


### PR DESCRIPTION
fix(ci): error downloading liblfds

## Summary

Replace liblfds zip download with git download.
The liblfds.org https servers often suffers instabilities, changing to git enhances Magma stability against this dependency.
Persistent error presented:
```
magma@magma-agw:~/magma/lte/gateway/docker$ docker compose build gateway_c gateway_python
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "MAGMA_DEV_MODE" variable is not set. Defaulting to a blank string. 
WARN[0000] /home/magma/magma/lte/gateway/docker/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /home/magma/magma/lte/gateway/docker/docker-compose.override.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
Compose can now delegate builds to bake for better performance.
 To do so, set COMPOSE_BAKE=true.
[+] Building 25.0s (81/127)                                                                                                                                                        docker:default
 => [gateway_python internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 6.44kB                                                                                                                                                       0.0s
 => [gateway_c internal] load build definition from Dockerfile                                                                                                                               0.0s
 => => transferring dockerfile: 11.12kB                                                                                                                                                      0.0s
 => [gateway_c internal] load metadata for docker.io/library/ubuntu:focal                                                                                                                    1.2s
 => [gateway_python internal] load .dockerignore                                                                                                                                             0.0s
 => => transferring context: 1.08kB                                                                                                                                                          0.0s
 => [gateway_c internal] load .dockerignore                                                                                                                                                  0.0s
 => => transferring context: 1.08kB                                                                                                                                                          0.0s
 => [gateway_c builder  1/24] FROM docker.io/library/ubuntu:focal@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214                                                    0.0s
 => [gateway_c internal] load build context                                                                                                                                                  0.3s
 => => transferring context: 13.41MB                                                                                                                                                         0.3s
 => [gateway_python internal] load build context                                                                                                                                             0.2s
 => => transferring context: 4.28MB                                                                                                                                                          0.2s
 => CACHED [gateway_python gateway_python  2/15] RUN echo "Acquire::AllowInsecureRepositories true;" > /etc/apt/apt.conf.d/99AllowInsecureRepositories     && echo "APT::Get::AllowUnauthen  0.0s
 => CACHED [gateway_python gateway_python  3/15] RUN apt-get update && apt-get install -y   apt-transport-https   ca-certificates   docker.io   ethtool   inetutils-ping   iproute2   iptab  0.0s
 => CACHED [gateway_python gateway_python  4/15] COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc                                                                0.0s
 => CACHED [gateway_python gateway_python  5/15] RUN echo "deb [trusted=yes] https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main"     > /etc/apt/sources.list.d/  0.0s
 => CACHED [gateway_python gateway_python  6/15] RUN echo "deb https://packages.fluentbit.io/ubuntu/focal focal main" > /etc/apt/sources.list.d/tda.list                                     0.0s
 => CACHED [gateway_python gateway_python  7/15] RUN wget -qO - https://packages.fluentbit.io/fluentbit.key | apt-key add -                                                                  0.0s
 => CACHED [gateway_python gateway_python  8/15] RUN apt-get update && apt-get install -y   bcc-tools   libopenvswitch   openvswitch-datapath-dkms   openvswitch-common   openvswitch-switc  0.0s
 => CACHED [gateway_python gateway_python  9/15] COPY ./lte/gateway/python/dhcp_helper_cli/dhcp_helper_cli.py /usr/local/bin/                                                                0.0s
 => CACHED [gateway_python gateway_python 10/15] RUN mkdir -p /var/opt/magma/                                                                                                                0.0s
 => CACHED [gateway_python builder  2/30] RUN echo "Acquire::AllowInsecureRepositories true;" > /etc/apt/apt.conf.d/99AllowInsecureRepositories     && echo "APT::Get::AllowUnauthenticated  0.0s
 => CACHED [gateway_python builder  3/30] RUN apt-get update && apt-get install -y   docker.io   git   lsb-release   libsystemd-dev   pkg-config   python3-dev   python3-pip   sudo   wget   0.0s
 => CACHED [gateway_python builder  4/30] RUN  wget -P /usr/sbin --progress=dot:giga https://github.com/bazelbuild/bazelisk/releases/download/v1.10.0/bazelisk-linux-"amd64" &&   chmod +x   0.0s
 => CACHED [gateway_python builder  5/30] COPY ./lte/gateway/python/integ_tests/s1aptests/ovs /magma/lte/gateway/python/integ_tests/s1aptests/ovs                                            0.0s
 => CACHED [gateway_python builder  6/30] COPY ./lte/gateway/python/load_tests /magma/lte/gateway/python/load_tests                                                                          0.0s
 => CACHED [gateway_python builder  7/30] COPY ./lte/gateway/python/scripts /magma/lte/gateway/python/scripts                                                                                0.0s
 => CACHED [gateway_python builder  8/30] COPY ./lte/gateway/python/dhcp_helper_cli /magma/lte/gateway/python/dhcp_helper_cli                                                                0.0s
 => CACHED [gateway_python builder  9/30] COPY ./lte/gateway/python/magma /magma/lte/gateway/python/magma                                                                                    0.0s
 => CACHED [gateway_python builder 10/30] COPY ./orc8r/gateway/python /magma/orc8r/gateway/python                                                                                            0.0s
 => CACHED [gateway_python builder 11/30] COPY ./lte/gateway/configs /magma/lte/gateway/configs                                                                                              0.0s
 => CACHED [gateway_python builder 12/30] COPY ./orc8r/gateway/configs/templates /magma/orc8r/gateway/configs/templates                                                                      0.0s
 => CACHED [gateway_python builder 13/30] COPY ./protos /magma/protos                                                                                                                        0.0s
 => CACHED [gateway_python builder 14/30] COPY ./cwf/protos /magma/cwf/protos                                                                                                                0.0s
 => CACHED [gateway_python builder 15/30] COPY ./lte/protos /magma/lte/protos                                                                                                                0.0s
 => CACHED [gateway_python builder 16/30] COPY ./orc8r/protos /magma/orc8r/protos                                                                                                            0.0s
 => CACHED [gateway_python builder 17/30] COPY ./feg/protos /magma/feg/protos                                                                                                                0.0s
 => CACHED [gateway_python builder 18/30] COPY ./dp/protos /magma/dp/protos                                                                                                                  0.0s
 => CACHED [gateway_python builder 19/30] COPY ./cwf/swagger /magma/cwf/swagger                                                                                                              0.0s
 => CACHED [gateway_python builder 20/30] COPY ./feg/swagger /magma/feg/swagger                                                                                                              0.0s
 => CACHED [gateway_python builder 21/30] COPY ./lte/swagger /magma/lte/swagger                                                                                                              0.0s
 => CACHED [gateway_python builder 22/30] COPY ./orc8r/swagger /magma/orc8r/swagger                                                                                                          0.0s
 => CACHED [gateway_python builder 23/30] COPY ./lte/gateway/deploy/roles/magma/files/patches /magma/lte/gateway/deploy/roles/magma/files/patches                                            0.0s
 => CACHED [gateway_python builder 24/30] COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion /magma/                                                                       0.0s
 => CACHED [gateway_python builder 25/30] COPY bazel/ /magma/bazel                                                                                                                           0.0s
 => CACHED [gateway_python builder 26/30] COPY ./lte/gateway/python/BUILD.bazel /magma/lte/gateway/python/BUILD.bazel                                                                        0.0s
 => CACHED [gateway_python builder 27/30] COPY ./lte/gateway/release/BUILD.bazel /magma/lte/gateway/release/BUILD.bazel                                                                      0.0s
 => CACHED [gateway_python builder 28/30] COPY ./lte/gateway/release/deb_dependencies.bzl /magma/lte/gateway/release/deb_dependencies.bzl                                                    0.0s
 => CACHED [gateway_python builder 29/30] WORKDIR /magma                                                                                                                                     0.0s
 => CACHED [gateway_python builder 30/30] RUN bazel build //lte/gateway/release:python_executables_tar //lte/gateway/release:dhcp_helper_cli_tar                                             0.0s
 => CACHED [gateway_python gateway_python 11/15] COPY --from=builder /magma/bazel-bin/lte/gateway/release/magma_python_executables.tar.gz                     /tmp/magma_python_executables  0.0s
 => CACHED [gateway_python gateway_python 12/15] RUN tar -xf /tmp/magma_python_executables.tar.gz --directory / &&     rm /tmp/magma_python_executables.tar.gz                               0.0s
 => CACHED [gateway_python gateway_python 13/15] COPY --from=builder /magma/bazel-bin/lte/gateway/release/magma-dhcp-cli_1.9.0-VERSION-SUFFIX_amd64.tar.gz                     /tmp/magma-d  0.0s
 => CACHED [gateway_python gateway_python 14/15] RUN tar -xf /tmp/magma-dhcp-cli_1.9.0-VERSION-SUFFIX_amd64.tar.gz --directory / &&     rm /tmp/magma-dhcp-cli_1.9.0-VERSION-SUFFIX_amd64.t  0.0s
 => CACHED [gateway_python gateway_python 15/15] WORKDIR /usr/local/bin                                                                                                                      0.0s
 => [gateway_python] exporting to image                                                                                                                                                      0.0s
 => => exporting layers                                                                                                                                                                      0.0s
 => => writing image sha256:a7369536c1fa6f2cf6a9b3a68a9c481e55ef4914cd5a00af792f6ecd2d92a05e                                                                                                 0.0s
 => => naming to docker.io/library/agw-gateway_python                                                                                                                                        0.0s
 => CACHED [gateway_c gateway_c  2/52] RUN ln -snf /usr/share/zoneinfo/Europe/Paris /etc/localtime && echo Europe/Paris > /etc/timezone                                                      0.0s
 => CACHED [gateway_c gateway_c  3/52] RUN echo "Acquire::AllowInsecureRepositories true;" > /etc/apt/apt.conf.d/99AllowInsecureRepositories     && echo "APT::Get::AllowUnauthenticated tr  0.0s
 => CACHED [gateway_c gateway_c  4/52] RUN apt-get update   && DEBIAN_FRONTEND=noninteractive apt-get install -y   apt-transport-https   apt-utils   ca-certificates   gnupg   iproute2   i  0.0s
 => CACHED [gateway_c gateway_c  5/52] COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc                                                                          0.0s
 => CACHED [gateway_c gateway_c  6/52] RUN echo "deb [trusted=yes] https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main"     > /etc/apt/sources.list.d/magma.list  0.0s
 => CACHED [gateway_c gateway_c  7/52] RUN apt-get update && apt-get install -y   libopenvswitch   openvswitch-common   openvswitch-datapath-dkms   openvswitch-switch   && rm -rf /var/lib  0.0s
 => CACHED [gateway_c builder  2/24] RUN echo "Acquire::AllowInsecureRepositories true;" > /etc/apt/apt.conf.d/99AllowInsecureRepositories     && echo "APT::Get::AllowUnauthenticated true  0.0s
 => CACHED [gateway_c builder  3/24] RUN apt-get update &&   apt-get install -y apt-utils software-properties-common apt-transport-https gnupg wget &&   wget -P /usr/sbin --progress=dot:g  0.0s
 => CACHED [gateway_c builder  4/24] RUN apt-get update && apt-get install -y   autoconf   autogen   build-essential   ccache   check   cmake   curl   git   libboost-chrono-dev   libboost  0.0s
 => CACHED [gateway_c builder  5/24] COPY keys/linux_foundation_registry_key.asc /etc/apt/trusted.gpg.d/magma.asc                                                                            0.0s
 => CACHED [gateway_c builder  6/24] RUN echo "deb [trusted=yes] https://linuxfoundation.jfrog.io/artifactory/magma-packages-test focal-ci main"     > /etc/apt/sources.list.d/magma.list    0.0s
 => CACHED [gateway_c builder  7/24] RUN apt-get update && apt-get install -y   grpc-dev   libfolly-dev   liblfds710   magma-cpp-redis   magma-libfluid   oai-asn1c   oai-freediameter   oa  0.0s
 => CACHED [gateway_c builder  8/24] WORKDIR /magma                                                                                                                                          0.0s
 => CACHED [gateway_c builder  9/24] COPY WORKSPACE.bazel BUILD.bazel .bazelignore .bazelrc .bazelversion /magma/                                                                            0.0s
 => CACHED [gateway_c builder 10/24] COPY bazel/ /magma/bazel                                                                                                                                0.0s
 => CACHED [gateway_c builder 11/24] COPY third_party/build/patches/libfluid/ /magma/third_party/build/patches/libfluid/                                                                     0.0s
 => CACHED [gateway_c builder 12/24] RUN bazel build   @com_github_grpc_grpc//:grpc++   @com_google_protobuf//:protobuf   @prometheus_cpp//:prometheus-cpp   @yaml-cpp//:yaml-cpp   @github  0.0s
 => CACHED [gateway_c builder 13/24] COPY feg/protos /magma/feg/protos                                                                                                                       0.0s
 => CACHED [gateway_c builder 14/24] COPY feg/gateway/services/aaa/protos /magma/feg/gateway/services/aaa/protos                                                                             0.0s
 => CACHED [gateway_c builder 15/24] COPY lte/protos /magma/lte/protos                                                                                                                       0.0s
 => CACHED [gateway_c builder 16/24] COPY orc8r/protos /magma/orc8r/protos                                                                                                                   0.0s
 => CACHED [gateway_c builder 17/24] COPY protos /magma/protos                                                                                                                               0.0s
 => CACHED [gateway_c builder 18/24] COPY orc8r/gateway/c/common /magma/orc8r/gateway/c/common                                                                                               0.0s
 => CACHED [gateway_c builder 19/24] COPY lte/gateway/c /magma/lte/gateway/c                                                                                                                 0.0s
 => CACHED [gateway_c builder 20/24] COPY lte/gateway/python/scripts /magma/lte/gateway/python/scripts                                                                                       0.0s
 => CACHED [gateway_c builder 21/24] COPY lte/gateway/docker /magma/lte/gateway/docker                                                                                                       0.0s
 => CACHED [gateway_c builder 22/24] COPY lte/gateway/docker/mme/configs/ /magma/lte/gateway/docker/configs/                                                                                 0.0s
 => ERROR [gateway_c builder 23/24] RUN bazel build    --config=production   //lte/gateway/c/sctpd/src:sctpd   //lte/gateway/c/connection_tracker/src:connectiond   //lte/gateway/c/li_age  23.2s
 => [gateway_python] resolving provenance for metadata file                                                                                                                                  0.0s
------
 > [gateway_c builder 23/24] RUN bazel build    --config=production   //lte/gateway/c/sctpd/src:sctpd   //lte/gateway/c/connection_tracker/src:connectiond   //lte/gateway/c/li_agent/src:liagentd   //lte/gateway/c/session_manager:sessiond   //lte/gateway/c/core:agw_of:
0.305 Starting local Bazel server and connecting to it...
1.853 INFO: Invocation ID: a8e65a23-b1d1-4c11-8de7-a7e89e58abc2
1.855 INFO: Reading 'startup' options from /magma/.bazelrc: --output_base=/var/tmp/bazel, --host_jvm_args=-Xmx8g
1.855 INFO: Options provided by the client:
1.855   Inherited 'common' options: --isatty=0 --terminal_columns=80
1.856 INFO: Reading rc options for 'build' from /magma/.bazelrc:
1.856   Inherited 'common' options: --experimental_allow_tags_propagation --repository_cache=/var/cache/bazel-cache-repo
1.856 INFO: Reading rc options for 'build' from /magma/.bazelrc:
1.856   'build' options: --announce_rc --color=yes --cxxopt=-std=c++14 --strip=never --per_file_copt=^lte/gateway/c/.*$@-g --per_file_copt=^external/.*$@-Wno-all,-Wno-format-security,-Wno-deprecated-declarations --disk_cache=/var/cache/bazel-cache --test_env=PATH=/bin:/usr/bin:/usr/local/bin:/usr/sbin --test_env=MAGMA_ROOT --test_env=S1AP_TESTER_ROOT --test_env=GO_TEST_WRAP_TESTV=1 --per_file_copt=^lte/gateway/c/core/.*$@-DPACKAGE_BUGREPORT="TBD" --per_file_copt=^lte/gateway/c/core/.*$@-DPACKAGE_VERSION="0.1" --per_file_copt=^lte/gateway/c/core/oai/tasks/amf/.*$@-DPACKAGE_NAME="AMF" --per_file_copt=^lte/gateway/c/core/oai/tasks/mme_app/.*$@-DPACKAGE_NAME="MME" --per_file_copt=^lte/gateway/c/core/oai/tasks/sgw/.*$@-DPACKAGE_NAME="S/P-GW" --javacopt=-source 8 --javacopt=-target 8 --java_runtime_version=remotejdk_11
1.857 INFO: Found applicable config definition build:production in file /magma/.bazelrc: --define=production=1
2.022 Loading: 
2.025 Loading: 0 packages loaded
3.030 Loading: 0 packages loaded
3.434 Analyzing: 5 targets (5 packages loaded, 0 targets configured)
4.442 Analyzing: 5 targets (49 packages loaded, 207 targets configured)
5.588 Analyzing: 5 targets (56 packages loaded, 212 targets configured)
6.814 Analyzing: 5 targets (61 packages loaded, 212 targets configured)
7.931 Analyzing: 5 targets (66 packages loaded, 288 targets configured)
8.963 Analyzing: 5 targets (75 packages loaded, 483 targets configured)
10.08 Analyzing: 5 targets (106 packages loaded, 5412 targets configured)
11.34 Analyzing: 5 targets (115 packages loaded, 7141 targets configured)
12.77 Analyzing: 5 targets (115 packages loaded, 7141 targets configured)
16.02 Analyzing: 5 targets (115 packages loaded, 7141 targets configured)
22.88 Analyzing: 5 targets (115 packages loaded, 7141 targets configured)
22.89 INFO: Repository liblfds instantiated at:
22.89   /magma/WORKSPACE.bazel:117:17: in <toplevel>
22.89   /magma/bazel/cpp_repositories.bzl:107:17: in cpp_repositories
22.89 Repository rule http_archive defined at:
22.89   /var/tmp/bazel/external/bazel_tools/tools/build_defs/repo/http.bzl:353:31: in <toplevel>
22.90 WARNING: Download from https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip failed: class javax.net.ssl.SSLHandshakeException PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
22.91 ERROR: An error occurred during the fetch of repository 'liblfds':
22.91    Traceback (most recent call last):
22.91   File "/var/tmp/bazel/external/bazel_tools/tools/build_defs/repo/http.bzl", line 100, column 45, in _http_archive_impl
22.91           download_info = ctx.download_and_extract(
22.91 Error in download_and_extract: java.io.IOException: Error downloading [https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip] to /var/tmp/bazel/external/liblfds/temp17916668545163735604/liblfds%20release%207.1.0%20source.zip: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
22.91 ERROR: /magma/WORKSPACE.bazel:117:17: fetching http_archive rule //external:liblfds: Traceback (most recent call last):
22.91   File "/var/tmp/bazel/external/bazel_tools/tools/build_defs/repo/http.bzl", line 100, column 45, in _http_archive_impl
22.91           download_info = ctx.download_and_extract(
22.91 Error in download_and_extract: java.io.IOException: Error downloading [https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip] to /var/tmp/bazel/external/liblfds/temp17916668545163735604/liblfds%20release%207.1.0%20source.zip: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
22.92 ERROR: /magma/lte/gateway/c/core/BUILD.bazel:1159:11: //lte/gateway/c/core:lib_agw_of depends on @liblfds//:lfds710 in repository @liblfds which failed to fetch. no such package '@liblfds//': java.io.IOException: Error downloading [https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip] to /var/tmp/bazel/external/liblfds/temp17916668545163735604/liblfds%20release%207.1.0%20source.zip: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
23.03 ERROR: Analysis of target '//lte/gateway/c/core:agw_of' failed; build aborted: 
23.05 INFO: Elapsed time: 22.739s
23.05 INFO: 0 processes.
23.05 FAILED: Build did NOT complete successfully (115 packages loaded, 7141 targets configured)
23.06 FAILED: Build did NOT complete successfully (115 packages loaded, 7141 targets configured)
23.07 
------
failed to solve: process "/bin/sh -c bazel build    --config=production   //lte/gateway/c/sctpd/src:sctpd   //lte/gateway/c/connection_tracker/src:connectiond   //lte/gateway/c/li_agent/src:liagentd   //lte/gateway/c/session_manager:sessiond   //lte/gateway/c/core:agw_of" did not complete successfully: exit code: 1
```

## Test Plan

```
cd ~/magma/lte/gateway/docker
docker compose build gateway_c gateway_python
```

## Additional Information

Error description:


- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

