### PR TITLE
Remove schedule for docker-builder-devcontainer

### DIFF
--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -36,8 +36,6 @@ on:
       - .devcontainer/Dockerfile
       - .github/workflows/docker-builder-devcontainer.yml
       - .github/workflows/composite/**
-  schedule:
-    - cron: '17 4 * * 6' # At 04:17 on Saturday
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
The job doesn't run successfully anymore. Given that I last updated the cron schedule I get notified of the failures, so I'd like to delete the schedule.