### PR TITLE
Fix: Bazel build failure by switching liblfds dependency to archive.org mirror

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -106,7 +106,7 @@ def cpp_repositories():
 
     http_archive(
         name = "liblfds",
-        urls = ["https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip"],
+        urls = ["https://web.archive.org/web/20211022085046/https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip"],
         sha256 = "1b1938db2c6928cd8668087effcf4a1211585d24310ab2a82fe446442473c1c4",
         build_file = "//bazel/external:liblfds.BUILD",
     )

--- a/third_party/build/bin/liblfds_build.sh
+++ b/third_party/build/bin/liblfds_build.sh
@@ -48,7 +48,7 @@ mkdir ${WORK_DIR}
 cd ${WORK_DIR}
 
 mkdir -p liblfds/liblfds
-wget --no-check-certificate https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip -P liblfds/liblfds
+wget https://web.archive.org/web/20211022085046/https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip -P liblfds/liblfds
 
 unzip liblfds/liblfds/'liblfds release 7.1.0 source.zip' -d liblfds/
 # maybe want to edit a persistent copy...


### PR DESCRIPTION
## Summary

This PR fixes a blocking Bazel build failure caused by the upstream `liblfds.org` download URL returning an SSL certificate validation error (`SSLHandshakeException: PKIX path validation failed`).

The original download endpoint:
```
https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip
```
is no longer reliable due to an invalid/expired certificate, preventing AGW C/C++ targets and `gen_compilation_database.py` from building inside the  VS Code devcontainer.

**Changes included:**
- Updated `bazel/cpp_repositories.bzl` to use a stable archive.org snapshot:
https://web.archive.org/web/20211022085046/https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip

- Updated fallback script in `third_party/build/bin/liblfds_build.sh` to use the same mirror.
- SHA256 remains unchanged, as the archive.org snapshot serves the identical artifact.

This restores reliable dependency fetching for developers on Ubuntu 24.04, WSL2, and the devcontainer workflow.

## Test Plan

- Performed `apt update`, CA certificate updates, Bazel resets (`shutdown`, `clean --expunge`) to rule out local causes.
- Applied the updated mirror URL and verified Bazel builds successfully.
- Successful run of:
  ```
  bazel build //lte/gateway/c/core:all
  ```
confirming the dependency now downloads correctly and build proceeds past theprevious failure point.
  
  Build output included:
```
INFO: Build completed successfully, 4638 total actions
```

## Additional Information
Fixes: #15797 

## Security Considerations
- Replaces an endpoint with an invalid/expired SSL certificate.
- Archive.org provides a stable HTTPS-backed snapshot, improving supply-chain reliability.
- Does not introduce new dependencies or weaken TLS validation.
