### PR TITLE
fix(nms): Handle null error object in login failure callbacks

### DIFF
--- a/nms/server/auth/express.ts
+++ b/nms/server/auth/express.ts
@@ -88,7 +88,8 @@ function userMiddleware(options: Options) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       passport.authenticate('local', (err: Error, user: UserModel) => {
         if (!user || err) {
-          logger.error('Failed login: ' + err.toString());
+          const msg = err ? err.toString() : 'Authentication failed';
+          logger.error('Failed login: ' + msg);
           return res.redirect(loginFailureUrl);
         }
         req.logIn(user, err => {
@@ -185,7 +186,8 @@ function userMiddleware(options: Options) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       passport.authenticate('oidc', (err: Error, user: UserModel) => {
         if (!user || err) {
-          logger.error('Error logging in with oidc: ' + err.toString());
+          const msg = err ? err.toString() : 'OIDC authentication failed';
+          logger.error('Error logging in with oidc: ' + msg);
           return res.redirect(options.loginFailureUrl);
         }
         req.logIn(user, err => {


### PR DESCRIPTION
## Summary
Fixes a crash in the NMS auth middleware where `err.toString()` was called on a null/undefined `err` object during login or OIDC authentication failure.

## Changes
- Added a check for `err` existence before converting to string.
- - Default to "Authentication failed" or "OIDC authentication failed" if no error object is present.
- - Impacted file: nms/server/auth/express.ts
## Testing
- Verified logic handles both present and missing error objects.
- - (Recommended) Verify NMS login flow locally by triggering a failure.
Fixes #15799 
Signed-off-by: Gyan Ranjan Panda <your.email@example.com>