### PR TITLE
Pin Ruby gem dependencies for fluentd on Ruby 2.7

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -10,12 +10,12 @@
 # limitations under the License.
 
 FROM fluent/fluentd:v1.14.6-debian-1.0
+
 USER root
-# Pin multi_json for Ruby 2.7 compatibility
-RUN gem install multi_json -v 1.15.0 --no-document
-# Pin excon for Ruby 2.7 compatibility
-RUN gem install excon -v 1.2.5 --no-document
+
 RUN gem install \
+multi_json -v 1.15.0 \
+excon -v 1.2.5 \ 
     elasticsearch:7.13.0 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \

--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -11,6 +11,10 @@
 
 FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
+# Pin multi_json for Ruby 2.7 compatibility
+RUN gem install multi_json -v 1.15.0 --no-document
+# Pin excon for Ruby 2.7 compatibility
+RUN gem install excon -v 1.2.5 --no-document
 RUN gem install \
     elasticsearch:7.13.0 \
     fluent-plugin-elasticsearch:5.2.1 \


### PR DESCRIPTION
On fresh setups, the fluentd Docker image build fails due to Ruby gems
dropping support for Ruby 2.7.

Specifically:
- multi_json now requires Ruby >= 3.0
- excon now requires Ruby >= 3.1

This PR pins multi_json and excon to the last versions compatible with
Ruby 2.7, restoring successful fluentd builds without changing runtime
behavior.
