### PR TITLE
docs(orc8r): improve bare metal deployment discoverability

### DIFF
--- a/docs/readmes/orc8r/deploy_install.md
+++ b/docs/readmes/orc8r/deploy_install.md
@@ -1,12 +1,12 @@
 ---
 id: deploy_install
-title: Install Orchestrator
+title: Install Orchestrator on AWS
 hide_title: true
 ---
 
-# Install Orchestrator
+# Install Orchestrator on AWS
 
-This page walks through a full, vanilla Orchestrator install.
+This page walks through a full, vanilla Orchestrator install on AWS.
 
 If you want to install a specific release version, see the notes in the
 [deployment intro](./deploy_intro.md).

--- a/docs/readmes/orc8r/deploy_intro.md
+++ b/docs/readmes/orc8r/deploy_intro.md
@@ -10,9 +10,9 @@ This section walks through installing a production Orchestrator deployment.
 
 We assume you will use the versioned artifacts provided by the project's official artifactory at [linuxfoundation.jfrog.io](https://linuxfoundation.jfrog.io/). If you would like to build and host your own artifacts, see the [Build Orchestrator](./dev_build.md) page.
 
-To deploy orc8r on AWS, see the [AWS Deployment](./deploy_install.md) page.
+To deploy Orchestrator on AWS, see the [AWS Deployment](./deploy_install.md) page.
 
-To deploy orc8r on Bare Metal or a standard Linux VM, see the [Ansible Deployment](./deploy_using_ansible.md) page.
+To deploy Orchestrator on Bare Metal or a standard Linux VM, see the [Ansible Deployment](./deploy_using_ansible.md) page.
 
 ## Prerequisites
 

--- a/docs/readmes/orc8r/deploy_intro.md
+++ b/docs/readmes/orc8r/deploy_intro.md
@@ -10,7 +10,9 @@ This section walks through installing a production Orchestrator deployment.
 
 We assume you will use the versioned artifacts provided by the project's official artifactory at [linuxfoundation.jfrog.io](https://linuxfoundation.jfrog.io/). If you would like to build and host your own artifacts, see the [Build Orchestrator](./dev_build.md) page.
 
-To deploy orc8r, see the [Manual installation](./deploy_install.md) page.
+To deploy orc8r on AWS, see the [AWS Deployment](./deploy_install.md) page.
+
+To deploy orc8r on Bare Metal or a standard Linux VM, see the [Ansible Deployment](./deploy_using_ansible.md) page.
 
 ## Prerequisites
 
@@ -24,9 +26,10 @@ Before deployment, it may be useful to read through the [Magma prerequisites](..
 
 Familiarity with the following is assumed
 
-- AWS
 - Kubernetes
-- Terraform
+- AWS (if deploying on AWS)
+- Terraform (if deploying on AWS)
+- Ansible (if deploying on Bare Metal)
 
 The instructions in this section have been tested on macOS and Linux. If you are deploying from a Windows host, some shell commands will likely require adjustments.
 


### PR DESCRIPTION
Fixes #15798 
## Summary
Updates deployment docs to distinguish between AWS and Bare Metal paths.

## Changes
- Added link to Ansible guide in deploy_intro.md
- - Renamed deploy_install.md title to "Install Orchestrator on AWS"
- - Clarified prerequisites