### PR TITLE
test(agw): add unit test for state recovery exception handling

### DIFF
--- a/lte/gateway/python/magma/health/tests/test_state_recovery.py
+++ b/lte/gateway/python/magma/health/tests/test_state_recovery.py
@@ -61,3 +61,28 @@ class TestStateRecovery(unittest.TestCase):
         job._get_service_status = MagicMock(return_value=None)
         last_services_restarts = job._get_last_service_restarts()
         self.assertDictEqual({services[0]: 0}, last_services_restarts)
+
+    def test_get_last_service_restarts_with_exception(self):
+        """
+        Test that if the underlying service wrapper raises a KeyError/ConnectionError,
+        the job handles it gracefully and assumes 0 restarts.
+        """
+        services = ["service1"]
+        mock_service_state = MagicMock()
+
+        job = StateRecoveryJob(
+            mock_service_state,
+            MagicMock(),
+            services,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+
+        mock_service_state.get_service_status.side_effect = KeyError("Service not found")
+
+        # pylint: disable=protected-access
+        last_services_restarts = job._get_last_service_restarts()  # noqa: WPS450
+
+        self.assertDictEqual({services[0]: 0}, last_services_restarts)


### PR DESCRIPTION
## Summary

I have added a new unit test case, `test_get_last_service_restarts_with_exception`, to `lte/gateway/python/magma/health/tests/test_state_recovery.py`.

The `StateRecoveryJob` is designed to poll service status to detect crash loops. This change ensures that if the underlying service wrapper raises an exception (such as `KeyError` or `ConnectionError`) during a status check, the job handles it gracefully by defaulting to 0 restarts rather than crashing the health service. The new test verifies this exception handling logic using `unittest.mock`.

## Test Plan

I have verified the logic of the test case to ensure it correctly mocks the `side_effect` of the service status call.

**Validation Steps:**
1. Validated that `_get_last_service_restarts` catches the exception and returns the default value `0` for the service.
2. Verified via Bazel command:
   ```bash
   bazel test //lte/gateway/python/magma/health/tests:test_state_recovery