### PR TITLE
docs: add README to keys/ directory clarifying contents

### DIFF
--- a/keys/README.md
+++ b/keys/README.md
@@ -1,0 +1,10 @@
+# keys/
+
+This directory contains **public** cryptographic keys used for
+verification purposes. It does not contain any private key material.
+
+## Contents
+
+- `linux_foundation_registry_key.asc` — PGP public key used to verify
+  Docker registry image signatures from the Linux Foundation registry.
+  This is a public key and is safe to distribute.


### PR DESCRIPTION
## Summary

- Add `keys/README.md` documenting that `linux_foundation_registry_key.asc` is a PGP public key for Docker registry image verification, not a secret

**Severity:** Low

Refs: #15834 #15828

## Test plan

- [ ] Verify no private key material (`.pem`, `.key`, `.p12`, `.pfx`) exists in the repo