### PR TITLE
fix(ci): upgrade Go to 1.23 to unblock broken CI builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -82,7 +82,7 @@ RUN gem install dotenv -v 2.8.1 && \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.23.6"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
     && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
     && tar -xzf ${GO_TARBALL} \

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -119,7 +119,7 @@ jobs:
         if: always()
         id: gateway_test_init
         with:
-          go-version: '1.21.12'
+          go-version: '1.23.6'
       - name: Download dependencies
         if: always() && steps.gateway_test_init.outcome=='success'
         id: gateway_test_dep

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.21.12'
+          go-version: '1.23.6'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.20.1'
+          go-version: '1.23.6'
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh
       - name: Run go mod download with retry

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.20.1'
+          go-version: '1.23.6'
       - run: go version
       - name: Run golang_before_install.sh script
         run: ./.github/workflows/scripts/golang_before_install.sh

--- a/.github/workflows/scripts/golang_check_version.sh
+++ b/.github/workflows/scripts/golang_check_version.sh
@@ -13,6 +13,7 @@
 expected_version="1.20.1"
 second_expected_version="1.21.0"
 ternary_expected_version="1.21.12"
+quaternary_expected_version="1.23.6"
 all_versions_good=true
 
 while IFS= read -r -d '' file
@@ -20,7 +21,7 @@ do
   while read -r line;
   do
     version=$(echo "$line" | awk -F '[]["'"'"']' '{print $2}')
-    if [[ -n $version && $version != "$expected_version" && $version != "$second_expected_version" && $version != "$ternary_expected_version" ]]
+    if [[ -n $version && $version != "$expected_version" && $version != "$second_expected_version" && $version != "$ternary_expected_version" && $version != "$quaternary_expected_version" ]]
     then
       echo "Found unexpected Go version $version in file $(realpath --relative-to="$MAGMA_ROOT" "$file"):"
       echo "$line"
@@ -31,7 +32,7 @@ do
   while read -r line;
   do
     version=$(echo "$line" | awk '{ print $NF }')
-    if [[ -n $version && $version != "go$expected_version.linux-amd64.tar.gz" && $version != "go$second_expected_version.linux-amd64.tar.gz" && $version != "go$ternary_expected_version.linux-amd64.tar.gz" ]]
+    if [[ -n $version && $version != "go$expected_version.linux-amd64.tar.gz" && $version != "go$second_expected_version.linux-amd64.tar.gz" && $version != "go$ternary_expected_version.linux-amd64.tar.gz" && $version != "go$quaternary_expected_version.linux-amd64.tar.gz" ]]
     then
       echo "Found unexpected Go version $version in file $(realpath --relative-to="$MAGMA_ROOT" "$file"):"
       echo "$line"
@@ -45,7 +46,7 @@ do
   while read -r line;
   do
     version=$(echo "$line" | awk -F '"' '{print $2}')
-    if [[ -n $version && $version != "$expected_version" && $version != "$second_expected_version" && $version != "$ternary_expected_version" ]]
+    if [[ -n $version && $version != "$expected_version" && $version != "$second_expected_version" && $version != "$ternary_expected_version" && $version != "$quaternary_expected_version" ]]
     then
       echo "Found unexpected Go version $version in file $(realpath --relative-to="$MAGMA_ROOT" "$file"):"
       echo "$line"
@@ -58,7 +59,7 @@ while IFS= read -r -d '' file
 do
   while read -r version;
   do
-    if [[ -n $version && $version != "go$expected_version" && $version != "$second_expected_version" && $version != "$ternary_expected_version" ]]
+    if [[ -n $version && $version != "go$expected_version" && $version != "$second_expected_version" && $version != "$ternary_expected_version" && $version != "go$quaternary_expected_version" ]]
     then
       echo "Found unexpected Go version $version in file $(realpath --relative-to="$MAGMA_ROOT" "$file"):"
       all_versions_good=false

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -55,7 +55,7 @@ go_repositories()
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.17")
+go_register_toolchains(version = "1.23")
 
 gazelle_dependencies()
 

--- a/cwf/cloud/go/go.mod
+++ b/cwf/cloud/go/go.mod
@@ -105,4 +105,4 @@ require (
 	magma/gateway v0.0.0 // indirect
 )
 
-go 1.20
+go 1.23

--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && apt-get install -y \
 
 # Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.21.12"
+ARG GOLANG_VERSION="1.23.6"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
     && curl https://golang.org/dl/${GO_TARBALL} --remote-name --location \
     && tar -xzf ${GO_TARBALL} \

--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -147,6 +147,6 @@ require (
 	magma/feg/cloud/go v0.0.0 // indirect
 )
 
-go 1.21
+go 1.23
 
 toolchain go1.21.12

--- a/cwf/k8s/cwf_operator/docker/Dockerfile
+++ b/cwf/k8s/cwf_operator/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y bzr curl daemontools gcc
 
 # Install Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.21.12"
+ARG GOLANG_VERSION="1.23.6"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
     && curl https://golang.org/dl/${GO_TARBALL} --remote-name --location \
     && tar -xzf ${GO_TARBALL} \

--- a/cwf/k8s/cwf_operator/go.mod
+++ b/cwf/k8s/cwf_operator/go.mod
@@ -26,7 +26,7 @@
 //
 module magma/cwf/k8s/cwf_operator
 
-go 1.20
+go 1.23
 
 require (
 	github.com/go-logr/glogr v0.1.0

--- a/dp/cloud/go/go.mod
+++ b/dp/cloud/go/go.mod
@@ -11,7 +11,7 @@
 //
 module magma/dp/cloud/go
 
-go 1.20
+go 1.23
 
 replace (
 	magma/dp/cloud/go => ../../../dp/cloud/go

--- a/feg/cloud/go/go.mod
+++ b/feg/cloud/go/go.mod
@@ -104,4 +104,4 @@ require (
 	magma/gateway v0.0.0 // indirect
 )
 
-go 1.20
+go 1.23

--- a/feg/cloud/go/protos/go.mod
+++ b/feg/cloud/go/protos/go.mod
@@ -13,4 +13,4 @@ require (
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 )
 
-go 1.20
+go 1.23

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y \
 
 # Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.21.0"
+ARG GOLANG_VERSION="1.23.6"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://golang.org/dl/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -153,4 +153,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-go 1.20
+go 1.23

--- a/feg/radius/lib/go/http/go.mod
+++ b/feg/radius/lib/go/http/go.mod
@@ -1,6 +1,6 @@
 module fbc/lib/go/http
 
-go 1.20
+go 1.23
 
 replace (
 	fbc/lib/go/log => ../log

--- a/feg/radius/lib/go/libgraphql/go.mod
+++ b/feg/radius/lib/go/libgraphql/go.mod
@@ -2,4 +2,4 @@ module libgraphql
 
 require github.com/google/uuid v1.1.1
 
-go 1.20
+go 1.23

--- a/feg/radius/lib/go/log/go.mod
+++ b/feg/radius/lib/go/log/go.mod
@@ -1,6 +1,6 @@
 module fbc/lib/go/log
 
-go 1.20
+go 1.23
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/feg/radius/lib/go/machine/go.mod
+++ b/feg/radius/lib/go/machine/go.mod
@@ -1,3 +1,3 @@
 module machine
 
-go 1.20
+go 1.23

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -1,6 +1,6 @@
 module fbc/lib/go/oc
 
-go 1.20
+go 1.23
 
 replace (
 	fbc/lib/go/http => ../http

--- a/feg/radius/lib/go/oc/helpers/go.mod
+++ b/feg/radius/lib/go/oc/helpers/go.mod
@@ -1,5 +1,5 @@
 module fbc/lib/go/oc/helpers
 
-go 1.20
+go 1.23
 
 require go.opencensus.io v0.21.0

--- a/feg/radius/src/go.mod
+++ b/feg/radius/src/go.mod
@@ -49,4 +49,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-go 1.20
+go 1.23

--- a/lte/cloud/go/go.mod
+++ b/lte/cloud/go/go.mod
@@ -114,4 +114,4 @@ require (
 	magma/gateway v0.0.0 // indirect
 )
 
-go 1.20
+go 1.23

--- a/lte/gateway/docker/ghz/Dockerfile
+++ b/lte/gateway/docker/ghz/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.23.6"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.23.6"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/orc8r/cloud/api/v1/go/go.mod
+++ b/orc8r/cloud/api/v1/go/go.mod
@@ -11,7 +11,7 @@
 
 module magma/orc8r/cloud/api/v1/go
 
-go 1.20
+go 1.23
 
 require (
 	github.com/go-openapi/errors v0.20.2

--- a/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
+++ b/orc8r/cloud/deploy/orc8r_deployer/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform
     rm -rf /root/download/*
 
 # Install go if we are building testframework image
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.23.6"
 RUN if [ "$ENV" = "testframework" ]; \
     then \
         GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
 
 # Golang
 WORKDIR /usr/local
-ARG GOLANG_VERSION="1.20.1"
+ARG GOLANG_VERSION="1.23.6"
 RUN GO_TARBALL="go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && curl https://linuxfoundation.jfrog.io/artifactory/magma-blob/${GO_TARBALL} --remote-name --location \
  && tar -xzf ${GO_TARBALL} \

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -169,4 +169,4 @@ require (
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
 
-go 1.20
+go 1.23

--- a/orc8r/cloud/test/go.mod
+++ b/orc8r/cloud/test/go.mod
@@ -1,6 +1,6 @@
 module magma/orc8r/cloud/test
 
-go 1.20
+go 1.23
 
 replace (
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20191016111102-bec269661e48

--- a/orc8r/gateway/go/go.mod
+++ b/orc8r/gateway/go/go.mod
@@ -52,4 +52,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 
-go 1.20
+go 1.23

--- a/orc8r/lib/go/go.mod
+++ b/orc8r/lib/go/go.mod
@@ -1,6 +1,6 @@
 module magma/orc8r/lib/go
 
-go 1.20
+go 1.23
 
 replace magma/orc8r/lib/go/protos => ./protos
 

--- a/orc8r/lib/go/protos/go.mod
+++ b/orc8r/lib/go/protos/go.mod
@@ -1,6 +1,6 @@
 module magma/orc8r/lib/go/protos
 
-go 1.20
+go 1.23
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b


### PR DESCRIPTION
## Summary

**CI is broken.** Multiple build jobs fail on every PR because `golang.org/x/crypto v0.35.0` (merged via dependabot in #15662) requires Go >= 1.23.0, but Docker builds and go.mod files specify Go 1.20–1.21.

The error:
```
go: golang.org/x/crypto@v0.35.0: module requires go >= 1.23.0 (running go 1.21.0)
```

### Failing jobs (on every PR, including master)
- `feg-build` — `go mod download` fails
- `orc8r build job` — `go mod download` fails
- `AGW build-containers` — `go mod download` fails  
- `CodeQL Analyze (go)` — Autobuild fails
- `cwag deploy job` — downstream failure

### Changes
| What | Old | New |
|------|-----|-----|
| `GOLANG_VERSION` in 7 Dockerfiles | 1.20.1 / 1.21.x | **1.23.6** |
| `go` directive in 21 `go.mod` files | 1.20 / 1.21 | **1.23** |
| Bazel Go toolchain (`WORKSPACE.bazel`) | 1.17 | **1.23** |
| CI workflow `go-version` (4 workflows) | 1.20.1 / 1.21.12 | **1.23.6** |

### Related
- Fluentd/Ruby build failure is a separate issue, already addressed in #15821
- Supersedes the Go portions of #15854 (which can be closed if this merges first)

Part of [P027 Phase 3: CI/CD Modernization](https://github.com/magma/magma/issues/15835)

## Test plan
- [ ] Verify `feg-build` job passes (the primary failing job)
- [ ] Verify `orc8r build job` passes
- [ ] Verify `CodeQL Analyze (go)` passes
- [ ] Verify `go mod download` succeeds in all module directories