### PR TITLE
fix(nms): Handle login for null state

### DIFF
--- a/nms/app/views/login/LoginForm.tsx
+++ b/nms/app/views/login/LoginForm.tsx
@@ -90,13 +90,33 @@ type Props = {
 const HOST_PORTAL_TITLE = 'Magma Host Portal';
 const ORGANIZATION_PORTAL_TITLE = 'Magma Organization Portal';
 
-class LoginForm extends React.Component<Props> {
+class LoginForm extends React.Component<Props, {validationError: string}> {
   form: HTMLFormElement | null = null;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {validationError: ''};
+  }
+
+  validateSubmit = () => {
+    const email = document.getElementsByName('email')[0] as HTMLInputElement;
+    const password = document.getElementsByName(
+      'password'
+    )[0] as HTMLInputElement;
+    if (this.form && email.value !== '' && password.value !== '') {
+      this.form.submit();
+    } else {
+      this.setState({validationError: 'Invalid email or password'});
+    }
+  };
 
   render() {
     const {classes, csrfToken, ssoEnabled, ssoAction} = this.props;
-    const error = this.props.error ? (
-      <FormLabel error>{this.props.error}</FormLabel>
+    const error = 
+      this.props.error || this.state.validationError ? (
+    <FormLabel error>
+      {this.props.error || this.state.validationError}
+    </FormLabel>
     ) : null;
 
     const params = new URLSearchParams(window.location.search);
@@ -168,7 +188,7 @@ class LoginForm extends React.Component<Props> {
                       placeholder="Email"
                       className={classes.input}
                       onKeyUp={key =>
-                        key.keyCode === ENTER_KEY && this.form!.submit()
+                        key.keyCode === ENTER_KEY && this.validateSubmit()
                       }
                     />
                   </AltFormField>
@@ -180,7 +200,7 @@ class LoginForm extends React.Component<Props> {
                       type="password"
                       className={classes.input}
                       onKeyUp={key =>
-                        key.keyCode === ENTER_KEY && this.form!.submit()
+                        key.keyCode === ENTER_KEY && this.validateSubmit()
                       }
                     />
                   </AltFormField>
@@ -190,7 +210,7 @@ class LoginForm extends React.Component<Props> {
                     color="primary"
                     variant="contained"
                     className={classes.submitButton}
-                    onClick={() => this.form!.submit()}>
+                    onClick={this.validateSubmit}>
                     Login
                   </Button>
                 </CardActions>


### PR DESCRIPTION
## Summary

Fixes issue #15799 by adding client-side validation to the NMS login form to prevent login attempts when required fields are empty.
The update ensures that login requests are only sent when both the email and password fields contain values, reducing unnecessary authentication requests and improving user feedback.

## Changes

- Added `validateSubmit()` logic to verify that both email and password inputs are populated.
- Prevented form submission when either field is empty.
- Displayed a validation error message: **"Invalid email or password"** when validation fails.
- Ensured the Enter key triggers the same validation logic as the login button.

## Test Plan

- Verified successful login when both email and password are provided.
- Verified validation error appears when the email field is empty.
- Verified validation error appears when the password field is empty.
- Confirmed the Enter key triggers the same validation and submission behavior.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

This change introduces client-side validation to reduce invalid login attempts.
Server-side authentication and validation remain unchanged, so no additional security risks are introduced.