### PR TITLE
fix(ci): resolve golangci-lint cache initialization failure

### DIFF
--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -67,7 +67,7 @@ jobs:
       GOCACHE: ${{ github.workspace }}/.cache/go-build
       GOMODCACHE: ${{ github.workspace }}/.cache/go-mod
       GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint
-      GOPATH: "${{ github.workspace }}/../../_work/_tool/go/1.20.1/x64/bin/go"
+      GOPATH: "${{ github.workspace }}/../../_work/_tool/go/1.20.1/x64"
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -64,12 +64,21 @@ jobs:
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"
+      GOCACHE: ${{ github.workspace }}/.cache/go-build
+      GOMODCACHE: ${{ github.workspace }}/.cache/go-mod
+      GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.cache/golangci-lint
+      GOPATH: "${{ github.workspace }}/../../_work/_tool/go/1.20.1/x64/bin/go"
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
           go-version: '1.20.1'
       - run: go version
+      - name: Create Go cache directories
+        run: |
+          mkdir -p ${{ github.workspace }}/.cache/go-build
+          mkdir -p ${{ github.workspace }}/.cache/go-mod
+          mkdir -p ${{ github.workspace }}/.cache/golangci-lint
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary
Fixed golangci-lint build cache initialization failure in GitHub Actions by adding explicit cache directory creation and GOLANGCI_LINT_CACHE environment variable. This resolves the "mkdir : no such file or directory" error that was causing the feg-lint-precommit job to fail.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

