### PR TITLE
fix: rename docs files to lowercase and add linter check

### DIFF
--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -71,6 +71,15 @@ jobs:
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
         with:
           python-version: '3.8.10'
+      - name: Check for capital letters in filenames
+        shell: bash
+        run: |
+          files=$(find docs/readmes -name "*[A-Z]*.md" -not -name "README.md")
+          if [ -n "$files" ]; then
+            echo "Error: Found filenames with capital letters:"
+            echo "$files"
+            exit 1
+          fi
       - name: Run docs precommit
         shell: bash
         run: |

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -395,7 +395,7 @@
           "proposals/p004_fua_restrict_feature",
           "proposals/p007_header_enrichment",
           "proposals/p008_apn_correction",
-          "proposals/p013_Ubuntu_upgrade",
+          "proposals/p013_ubuntu_upgrade",
           "proposals/p018_control_network_metrics",
           "proposals/p019_enodeb_cbrs_support",
           "proposals/p020_sgi_tunnel_transport"

--- a/docs/readmes/proposals/p008_mandatory_integration_tests_for_each_pr.md
+++ b/docs/readmes/proposals/p008_mandatory_integration_tests_for_each_pr.md
@@ -1,5 +1,5 @@
 ---
-id: p006_mandatory_integration_tests_for_each_PR.md
+id: p006_mandatory_integration_tests_for_each_pr.md
 title: Enable integration tests as a mandatory check required to merge any PR
 hide_title: true
 ---

--- a/docs/readmes/proposals/p013_ubuntu_upgrade.md
+++ b/docs/readmes/proposals/p013_ubuntu_upgrade.md
@@ -1,5 +1,5 @@
 ---
-id: p013_Ubuntu_upgrade
+id: p013_ubuntu_upgrade
 title: AGW Ubuntu upgrade
 hide_title: true
 ---


### PR DESCRIPTION
# Fix: Enforce lowercase filenames in docs to prevent 404s

## Summary
The Docusaurus search engine redirects to all-lowercase URLs, which causes 404 errors if documentation files have capital letters in their names. This PR addresses this issue by renaming existing files and enforcing a lowercase-only policy for docs filenames in CI.

## Changes
- **Renamed Files**:
  - `docs/readmes/proposals/p013_Ubuntu_upgrade.md` -> `p013_ubuntu_upgrade.md`
  - `docs/readmes/proposals/p008_mandatory_integration_tests_for_each_PR.md` -> `p008_mandatory_integration_tests_for_each_pr.md`
- **Updated References**:
  - Updated `docs/docusaurus/sidebars.json` to point to the new lowercase filenames.
  - Updated `id` fields within the renamed markdown files.
- **CI Enhancement**:
  - Added a new step to `.github/workflows/docs-workflow.yml` that fails the build if any file in `docs/readmes` (excluding `README.md`) contains capital letters.

## Test Plan
- [x] **CI Check**: Verified that the new workflow step correctly identifies files with capital letters (tested locally).
- [x] **File Integrity**: Verified that renamed files are correctly referenced in `sidebars.json`.
- [x] **Search Compatibility**: Ensuring all filenames are lowercase ensures compatibility with Docusaurus search behavior.

## Related Issues
- Fixes https://github.com/magma/magma/issues/14961