### PR TITLE
fix(lte): deprecate weak cryptographic algorithms in HEConfig proto

### DIFF
--- a/lte/protos/mconfig/mconfigs.proto
+++ b/lte/protos/mconfig/mconfigs.proto
@@ -149,13 +149,13 @@ message PipelineD {
 
     message HEConfig {
         enum EncryptionAlgorithm {
-            RC4 = 0;
-            AES256_CBC_HMAC_MD5 = 1;
-            AES256_ECB_HMAC_MD5 = 2;
+            RC4 = 0 [deprecated = true]; // Deprecated 2026-03: cryptographically broken (RFC 7465)
+            AES256_CBC_HMAC_MD5 = 1 [deprecated = true]; // Deprecated 2026-03: uses MD5
+            AES256_ECB_HMAC_MD5 = 2 [deprecated = true]; // Deprecated 2026-03: uses ECB mode and MD5
             GZIPPED_AES256_ECB_SHA1 = 3;
         }
         enum HashFunction{
-            MD5 = 0;
+            MD5 = 0 [deprecated = true]; // Deprecated 2026-03: cryptographically broken
             HEX = 1;
             SHA256 = 2;
         }


### PR DESCRIPTION
## Summary

- Mark `RC4`, `AES256_CBC_HMAC_MD5`, `AES256_ECB_HMAC_MD5` encryption algorithms as `[deprecated = true]` in `HEConfig.EncryptionAlgorithm`
- Mark `MD5` hash function as `[deprecated = true]` in `HEConfig.HashFunction`
- RC4 is cryptographically broken per RFC 7465; the other algorithms use MD5 or ECB mode
- Proto default values cannot be changed without breaking wire compatibility, so deprecation annotations generate compiler warnings in consuming code

**Severity:** Medium

Refs: #15834 #15828

## Test plan

- [ ] Proto file compiles without errors
- [ ] Deprecation annotations are present on RC4, MD5, and related enum values
- [ ] Wire compatibility is preserved (no field number changes)