### PR TITLE
docs: fix broken security policy link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The Magma materials are provided in accordance with the licenses made available 
 
 ## Security
 
-Responsible disclosures from independent researchers are gratefully accepted. See the [Security Policy](/magma/magma/security/policy) for submission details and [Security Overview for Contributors](https://github.com/magma/magma/wiki/Security-Overview-for-Contributors) to learn about other ways of contributing.
+Responsible disclosures from independent researchers are gratefully accepted. See the [Security Policy](SECURITY.md) for submission details and [Security Overview for Contributors](https://github.com/magma/magma/wiki/Security-Overview-for-Contributors) to learn about other ways of contributing.
 
 We appreciate very much the valuable disclosures (and often fixes) from the following security researchers:
 


### PR DESCRIPTION
## Summary
The "Security Policy" link in the `README.md` file was broken. It pointed to a path (`/magma/magma/security/policy`) that returns a **404 Page Not Found** error, even on the main repository.

I have updated the link to point directly to the `SECURITY.md` file located in the root directory. This ensures the link resolves correctly for all users.

## Test Plan

I verified that the new link correctly opens the Security Policy file.

**Before (Broken Link):**
<img width="1312" height="735" alt="before" src="https://github.com/user-attachments/assets/1057f9b5-c34c-457a-84b4-14045f381c0b" />


**After (Working Link):**
<img width="1313" height="733" alt="after" src="https://github.com/user-attachments/assets/c04feafb-656d-4b61-95c7-8d8919a6b075" />


## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

This change improves security hygiene by ensuring that the Security Policy and vulnerability reporting instructions are easily accessible to contributors and researchers.