### PR TITLE
fix(agw): Fix MME crash caused by null bstring in APN correction

### DIFF
--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_apn_selection.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_apn_selection.cpp
@@ -202,26 +202,20 @@ bstring mme_app_process_apn_correction(imsi_t* imsi, bstring accesspointname) {
   int i;
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
   apn_map_config_t config = mme_config.nas_config.apn_map_config;
-
   IMSI_TO_STRING(imsi, imsi_str, IMSI_BCD_DIGITS_MAX + 1);
-
   for (i = 0; i < config.nb; i++) {
     const char* imsi_prefix = bdata(config.apn_map[i].imsi_prefix);
     int imsi_prefix_len = strlen(imsi_prefix);
-
     if ((imsi_prefix_len <= IMSI_BCD_DIGITS_MAX) &&
         !strncmp(imsi_prefix, imsi_str, imsi_prefix_len)) {
-
       if (config.apn_map[i].apn_override &&
           bdata(config.apn_map[i].apn_override)) {
         return bstrcpy(config.apn_map[i].apn_override);
       }
     }
   }
-
   if (accesspointname && bdata(accesspointname)) {
     return bstrcpy(accesspointname);
   }
-
   return bfromcstr("");  
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_apn_selection.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_apn_selection.cpp
@@ -204,13 +204,24 @@ bstring mme_app_process_apn_correction(imsi_t* imsi, bstring accesspointname) {
   apn_map_config_t config = mme_config.nas_config.apn_map_config;
 
   IMSI_TO_STRING(imsi, imsi_str, IMSI_BCD_DIGITS_MAX + 1);
+
   for (i = 0; i < config.nb; i++) {
     const char* imsi_prefix = bdata(config.apn_map[i].imsi_prefix);
     int imsi_prefix_len = strlen(imsi_prefix);
+
     if ((imsi_prefix_len <= IMSI_BCD_DIGITS_MAX) &&
         !strncmp(imsi_prefix, imsi_str, imsi_prefix_len)) {
-      return config.apn_map[i].apn_override;
+
+      if (config.apn_map[i].apn_override &&
+          bdata(config.apn_map[i].apn_override)) {
+        return bstrcpy(config.apn_map[i].apn_override);
+      }
     }
   }
-  return accesspointname;
+
+  if (accesspointname && bdata(accesspointname)) {
+    return bstrcpy(accesspointname);
+  }
+
+  return bfromcstr("");  
 }

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_apn_selection.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_apn_selection.cpp
@@ -214,8 +214,8 @@ bstring mme_app_process_apn_correction(imsi_t* imsi, bstring accesspointname) {
       }
     }
   }
-  if (accesspointname && bdata(accesspointname)) {
+if (accesspointname && bdata(accesspointname)) {
     return bstrcpy(accesspointname);
   }
-  return bfromcstr("");  
+  return bfromcstr("");
 }


### PR DESCRIPTION
## Summary
Fixes #15761 — resolves MME crash caused by returning a shared pointer to config-owned memory in mme_app_process_apn_correction.

## Changes
at
 lte/gateway/c/core/oai/tasks/mme_app/mme_app_apn_selection.cpp
- Replaced:
  - `config.apn_map[i].apn_override` → `bstrcpy(config.apn_map[i].apn_override)`
  - `accesspointname` → `bstrcpy(accesspointname)`
- Ensures returned values are independent copies instead of shared pointers
- Added null safety checks using `bdata()` before copying
- Introduced `bfromcstr("")` as a safe fallback to avoid null propagation to serializer

## Testing
- Verified MME stability under commercial load with `enable_apn_correction: true`
- Confirmed APN override works correctly for matching IMSI prefixes
- Verified normal behavior with `enable_apn_correction: false`
- Confirmed no crashes during UE state serialization post-fix

## Related Issue
Closes #15761