### PR TITLE
build(fluentd): update fluentd Dockerfile

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -11,9 +11,10 @@
 
 FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
-RUN gem install \
-    elasticsearch:7.13.0 \
-    fluent-plugin-elasticsearch:5.2.1 \
-    fluent-plugin-multi-format-parser:1.0.0 \
-    --no-document
+  RUN gem install rubygems-update -v 3.2.33 --no-document && \
+  update_rubygems && \
+  gem install multi_json -v 1.15.0 --no-document && \
+  gem install elasticsearch -v 7.13.0 --no-document && \
+  gem install fluent-plugin-elasticsearch -v 5.2.1 --no-document && \
+  gem install fluent-plugin-multi-format-parser -v 1.0.0 --no-document
 USER fluent


### PR DESCRIPTION
## Summary
Updated the Fluentd Dockerfile according to Kidus's guidelines.  
The base image remains `fluent/fluentd:v1.14.6-debian-1.0`, but required Ruby gems are now explicitly installed during the build process to ensure consistent dependency versions and avoid manual updates later.

Installed/updated gems:
- rubygems-update (3.2.33)
- multi_json (1.15.0)
- elasticsearch (7.13.0)
- fluent-plugin-elasticsearch (5.2.1)
- fluent-plugin-multi-format-parser (1.0.0)

## Test Plan
- Built the Docker image locally using the updated Dockerfile.
- Verified that all gems install successfully during the build.
- Started a container from the built image.
- Confirmed Fluentd starts correctly and loads the installed plugins without errors.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations
No known security impact.  
The change only installs specific gem versions and updates RubyGems to ensure compatibility and stability in the Fluentd environment.