### PR TITLE
fix(agw): Add APN length check in IP allocation response

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.cpp
@@ -65,7 +65,13 @@ static void handle_allocate_ipv4_address_status(
   memcpy(amf_ip_allocation_response_p->gnb_gtp_teid_ip_addr,
          gnb_gtp_teid_ip_addr, gnb_gtp_teid_ip_addr_len);
 
-  memcpy(amf_ip_allocation_response_p->apn, apn, strlen(apn) + 1);
+  size_t apn_len = strlen(apn);
+  if (apn_len >= sizeof(amf_ip_allocation_response_p->apn)) {
+    OAILOG_ERROR(LOG_AMF_APP, "APN too long (%zu bytes), dropping IPv4 allocation response\n", apn_len);
+    itti_free(ITTI_MSG_ORIGIN_ID(message_p), message_p);
+    return;
+  }
+  memcpy(amf_ip_allocation_response_p->apn, apn, apn_len + 1);
 
   if (status.ok()) {
     amf_ip_allocation_response_p->result = SGI_STATUS_OK;
@@ -105,7 +111,13 @@ static void handle_allocate_ipv6_address_status(
   memcpy(amf_ip_allocation_response_p->gnb_gtp_teid_ip_addr,
          gnb_gtp_teid_ip_addr, gnb_gtp_teid_ip_addr_len);
 
-  memcpy(amf_ip_allocation_response_p->apn, apn, strlen(apn) + 1);
+  size_t apn_len = strlen(apn);
+  if (apn_len >= sizeof(amf_ip_allocation_response_p->apn)) {
+    OAILOG_ERROR(LOG_AMF_APP, "APN too long (%zu bytes), dropping IPv6 allocation response\n", apn_len);
+    itti_free(ITTI_MSG_ORIGIN_ID(message_p), message_p);
+    return;
+  }
+  memcpy(amf_ip_allocation_response_p->apn, apn, apn_len + 1);
 
   if (status.ok()) {
     amf_ip_allocation_response_p->result = SGI_STATUS_OK;
@@ -146,7 +158,13 @@ static void handle_allocate_ipv4v6_address_status(
   memcpy(amf_ip_allocation_response_p->gnb_gtp_teid_ip_addr,
          gnb_gtp_teid_ip_addr, gnb_gtp_teid_ip_addr_len);
 
-  memcpy(amf_ip_allocation_response_p->apn, apn, strlen(apn) + 1);
+  size_t apn_len = strlen(apn);
+  if (apn_len >= sizeof(amf_ip_allocation_response_p->apn)) {
+    OAILOG_ERROR(LOG_AMF_APP,"APN too long (%zu bytes), dropping IPv4v6 allocation response\n",apn_len);
+    itti_free(ITTI_MSG_ORIGIN_ID(message_p), message_p);
+    return;
+  }
+  memcpy(amf_ip_allocation_response_p->apn, apn, apn_len + 1);
 
   if (status.ok()) {
     amf_ip_allocation_response_p->result = SGI_STATUS_OK;

--- a/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.cpp
@@ -67,7 +67,7 @@ static void handle_allocate_ipv4_address_status(
 
   size_t apn_len = strlen(apn);
   if (apn_len >= sizeof(amf_ip_allocation_response_p->apn)) {
-    OAILOG_ERROR(LOG_AMF_APP, "APN too long (%zu bytes), dropping IPv4 allocation response\n", apn_len);
+    OAILOG_ERROR(LOG_AMF_APP, "APN too long (%zu bytes), dropping IPv4v6 allocation response\n", apn_len);
     itti_free(ITTI_MSG_ORIGIN_ID(message_p), message_p);
     return;
   }
@@ -160,7 +160,7 @@ static void handle_allocate_ipv4v6_address_status(
 
   size_t apn_len = strlen(apn);
   if (apn_len >= sizeof(amf_ip_allocation_response_p->apn)) {
-    OAILOG_ERROR(LOG_AMF_APP,"APN too long (%zu bytes), dropping IPv4v6 allocation response\n",apn_len);
+    OAILOG_ERROR(LOG_AMF_APP, "APN too long (%zu bytes), dropping IPv4v6 allocation response\n", apn_len);
     itti_free(ITTI_MSG_ORIGIN_ID(message_p), message_p);
     return;
   }


### PR DESCRIPTION
## Summary
Fixes #15867 — adds APN length validation in `M5GMobilityServiceClient.cpp` to prevent potential buffer overflows and ensure safe handling of incoming APN values.

Previously, APN strings were copied without validating their length against the destination buffer, which could lead to memory corruption or crashes under malformed or unexpected inputs.

---

## Changes
**File:** `lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.cpp`

- Added APN length validation before copying into destination buffers:
  ```c
  if (apn_len >= sizeof(amf_ip_allocation_response_p->apn)) {
      OAILOG_ERROR(LOG_AMF_APP, "APN too long (%zu bytes), dropping response", apn_len);
      itti_free(ITTI_MSG_ORIGIN_ID(message_p), message_p);
      return;
  }

## Testing
- Verified normal behavior with valid APN values under standard traffic
- Tested boundary conditions with APN length equal to buffer size limit
- Confirmed no crashes, memory corruption, or regressions under load

## Related Issue
Closes #15867