### PR TITLE
chore(agw,feg,dp): Fix spelling typos in code and comments

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
+++ b/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py
@@ -55,7 +55,7 @@ def unregister_cbsd_on_response_condition(process_response_func) -> Callable:
     """
     def process_response_wrapper(obj: ResponseDBProcessor, response: DBResponse, session: Session) -> None:
         if response.response_code in {ResponseCodes.DEREGISTER.value, ResponseCodes.INVALID_VALUE.value}:
-            logger.info(f'SAS {response.payload} implies CBSD immedaite unregistration')
+            logger.info(f'SAS {response.payload} implies CBSD immediate unregistration')
             _unregister_cbsd(response, session)
             return
         process_response_func(obj, response, session)

--- a/feg/gateway/sbi/defs/TS29122_NIDD.yaml
+++ b/feg/gateway/sbi/defs/TS29122_NIDD.yaml
@@ -398,7 +398,7 @@ paths:
               $ref: '#/components/schemas/NiddDownlinkDataTransfer'
       responses:
         '200':
-          description: The pending NIDD downlink data is replaced sucessfully but delivery is pending.
+          description: The pending NIDD downlink data is replaced successfully but delivery is pending.
           content:
             application/json:
               schema:

--- a/hil_testing/spirent_automation/TS/ts_lib.py
+++ b/hil_testing/spirent_automation/TS/ts_lib.py
@@ -434,7 +434,7 @@ class TSBase(object):
                         else:
                             not_enriched += 1
                     except Exception as e:
-                        logging.error(f"pcap parsing faild: {e}")
+                        logging.error(f"pcap parsing failed: {e}")
 
                 enriched_pct = enriched / (enriched + not_enriched)
                 logging.info(

--- a/lte/gateway/c/core/oai/common/log.c
+++ b/lte/gateway/c/core/oai/common/log.c
@@ -754,7 +754,7 @@ void log_flush_message(struct shared_log_queue_item_s* item_p) {
       if (g_oai_log.log_fd) {
         rv_put = fputs((const char*)item_p->bstr->data, g_oai_log.log_fd);
         if (rv_put < 0) {
-          // error occured
+          // error occurred
           OAI_FPRINTF_ERR("Error while writing log %d\n", rv_put);
           rv = fclose(g_oai_log.log_fd);
           if (rv != 0) {

--- a/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2c.h
+++ b/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2c.h
@@ -167,9 +167,9 @@ typedef enum nw_gtpv2c_ulp_api_type_e {
 
   NW_GTPV2C_ULP_API_INITIAL_REQ_IND,   /**< Receive a initial message from stack
                                         */
-  NW_GTPV2C_ULP_API_TRIGGERED_RSP_IND, /**< Recieve a triggered rsp message from
+  NW_GTPV2C_ULP_API_TRIGGERED_RSP_IND, /**< Receive a triggered rsp message from
                                           stack */
-  NW_GTPV2C_ULP_API_TRIGGERED_REQ_IND, /**< Recieve a triggered req message from
+  NW_GTPV2C_ULP_API_TRIGGERED_REQ_IND, /**< Receive a triggered req message from
                                           stack */
   NW_GTPV2C_ULP_API_TRIGGERED_ACK_IND, /**< Receive a triggered ACK from stack
                                         */

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.cpp
@@ -325,14 +325,14 @@ void mme_app_handle_conn_est_cnf(
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
   emm_context_p = &ue_context_p->emm_context;
-  /* Check that if Service Request is recieved in response to SGS Paging for MT
+  /* Check that if Service Request is received in response to SGS Paging for MT
    * SMS */
   if (ue_context_p->sgs_context) {
     /*
      * Move the UE to ECM Connected State.
      */
     /*
-     * Check that if SGS paging is recieved without LAI then
+     * Check that if SGS paging is received without LAI then
      * send IMSI Detach towads UE to re-attach for non-eps services
      * otherwise send itti SGS Service request message to SGS
      */
@@ -3829,7 +3829,7 @@ void mme_app_handle_path_switch_request(
       (ue_network_capability.eia !=
        ue_context_p->emm_context._ue_network_capability.eia)) {
     /* clear ue security capabilities and store security capabilities
-     * recieved in PATH_SWITCH REQUEST */
+     * received in PATH_SWITCH REQUEST */
     emm_ctx_clear_ue_nw_cap(&ue_context_p->emm_context);
     emm_ctx_set_valid_ue_nw_cap(&ue_context_p->emm_context,
                                 &ue_network_capability);

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.cpp
@@ -99,7 +99,7 @@ status_code_e mme_app_send_s6a_update_location_req(
   /*
    * Check if we already have UE data
    * set the skip subscriber data flag as true in case we are sending ULR
-   * against recieved HSS Reset
+   * against received HSS Reset
    */
   if (ue_context_p->location_info_confirmed_in_hss == true) {
     s6a_ulr_p->skip_subscriber_data = 1;

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.cpp
@@ -647,7 +647,7 @@ status_code_e mme_app_handle_sgs_imsi_detach_ack(
     }
     /*
      * Send the S1AP NAS DL DATA REQ in case of IMSI or combined EPS/IMSI detach
-     * once the SGS IMSI Detach Ack recieved from SGS task.
+     * once the SGS IMSI Detach Ack received from SGS task.
      */
     if ((ue_context_p->sgs_detach_type ==
          SGS_EXPLICIT_UE_INITIATED_IMSI_DETACH_FROM_NONEPS) ||

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.cpp
@@ -147,7 +147,7 @@ static void nas_itti_auth_info_req(const mme_ue_s1ap_id_t ue_idP,
  **      reject:    Callback function executed when the authen-            **
  **             tication procedure fails or is rejected                    **
  **      failure:   Callback function executed whener a lower              **
- **             layer failure occured before the authenti-                 **
+ **             layer failure occurred before the authenti-                 **
  **             cation procedure comnpletes                                **
  **      Others:    None                                                   **
  **                                                                        **

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Detach.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Detach.cpp
@@ -380,7 +380,7 @@ status_code_e emm_proc_detach_request(mme_ue_s1ap_id_t ue_id,
     increment_counter("ue_detach", 1, 1, "action", "detach_accept_sent");
     detach_success_event(emm_ctx->_imsi64, "detach_accept_sent");
     /*
-     * If Detach request is recieved for IMSI only then don't trigger session
+     * If Detach request is received for IMSI only then don't trigger session
      * release and don't clear emm context return from here
      */
     if (params->type == EMM_DETACH_TYPE_IMSI) {

--- a/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.hpp
@@ -65,7 +65,7 @@ Description Defines callback functions executed within EMM common procedures
  * procedure has been initiated by the ongoing EMM procedure.
  * - The EMM common procedure successfully completed
  * - The EMM common procedure failed or is rejected
- * - Lower layer failure occured before the EMM common procedure completion
+ * - Lower layer failure occurred before the EMM common procedure completion
  */
 typedef status_code_e (*emm_common_success_callback_t)(void*);
 typedef status_code_e (*emm_common_reject_callback_t)(void*);

--- a/lte/gateway/c/core/oai/tasks/nas/emm/Identification.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/Identification.cpp
@@ -110,7 +110,7 @@ static status_code_e identification_request(nas_emm_ident_proc_t* const proc);
  **      reject:    Callback function executed when the identi-    **
  **             fication procedure fails or is rejected            **
  **      failure:   Callback function executed whener a lower      **
- **             layer failure occured before the identifi-         **
+ **             layer failure occurred before the identifi-         **
  **             cation procedure completes                         **
  **      Others:    None                                           **
  **                                                                **

--- a/lte/gateway/c/core/oai/tasks/nas/emm/NasTransportHdl.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/NasTransportHdl.cpp
@@ -92,7 +92,7 @@ extern "C" {
  **              3GPP TS 24.301, section 5.6.3.2                           **
  **      Upon receiving an UPLINK NAS TRANSPORT message, the MME shall  **
  **      send the available imsi,imeisv,ue time zone,                   **
- **      mobilestationclassmark2,tai,ecgi and recieved nas message      **
+ **      mobilestationclassmark2,tai,ecgi and received nas message      **
  **      container(SMS) to MSC/VLR.                                        **
  **                                                                        **
  ** Inputs:  ue_id:      UE lower layer identifier                  **

--- a/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.cpp
@@ -162,7 +162,7 @@ static status_code_e security_request(nas_emm_smc_proc_t* const smc_proc);
  **             rity mode control procedure fails or is    **
  **             rejected                                   **
  **      failure:   Callback function executed whener a lower  **
- **             layer failure occured before the security  **
+ **             layer failure occurred before the security  **
  **             mode control procedure completes          **
  **      Others:    None                                       **
  **                                                                        **

--- a/lte/gateway/c/core/oai/tasks/nas/emm/ServiceRequestHdl.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/ServiceRequestHdl.cpp
@@ -171,7 +171,7 @@ status_code_e emm_proc_extended_service_request(
       ue_id);
 
   /*
-   * if CSFB Response is recieved for MT CSFB as accepted by ue,
+   * if CSFB Response is received for MT CSFB as accepted by ue,
    * and if neaf flag is true then send the itti message to SGS
    * For triggering SGS ue activity indication message towards MSC.
    * In case of Csfb as rejected by ue ,then SGS paging reject shall be sent.

--- a/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.cpp
@@ -369,7 +369,7 @@ status_code_e emm_proc_tracking_area_update_request(
     }
   }
   /*
-   * Store the mobile station classmark2 information recieved in Tracking Area
+   * Store the mobile station classmark2 information received in Tracking Area
    * Update request This wil be required for SMS and SGS service request
    * procedure
    */

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.cpp
@@ -432,7 +432,7 @@ status_code_e emm_recv_attach_request(
   params->decode_status = *decode_status;
 
   /*
-   * Send the mobile station classmark2 information in recieved in Attach
+   * Send the mobile station classmark2 information in received in Attach
    * request This will be required for SMS and SGS service request procedure
    */
   MobileStationClassmark2 mob_stsn_clsMark2 = {0};
@@ -802,7 +802,7 @@ status_code_e emm_recv_service_request(
     service_type = PARENT_STRUCT(emm_ctx, struct ue_mm_context_s, emm_context)
                        ->sgs_context->csfb_service_type;
     /*
-     * if service request is recieved for either MO SMS or PS data,
+     * if service request is received for either MO SMS or PS data,
      * and if neaf flag is true then send the itti message to SGS
      * For triggering SGS ue activity indication message towards MSC.
      */

--- a/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.cpp
@@ -1693,7 +1693,7 @@ int emm_send_emm_information(const emm_as_data_t* msg,
  ** Description: Builds Downlink Nas Transport message                     **
  **                                                                        **
  **              The Downlink Nas Transport message is sent by the         **
- **              network to the UE to transfer the SMS recieved from MSC   **
+ **              network to the UE to transfer the SMS received from MSC   **
  **              This function is used to send DL NAS Transport message    **
  **              via S1AP DL NAS Transport message.                        **
  **                                                                        **

--- a/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.cpp
@@ -477,7 +477,7 @@ static int esm_sap_recv(int msg_type, unsigned int ue_id, bool is_standalone,
            */
           is_discarded = true;
         } else {
-          increment_counter("ue_pdn_connection", 1, 1, "result", "sucessful");
+          increment_counter("ue_pdn_connection", 1, 1, "result", "successful");
         }
         break;
 

--- a/lte/gateway/c/core/oai/tasks/nas/nas_proc.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas/nas_proc.cpp
@@ -701,7 +701,7 @@ status_code_e nas_proc_sgs_release_req(
   }
   /*
    * As per spec 29.118 section 5.11.4
-   * Check the SGS cause recieved in SGS Release Request
+   * Check the SGS cause received in SGS Release Request
    * if sgs cause is "IMSI unknown" or "IMSI detached for non-EPS services"
    * set the "VLR-Reliable" MM context variable to "false"
    * MME requests the UE to re-attach for non-EPS services

--- a/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
@@ -117,7 +117,7 @@ def _get_param_values_by_path(
 ) -> Dict[str, Any]:
     if not hasattr(inform, 'ParameterList') or \
             not hasattr(inform.ParameterList, 'ParameterValueStruct'):
-        raise ConfigurationError('Did not receive ParamterList in Inform')
+        raise ConfigurationError('Did not receive ParameterList in Inform')
     param_values_by_path = {}
     for param_value in inform.ParameterList.ParameterValueStruct:
         path = param_value.Name

--- a/lte/gateway/python/magma/pipelined/openflow/messages.py
+++ b/lte/gateway/python/magma/pipelined/openflow/messages.py
@@ -88,7 +88,7 @@ class MsgReply(object):
 
     def ok(self) -> bool:
         """
-        Return true if no exception occured
+        Return true if no exception occurred
         """
         return self._exception is None
 
@@ -123,7 +123,7 @@ class MessageHub(object):
     MessageHub can send flow modifications and and returns a channel
     to synchronously wait for any results (in the same vein as a Go channel).
     It does this by sending messages and barrier requests and responding with
-    any errors that occured before the barrier response. The app can call
+    any errors that occurred before the barrier response. The app can call
     `send` to send any message synchronously and wait for the result.
 
     IMPORTANT: To use the message hub, the app that contains it must call

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -1034,7 +1034,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
 
         local_f_teid_ng = request.local_f_teid
 
-        # PDR is deleted with ActiveRules or DelActive rules recieved
+        # PDR is deleted with ActiveRules or DelActive rules received
         if pdr_entry.pdr_state == PdrState.Value('REMOVE'):
             qos_enforce_rule = pdr_entry.del_qos_enforce_rule
             if qos_enforce_rule.ip_addr:

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -304,7 +304,7 @@ class ServiceManager:
     CONNTRACK_SERVICE_NAME = 'conntrack'
     RYU_REST_SERVICE_NAME = 'ryu_rest_service'
     RYU_REST_APP_NAME = 'ryu_rest_app'
-    STARTUP_FLOWS_RECIEVER_CONTROLLER = 'startup_flows'
+    STARTUP_FLOWS_RECEIVER_CONTROLLER = 'startup_flows'
     CHECK_QUOTA_SERVICE_NAME = 'check_quota'
     LI_MIRROR_SERVICE_NAME = 'li_mirror'
     UPLINK_BRIDGE_NAME = 'uplink_bridge'
@@ -418,7 +418,7 @@ class ServiceManager:
                 order_priority=0,
             ),
         ],
-        STARTUP_FLOWS_RECIEVER_CONTROLLER: [
+        STARTUP_FLOWS_RECEIVER_CONTROLLER: [
             App(
                 name=StartupFlows.APP_NAME,
                 module=StartupFlows.__module__,


### PR DESCRIPTION
This PR fixes multiple spelling typos across the codebase. The changes include:

### Code Fixes (Runtime Impact)
- **[acs_state_utils.py](cci:7://file:///c:/dev/magma/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py:0:0-0:0)**: Fixed "ParamterList" → "ParameterList" in exception message
- **[esm_sap.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.cpp:0:0-0:0)**: Fixed "sucessful" → "successful" in Prometheus metric label
- **[TS29122_NIDD.yaml](cci:7://file:///c:/dev/magma/feg/gateway/sbi/defs/TS29122_NIDD.yaml:0:0-0:0)**: Fixed "sucessfully" → "successfully" in API response description
- **[ts_lib.py](cci:7://file:///c:/dev/magma/hil_testing/spirent_automation/TS/ts_lib.py:0:0-0:0)**: Fixed "faild" → "failed" in error log message
- **[service_manager.py](cci:7://file:///c:/dev/magma/lte/gateway/python/magma/pipelined/service_manager.py:0:0-0:0)**: Fixed "RECIEVER" → "RECEIVER" in constant name

### Comment Fixes (Documentation Only)
- Fixed "immedaite" → "immediate" in [response_processing.py](cci:7://file:///c:/dev/magma/dp/cloud/python/magma/configuration_controller/response_processor/strategies/response_processing.py:0:0-0:0)
- Fixed "recieve/recieved" → "receive/received" in multiple files:
  - [NwGtpv2c.h](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/lib/gtpv2-c/nwgtpv2c-0.11/include/NwGtpv2c.h:0:0-0:0), [mme_app_bearer.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_bearer.cpp:0:0-0:0), [mme_app_location.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_location.cpp:0:0-0:0), [mme_app_sgs_detach.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/mme_app/mme_app_sgs_detach.cpp:0:0-0:0)
  - [nas_proc.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/nas_proc.cpp:0:0-0:0), [Detach.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/Detach.cpp:0:0-0:0), [NasTransportHdl.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/NasTransportHdl.cpp:0:0-0:0), [ServiceRequestHdl.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/ServiceRequestHdl.cpp:0:0-0:0)
  - [TrackingAreaUpdate.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/TrackingAreaUpdate.cpp:0:0-0:0), [emm_recv.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_recv.cpp:0:0-0:0), [emm_send.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/sap/emm_send.cpp:0:0-0:0), [rpc_servicer.py](cci:7://file:///c:/dev/magma/lte/gateway/python/magma/pipelined/rpc_servicer.py:0:0-0:0)
- Fixed "occured" → "occurred" in multiple files:
  - [messages.py](cci:7://file:///c:/dev/magma/lte/gateway/python/magma/pipelined/openflow/messages.py:0:0-0:0), [log.c](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/common/log.c:0:0-0:0), [Authentication.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/Authentication.cpp:0:0-0:0), [EmmCommon.hpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/EmmCommon.hpp:0:0-0:0)
  - [Identification.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/Identification.cpp:0:0-0:0), [SecurityModeControl.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/emm/SecurityModeControl.cpp:0:0-0:0)

## Test Plan

- These are spelling corrections only
- No logic changes were made
- Verified all modified files compile/parse correctly
- For the metric label change (`sucessful` → `successful`), existing monitoring dashboards should be updated if they reference this metric

## Additional Information

- [ ] This change is backwards-breaking

**Note:** The metric label change in [esm_sap.cpp](cci:7://file:///c:/dev/magma/lte/gateway/c/core/oai/tasks/nas/esm/sap/esm_sap.cpp:0:0-0:0) (`"sucessful"` → `"successful"`) could affect Prometheus queries or Grafana dashboards that filter on `result="sucessful"`. Operators should update their dashboards to use `result="successful"`.

## Security Considerations

No security impact. This PR only corrects spelling errors in:
- Exception messages
- Log messages
- Comments
- One metric label
- One constant name

No functional behavior is changed.