### PR TITLE
docs: fix typo 'succesfully' → 'successfully' in documentation

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.4.X/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.4.X/nms/metrics.md
@@ -124,7 +124,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 |unattended_upgrade_status	|Unattended Upgrade status	|AGW	|magmad	|
 |service_restart_status	|Count of service restarts	|AGW	|magmad	|
 |enb_connected	|Number of eNodeb connected to MME	|AGW	|MME	|
-|ue_registered	|Number of UE registered succesfully	|AGW	|MME	|
+|ue_registered	|Number of UE registered successfully	|AGW	|MME	|
 |ue_connected	|Number of UE connected	|AGW	|MME	|
 |ue_attach	|Number of UE attach success	|AGW	|MME	|
 |ue_detach	|Number of UE detach	|AGW	|MME	|

--- a/docs/docusaurus/versioned_docs/version-1.5.X/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.5.X/nms/metrics.md
@@ -124,7 +124,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 |unattended_upgrade_status	|Unattended Upgrade status	|AGW	|magmad	|
 |service_restart_status	|Count of service restarts	|AGW	|magmad	|
 |enb_connected	|Number of eNodeb connected to MME	|AGW	|MME	|
-|ue_registered	|Number of UE registered succesfully	|AGW	|MME	|
+|ue_registered	|Number of UE registered successfully	|AGW	|MME	|
 |ue_connected	|Number of UE connected	|AGW	|MME	|
 |ue_attach	|Number of UE attach success	|AGW	|MME	|
 |ue_detach	|Number of UE detach	|AGW	|MME	|

--- a/docs/docusaurus/versioned_docs/version-1.6.X/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.6.X/nms/metrics.md
@@ -124,7 +124,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 |unattended_upgrade_status	|Unattended Upgrade status	|AGW	|magmad	|
 |service_restart_status	|Count of service restarts	|AGW	|magmad	|
 |enb_connected	|Number of eNodeb connected to MME	|AGW	|MME	|
-|ue_registered	|Number of UE registered succesfully	|AGW	|MME	|
+|ue_registered	|Number of UE registered successfully	|AGW	|MME	|
 |ue_connected	|Number of UE connected	|AGW	|MME	|
 |ue_attach	|Number of UE attach success	|AGW	|MME	|
 |ue_detach	|Number of UE detach	|AGW	|MME	|

--- a/docs/docusaurus/versioned_docs/version-1.7.0/nms/metrics.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/nms/metrics.md
@@ -125,7 +125,7 @@ the left sidebar, then edit the feature flag named "Include tab for Grafana in t
 |unattended_upgrade_status |Unattended Upgrade status |AGW |magmad |
 |service_restart_status |Count of service restarts |AGW |magmad |
 |enb_connected |Number of eNodeb connected to MME |AGW |MME |
-|ue_registered |Number of UE registered succesfully |AGW |MME |
+|ue_registered |Number of UE registered successfully |AGW |MME |
 |ue_connected |Number of UE connected |AGW |MME |
 |ue_attach |Number of UE attach success |AGW |MME |
 |ue_detach |Number of UE detach |AGW |MME |

--- a/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p008_mandatory_integration_tests_for_each_PR.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/proposals/p008_mandatory_integration_tests_for_each_PR.md
@@ -37,7 +37,7 @@ Stage 1:
 
 - Ensure that for each commit of each PR all unit test jobs are executed by CircleCI
 - Ensure that each PR was reviewed and accepted by component maintainer
-- Ensure that each PR which succesfully passed unit testing and maintainer review gets "ready-to-merge" label assigned.
+- Ensure that each PR which successfully passed unit testing and maintainer review gets "ready-to-merge" label assigned.
 - Ensure that each PR marked with label "ready-to-merge" was tested by all integration tests.
  Stage 2:
 - Ensure that each PR marked with label "ready-to-merge", which passed integration tests is automatically merged by CI.

--- a/docs/readmes/proposals/p008_mandatory_integration_tests_for_each_PR.md
+++ b/docs/readmes/proposals/p008_mandatory_integration_tests_for_each_PR.md
@@ -36,7 +36,7 @@ Stage 1:
 
 - Ensure that for each commit of each PR all unit test jobs are executed by CircleCI
 - Ensure that each PR was reviewed and accepted by component maintainer
-- Ensure that each PR which succesfully passed unit testing and maintainer review gets "ready-to-merge" label assigned.
+- Ensure that each PR which successfully passed unit testing and maintainer review gets "ready-to-merge" label assigned.
 - Ensure that each PR marked with label "ready-to-merge" was tested by all integration tests.
  Stage 2:
 - Ensure that each PR marked with label "ready-to-merge", which passed integration tests is automatically merged by CI.


### PR DESCRIPTION
## Summary
Fixed spelling errors of "succesfully" → "successfully" across multiple documentation files to improve documentation quality and readability.

Changes made:
- Corrected typo in `proposals/p008_mandatory_integration_tests_for_each_PR.md`
- Corrected typo in `nms/metrics.md` across versions 1.4.X, 1.5.X, 1.6.X, and 1.7.0

## Test Plan
- Manually reviewed all changed files to ensure:
  - All instances of "succesfully" were corrected to "successfully"
  - No unintended changes were made
  - Documentation formatting remains intact
- Verified changes using `git diff` to confirm only spelling corrections were made

## Additional Information
- [x] This change is **NOT** backwards-breaking
- Part of LFX Mentorship contribution

## Security Considerations
No security impact. This change only corrects spelling errors in documentation with no code or functional changes.
