### PR TITLE
fix(fluentd): pin multi_json to v1.15.0 for Ruby 2.7 compatibility

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -11,7 +11,9 @@
 
 FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
-RUN gem install \
+RUN gem install multi_json -v 1.15.0 --no-document && \ 
+    gem install excon -v 1.2.5 --no-document && \
+    gem install \
     elasticsearch:7.13.0 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \


### PR DESCRIPTION
Fix Ruby 2.7 compatibility issue in Fluentd Docker build

## Problem

Fluentd Docker build fails due to multi_json requiring Ruby >= 3.0, while the base image uses Ruby 2.7.5.

##  Error

multi_json requires Ruby version >= 3.0. The current ruby version is 2.7.5.

## Solution

Pin multi_json to version 1.15.0, which is the last version compatible with Ruby 2.7.


## Impact
Restores successful Docker build for Fluentd without upgrading Ruby runtime.

