### PR TITLE
fix(enodebd): replace shell=True with safe subprocess invocation

### DIFF
--- a/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
+++ b/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
@@ -64,8 +64,8 @@ async def check_and_apply_iptables_rules(
     enodebd_public_ip: str,
     enodebd_ip: str,
 ) -> None:
-    command = 'sudo iptables -t nat -L'
-    output = subprocess.run(command, shell=True, stdout=subprocess.PIPE, check=True)
+    command = ['sudo', 'iptables', '-t', 'nat', '-L']
+    output = subprocess.run(command, stdout=subprocess.PIPE, check=True)
     command_output = output.stdout.decode('utf-8').strip()
     prerouting_rules = _get_prerouting_rules(command_output)
     if not prerouting_rules:
@@ -120,9 +120,13 @@ def check_rules(
 
 
 async def run(cmd):
-    """Fork shell and run command NOTE: Popen is non-blocking"""
+    """Fork and run command as a subprocess. NOTE: Popen is non-blocking"""
     cmd = shlex.split(cmd)
-    proc = await asyncio.create_subprocess_shell(" ".join(cmd))
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
     await proc.communicate()
     if proc.returncode != 0:
         # This can happen because the NAT prerouting rule didn't exist


### PR DESCRIPTION
## Summary

- Replace `subprocess.run(shell=True)` with an explicit argument list in `check_and_apply_iptables_rules()`
- Replace `asyncio.create_subprocess_shell()` with `asyncio.create_subprocess_exec()` in the `run()` function
- The previous code split the command with `shlex.split()` then immediately re-joined with spaces to pass to a shell — this was both unnecessary and unsafe

**Severity:** High

Refs: #15834 #15828

## Test plan

- [ ] Grep for `shell=True` and `create_subprocess_shell` in modified file — should be zero
- [ ] Verify iptables rule application logic is functionally unchanged