### PR TITLE
fix: Fix incorrect integer comparison for logging level in logger.py

### DIFF
--- a/lte/gateway/python/magma/enodebd/logger.py
+++ b/lte/gateway/python/magma/enodebd/logger.py
@@ -31,7 +31,7 @@ class EnodebdLogger:
 
     @staticmethod
     def init() -> None:
-        if logging.root.level is not logging.DEBUG:
+        if logging.root.level != logging.DEBUG:
             EnodebdLogger._LOGGER.propagate = False
         handler = RotatingFileHandler(
             LOG_FILE,


### PR DESCRIPTION
## Summary

fix(agw): replace identity comparison with equality comparison for logging level

The current implementation in `lte/gateway/python/magma/enodebd/logger.py` uses identity comparison:

```python
if logging.root.level is not logging.DEBUG:
```

This is incorrect because `is` and `is not` compare object identity, not value. While small integers like `logging.DEBUG` (value `10`) are often interned in CPython, relying on this behavior is implementation-dependent and not guaranteed.

This PR replaces the identity comparison with value comparison:

```python
if logging.root.level != logging.DEBUG:
```

This ensures correct and reliable logging level comparison across Python implementations and aligns with Python best practices.

---

## Test Plan

* Verified the change compiles successfully with no syntax errors.
* Confirmed that logging behavior remains unchanged when logging level is set to DEBUG.
* Confirmed that non-DEBUG logging levels are correctly detected.
* Ran static analysis and confirmed this resolves the improper identity comparison issue.
* Change is minimal and limited to comparison operator correction, with no functional logic changes.

---

## Additional Information

* [ ] This change is backwards-breaking

This change is fully backward compatible and does not modify functionality, only corrects comparison semantics.

---

## Security Considerations

This change improves code correctness and reliability. While it does not directly fix a security vulnerability, improper identity comparison could lead to incorrect logging behavior in certain Python environments, potentially affecting observability and debugging.

No new security risks are introduced.