### PR TITLE
fix(magmad): remove shell command injection vectors from gateway configs

### DIFF
--- a/feg/gateway/configs/magmad.yml
+++ b/feg/gateway/configs/magmad.yml
@@ -85,13 +85,4 @@ metricsd:
 generic_command_config:
   module: magma.magmad.generic_command.shell_command_executor
   class: ShellCommandExecutor
-  shell_commands:
-    - name: bash
-      command: "bash {}"
-      allow_params: True
-    - name: fab
-      command: "fab {}"
-      allow_params: True
-    - name: echo
-      command: "echo {}"
-      allow_params: True
+  shell_commands: []

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -137,15 +137,6 @@ generic_command_config:
   module: magma.magmad.generic_command.shell_command_executor
   class: ShellCommandExecutor
   shell_commands:
-    - name: bash
-      command: "bash {}"
-      allow_params: True
-    - name: fab
-      command: "fab {}"
-      allow_params: True
-    - name: echo
-      command: "echo {}"
-      allow_params: True
     - name: reboot_enodeb
       command: "enodebd_cli.py reboot_enodeb {}"
       allow_params: True

--- a/orc8r/gateway/configs/magmad.yml
+++ b/orc8r/gateway/configs/magmad.yml
@@ -81,13 +81,4 @@ metricsd:
 generic_command_config:
   module: magma.magmad.generic_command.shell_command_executor
   class: ShellCommandExecutor
-  shell_commands:
-    - name: bash
-      command: "bash {}"
-      allow_params: True
-    - name: fab
-      command: "fab {}"
-      allow_params: True
-    - name: echo
-      command: "echo {}"
-      allow_params: True
+  shell_commands: []

--- a/orc8r/gateway/python/magma/magmad/generic_command/shell_command_executor.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/shell_command_executor.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 import asyncio
 import logging
+import re
 import shlex
 from functools import partial
 from typing import Any, Dict
@@ -21,6 +22,23 @@ from magma.magmad.generic_command.command_executor import (
     ExecutorFuncT,
     ParamValueT,
 )
+
+# Only these command names may be registered via config.
+# Generic shell access (bash, fab, echo) is intentionally excluded
+# to prevent arbitrary command execution via the Orchestrator API.
+COMMAND_ALLOWLIST = frozenset({
+    'reboot_enodeb',
+    'reboot_all_enodeb',
+    'health',
+    'agw_health',
+    'get_flows',
+    'get_subscriber_table',
+    'check_stateless',
+    'configure_stateless',
+})
+
+# Shell metacharacters that must not appear in command parameters.
+_SHELL_METACHAR_RE = re.compile(r'[;|&$`\n]')
 
 
 class ShellCommandExecutor(CommandExecutor):
@@ -49,6 +67,7 @@ def get_shell_commands_from_config(
     """
     Gets a list of shell commands from the config. Creates subprocess
     coroutines for each command and stores it in a dictionary.
+    Only commands whose name is in COMMAND_ALLOWLIST are registered.
     """
     shell_commands = config\
         .get('generic_command_config', {})\
@@ -62,6 +81,12 @@ def get_shell_commands_from_config(
         if not name or not command:
             continue
 
+        if name not in COMMAND_ALLOWLIST:
+            logging.warning(
+                "Skipping command '%s': not in COMMAND_ALLOWLIST", name,
+            )
+            continue
+
         allow_params = shell_command.get('allow_params', False)
 
         logging.debug("Loading command %s", name)
@@ -71,6 +96,16 @@ def get_shell_commands_from_config(
             allow_params,
         )
     return command_dispatch_table
+
+
+def _validate_shell_params(params: list) -> None:
+    """Reject parameters containing shell metacharacters."""
+    for param in params:
+        if isinstance(param, str) and _SHELL_METACHAR_RE.search(param):
+            raise ValueError(
+                "shell_params contains forbidden metacharacter: "
+                f"{param!r}",
+            )
 
 
 async def _run_subprocess(
@@ -84,10 +119,11 @@ async def _run_subprocess(
     """
     cmd_str = cmd
     if allow_params:
-        if params["shell_params"] == []:
-            cmd_str = cmd.format([''])
-        else:
-            cmd_str = cmd.format(*params.get('shell_params', ['']))
+        shell_params = params.get('shell_params', [''])
+        if shell_params == []:
+            shell_params = ['']
+        _validate_shell_params(shell_params)
+        cmd_str = cmd.format(*shell_params)
 
     logging.info("Running command: %s", cmd_str)
 

--- a/orc8r/gateway/python/magma/magmad/generic_command/tests/shell_command_executor_test.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/tests/shell_command_executor_test.py
@@ -15,6 +15,7 @@ import unittest
 from unittest import mock
 
 from magma.magmad.generic_command.shell_command_executor import (
+    COMMAND_ALLOWLIST,
     get_shell_commands_from_config,
 )
 
@@ -28,14 +29,14 @@ class ShellCommandExecutorTest(unittest.TestCase):
         self.service.config = {
             'generic_command_config': {
                 'shell_commands': [
-                    {'name': 'test_1', 'command': '/bin/true'},
-                    {'name': 'test_2', 'command': '/bin/false'},
+                    {'name': 'health', 'command': '/bin/true'},
+                    {'name': 'get_flows', 'command': '/bin/false'},
                 ],
             },
         }
         table = get_shell_commands_from_config(self.service.config)
-        self.assertIn('test_1', table)
-        self.assertIn('test_2', table)
+        self.assertIn('health', table)
+        self.assertIn('get_flows', table)
 
     def test_get_shell_cmds_missing_config(self):
         self.service.config = {}
@@ -53,7 +54,7 @@ class ShellCommandExecutorTest(unittest.TestCase):
         self.service.config = {
             'generic_command_config': {
                 'shell_commands': [
-                    {'name': 'test_1'},
+                    {'name': 'health'},
                     {'command': '/bin/false'},
                 ],
             },
@@ -65,13 +66,13 @@ class ShellCommandExecutorTest(unittest.TestCase):
         self.service.config = {
             'generic_command_config': {
                 'shell_commands': [
-                    {'name': 'test_1', 'command': 'echo'},
+                    {'name': 'health', 'command': 'echo'},
                 ],
             },
         }
 
         table = get_shell_commands_from_config(self.service.config)
-        func_1 = table['test_1']
+        func_1 = table['health']
         result_1 = asyncio.get_event_loop().run_until_complete(
             func_1(mock.Mock()),
         )
@@ -86,7 +87,7 @@ class ShellCommandExecutorTest(unittest.TestCase):
             'generic_command_config': {
                 'shell_commands': [
                     {
-                        'name': 'test_1',
+                        'name': 'health',
                         'command': 'echo {} {}',
                         'allow_params': True,
                     },
@@ -98,7 +99,7 @@ class ShellCommandExecutorTest(unittest.TestCase):
         }
 
         table = get_shell_commands_from_config(self.service.config)
-        func_1 = table['test_1']
+        func_1 = table['health']
         result_1 = asyncio.get_event_loop().run_until_complete(
             func_1(params),
         )
@@ -107,19 +108,18 @@ class ShellCommandExecutorTest(unittest.TestCase):
             result_1,
             {'stdout': 'Hello world!\n', 'stderr': '', 'returncode': 0},
         )
-        pass
 
     def test_get_shell_cmds_nonexistent_func(self):
         self.service.config = {
             'generic_command_config': {
                 'shell_commands': [
-                    {'name': 'test_1', 'command': 'nonexistent/command foo'},
+                    {'name': 'health', 'command': 'nonexistent/command foo'},
                 ],
             },
         }
 
         table = get_shell_commands_from_config(self.service.config)
-        func_1 = table['test_1']
+        func_1 = table['health']
         try:
             asyncio.get_event_loop().run_until_complete(
                 func_1(mock.Mock()),
@@ -127,3 +127,52 @@ class ShellCommandExecutorTest(unittest.TestCase):
             self.fail('An exception should have been raised')
         except FileNotFoundError:
             pass
+
+    def test_allowlist_rejects_bash(self):
+        """Commands not in COMMAND_ALLOWLIST should be silently skipped."""
+        self.service.config = {
+            'generic_command_config': {
+                'shell_commands': [
+                    {'name': 'bash', 'command': 'bash {}', 'allow_params': True},
+                    {'name': 'fab', 'command': 'fab {}', 'allow_params': True},
+                    {'name': 'echo', 'command': 'echo {}', 'allow_params': True},
+                ],
+            },
+        }
+        table = get_shell_commands_from_config(self.service.config)
+        self.assertEqual(table, {})
+
+    def test_allowlist_permits_domain_commands(self):
+        """All COMMAND_ALLOWLIST entries should be registerable."""
+        commands = [
+            {'name': name, 'command': f'/usr/bin/{name}'}
+            for name in COMMAND_ALLOWLIST
+        ]
+        self.service.config = {
+            'generic_command_config': {
+                'shell_commands': commands,
+            },
+        }
+        table = get_shell_commands_from_config(self.service.config)
+        self.assertEqual(set(table.keys()), COMMAND_ALLOWLIST)
+
+    def test_metacharacter_rejection(self):
+        """Parameters with shell metacharacters should raise ValueError."""
+        self.service.config = {
+            'generic_command_config': {
+                'shell_commands': [
+                    {
+                        'name': 'health',
+                        'command': 'health_cli.py {}',
+                        'allow_params': True,
+                    },
+                ],
+            },
+        }
+        table = get_shell_commands_from_config(self.service.config)
+        func = table['health']
+
+        for bad_param in ['; rm -rf /', '| cat /etc/passwd', '& bg', '$(id)', '`id`', 'foo\nbar']:
+            params = {"shell_params": [bad_param]}
+            with self.assertRaises(ValueError, msg=f"Should reject: {bad_param!r}"):
+                asyncio.get_event_loop().run_until_complete(func(params))


### PR DESCRIPTION
## Summary

- Remove `bash {}`, `fab {}`, and `echo {}` shell_commands entries from all three gateway `magmad.yml` configs (orc8r, feg, lte). These entries allowed arbitrary command execution on any gateway reachable via the Orchestrator API.
- Add `COMMAND_ALLOWLIST` to `shell_command_executor.py` so only domain-specific commands (`reboot_enodeb`, `health`, `get_flows`, etc.) can be registered. Commands not in the allowlist are rejected with a warning.
- Add input validation to reject shell metacharacters (`;|&$\`` and newlines) in command parameters.
- LTE gateway retains all its domain-specific commands unchanged.

**Severity:** Critical

Refs: #15834 #15828

## Test plan

- [ ] Verify no `bash {}` or `fab {}` entries remain in any magmad.yml config
- [ ] Verify LTE config still has `reboot_enodeb`, `health`, `get_flows`, etc.
- [ ] Run `shell_command_executor_test.py` — includes new tests for allowlist rejection and metacharacter validation
- [ ] `test_allowlist_rejects_bash`: bash/fab/echo commands are silently skipped
- [ ] `test_allowlist_permits_domain_commands`: all allowlisted commands register successfully
- [ ] `test_metacharacter_rejection`: params with `;|&$\`` or newlines raise ValueError