### PR TITLE
docs(orc8r): add local Docker setup notes for Orc8r

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -56,7 +56,9 @@ def integ_test(
     rerun_fails="1",
 ):
     """
-    Run the integration tests. This defaults to running on local vagrant
+    Run the integration tests.
+
+    This defaults to running on local vagrant
     machines, but can also be pointed to an arbitrary host (e.g. amazon) by
     passing "address:port" as arguments
 
@@ -210,7 +212,8 @@ def transfer_artifacts(
     services="sessiond session_proxy", get_core_dump=False,
 ):
     """
-    Fetches service logs from Docker and optionally gets core dumps
+    Fetch service logs from Docker and optionally get core dumps.
+
     Args:
         c: Fabric connection
         gateway_vm: VM to fetch logs from
@@ -281,7 +284,7 @@ def _transfer_docker_images(c_cwf, skip_docker_load, tar_path):
 
 
 def _set_cwag_configs(c_vm, configfile):
-    """ Set the necessary config overrides """
+    """Set the necessary config overrides."""
     c_vm.run('sudo mkdir -p /var/opt/magma/configs')
     c_vm.run(f"sudo cp {CWAG_INTEG_ROOT}/{configfile} /var/opt/magma/configs/gateway.mconfig")
 
@@ -296,7 +299,7 @@ def _get_br_mac(c_vm, bridge_name):
 
 
 def _set_cwag_test_configs(c_test):
-    """ Set the necessary test configs """
+    """Set the necessary test configs."""
     c_test.run('sudo mkdir -p /etc/magma')
     # Create empty uesim config
     c_test.run('sudo touch /etc/magma/uesim.yml')
@@ -304,7 +307,7 @@ def _set_cwag_test_configs(c_test):
 
 
 def _start_ipfix_controller(c_test):
-    """ Start the IPFIX collector"""
+    """Start the IPFIX collector."""
     with c_test.cd("$MAGMA_ROOT"):
         c_test.run('mkdir -p records')
         c_test.run('rm -rf records/*')
@@ -323,8 +326,7 @@ def _set_cwag_test_networking(c_test, mac):
 
 
 def _add_networkhost_docker(c_cwf):
-    """ Add network host to docker engine """
-
+    """Add network host to docker engine."""
     local_host = "unix:///var/run/docker.sock"
     nw_host = "tcp://0.0.0.0:2375"
     tmp_daemon_json_fn = "/tmp/daemon.json"
@@ -351,7 +353,7 @@ def _add_networkhost_docker(c_cwf):
 
 
 def _stop_gateway(c_cwf):
-    """ Stop the gateway docker images """
+    """Stop the gateway docker images."""
     with c_cwf.cd(CWAG_ROOT + '/docker'):
         c_cwf.run(
             ' docker compose'
@@ -363,7 +365,7 @@ def _stop_gateway(c_cwf):
 
 
 def _build_gateway(c_cwf):
-    """ Builds the gateway docker images """
+    """Build the gateway docker images."""
     with c_cwf.cd(CWAG_ROOT + '/docker'):
         c_cwf.run(
             ' docker compose'
@@ -377,7 +379,7 @@ def _build_gateway(c_cwf):
 
 
 def _run_gateway(c_cwf):
-    """ Runs the gateway's docker images """
+    """Run the gateway's docker images."""
     with c_cwf.cd(CWAG_ROOT + '/docker'):
         c_cwf.run(
             ' docker compose'
@@ -392,7 +394,7 @@ def _run_gateway(c_cwf):
 def _check_docker_services(c_cwf, ignore_list):
     with c_cwf.cd(CWAG_ROOT + "/docker"):
         grep_ignore = "| grep --invert-match '" + \
-            '\\|'.join(ignore_list) + "'" if ignore_list else ""
+    	    r'\|'.join(ignore_list) + "'" if ignore_list else ""
         count = 0
         while count < 5:
             # force wait to make sure docker logs are up
@@ -414,7 +416,7 @@ def _check_docker_services(c_cwf, ignore_list):
 
 
 def _start_ue_simulator(c_test):
-    """ Starts the UE Sim Service and logs into uesim.log"""
+    """Start the UE Sim Service and log into uesim.log."""
     with c_test.cd(CWAG_ROOT + '/services/uesim/uesim'):
         c_test.run(
             env={'PATH': '$PATH:/usr/local/go/bin:/home/vagrant/go/bin'},
@@ -423,14 +425,14 @@ def _start_ue_simulator(c_test):
 
 
 def _start_trfserver(c_trf):
-    """ Starts the traffic gen server"""
+    """Start the traffic gen server."""
     trf_cmd = f'nohup iperf3 -s --json -B {TRF_SERVER_IP} > /dev/null &'
     c_trf.run('sudo apt-get install -y dtach')
     c_trf.run(f"sudo dtach -n `mktemp -u /tmp/dtach.XXXX` {trf_cmd}")
 
 
 def _run_unit_tests(c_cwf):
-    """ Run the cwag unit tests """
+    """Run the cwag unit tests."""
     with c_cwf.cd(CWAG_ROOT):
         c_cwf.run(
             'make test',
@@ -450,7 +452,7 @@ def _run_integ_tests(
     test_host, trf_host, tests_to_run: SubTests, test_re, count,
     test_result_xml, rerun_fails, c_test_vm, c_trf,
 ):
-    """ Run the integration tests """
+    """Run the integration tests."""
     # add docker host environment as well
     shell_env_vars = {
         "DOCKER_HOST": f"tcp://{CWAG_IP}:2375",
@@ -493,4 +495,6 @@ def _clean_up(c_test_vm, c_trf):
 
 
 class FabricException(Exception):
+    """Custom exception for Fabric-related errors."""
+
     pass

--- a/orc8r/cloud/docker/README.md
+++ b/orc8r/cloud/docker/README.md
@@ -1,0 +1,44 @@
+# Orc8r Local Docker Setup Notes
+
+This directory contains Docker Compose files for running Magma Orc8r services
+locally for development and testing purposes.
+
+## Notes on Local Setup (Docker Compose v2 & Ubuntu 24.04)
+
+Running Orc8r locally using Docker Compose may fail on newer environments
+(e.g. Ubuntu 24.04 with Docker Compose v2).
+
+During local setup, the following issues were observed:
+
+- Docker Compose v2 ignores the `version` field (harmless warning)
+- Orc8r controller, test, nginx, and fluentd images may fail to build
+- Build failures occur due to missing expected build-context paths such as:
+  - `configs/`
+  - `src/`
+  - `gomod/`
+
+Example error:
+
+`
+COPY configs /etc/magma/configs
+failed to calculate checksum: "/configs": not found
+`
+
+
+Because of these build failures:
+- Orc8r services may not fully start
+- The NMS (Admin UI) login page may not be reachable locally
+- Admin login issues discussed in the community may not be reproducible
+  without a fully running Orc8r environment
+
+## Recommendation
+
+- Local Orc8r Docker setup should be treated as **best-effort**
+- Contributors working on AGW, linting, documentation, or CI do **not**
+  need a locally running Orc8r
+- For admin login or NMS testing, a cloud-based or CI-backed Orc8r deployment
+  may be more reliable
+
+This documentation reflects observed behavior using official instructions
+and is intended to help contributors avoid setup blockers.
+

--- a/protos/gen_protos.py
+++ b/protos/gen_protos.py
@@ -20,7 +20,7 @@ from grpc.tools import protoc
 
 def find_all_proto_files_in_dir(input_dir: str) -> List[str]:
     """
-    Returns a list of filenames of .proto files in the given directory
+    Return a list of filenames of .proto files in the given directory.
 
     Args:
         input_dir: Directory to search in
@@ -51,7 +51,8 @@ def gen_bindings(
         output_dir: str,
 ) -> None:
     """
-    Generates python and Go bindings for all .proto files in input dir
+    Generate python and Go bindings for all .proto files in input dir.
+
        @input_dir - input directory with .proto files to generate code for
        @include_paths - a list of include paths to resolve relative imports in .protos
        @output_dir - output directory to put generated code in
@@ -77,8 +78,9 @@ def gen_bindings(
 
 def main():
     """
-    Default main module. Generates .py code for all proto files
-    specified by the arguments
+    Generate .py code for all proto files specified by the arguments.
+
+    Default main module.
     """
     if len(sys.argv) != 5:
         print(


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

This PR adds documentation describing **limitations and known issues when running
Orc8r locally using Docker Compose**, particularly on **Ubuntu 24.04 with Docker
Compose v2**.

While attempting a local Orc8r setup using official instructions, several build
failures were encountered due to missing expected build-context paths (e.g.
`configs`, `src`, `gomod`). As a result, Orc8r services did not fully start and
the NMS (Admin UI) login page could not be reached.

This documentation is intended to:
- Set correct expectations for contributors
- Reduce setup-related confusion and time spent debugging
- Clarify that local Orc8r Docker setup is best-effort for development

---

## Test Plan

- Followed official Orc8r local Docker setup steps from `orc8r/cloud/docker`
- Ran `docker compose up -d` using Docker Compose v2 on Ubuntu 24.04
- Observed and captured reproducible build failures in controller/test images
- Verified that the documented behavior matches observed results

No functional code changes were made.

---

## Additional Information

- [ ] This change is backwards-breaking

---

## Security Considerations

This change has **no security impact**.

It only adds documentation based on observed local development behavior and does
not modify runtime logic, configuration, authentication, or authorization paths.
