### PR TITLE
style(magmad): resolve linting and docstring violations

### DIFF
--- a/orc8r/gateway/python/magma/magmad/generic_command/shell_command_executor.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/shell_command_executor.py
@@ -26,7 +26,7 @@ from magma.magmad.generic_command.command_executor import (
 # Only these command names may be registered via config.
 # Generic shell access (bash, fab, echo) is intentionally excluded
 # to prevent arbitrary command execution via the Orchestrator API.
-COMMAND_ALLOWLIST = frozenset({
+COMMAND_ALLOWLIST = frozenset((
     'reboot_enodeb',
     'reboot_all_enodeb',
     'health',
@@ -35,7 +35,7 @@ COMMAND_ALLOWLIST = frozenset({
     'get_subscriber_table',
     'check_stateless',
     'configure_stateless',
-})
+))
 
 # Shell metacharacters that must not appear in command parameters.
 _SHELL_METACHAR_RE = re.compile(r'[;|&$`\n]')
@@ -44,7 +44,7 @@ _SHELL_METACHAR_RE = re.compile(r'[;|&$`\n]')
 class ShellCommandExecutor(CommandExecutor):
     """
     The shell command executor stores shell commands from the service config
-    into its dispatch table
+    into its dispatch table.
     """
 
     def __init__(
@@ -58,16 +58,29 @@ class ShellCommandExecutor(CommandExecutor):
     def get_command_dispatch(
             self,
     ) -> Dict[str, ExecutorFuncT]:
+        """Get the command dispatch table.
+
+        Returns:
+            Dict[str, ExecutorFuncT]: The dispatch table.
+        """
         return self._dispatch_table
 
 
 def get_shell_commands_from_config(
         config: Dict[str, Any],
 ) -> Dict[str, ExecutorFuncT]:
-    """
-    Gets a list of shell commands from the config. Creates subprocess
-    coroutines for each command and stores it in a dictionary.
-    Only commands whose name is in COMMAND_ALLOWLIST are registered.
+    """Get a list of shell commands from the config.
+
+    Creates subprocess coroutines for each command and stores it in a
+    dictionary. Only commands whose name is in COMMAND_ALLOWLIST are
+    registered.
+
+    Args:
+        config: The service configuration dictionary.
+
+    Returns:
+        Dict[str, ExecutorFuncT]: A dispatch table mapping command names
+            to functions.
     """
     shell_commands = config\
         .get('generic_command_config', {})\
@@ -113,14 +126,20 @@ async def _run_subprocess(
         allow_params: bool,
         params: Dict[str, ParamValueT],
 ) -> Dict[str, Any]:
-    """
-    Runs a command given params (optional), and returns the return code,
-    stdout, and stderr.
+    """Run a command given params and return results.
+
+    Args:
+        cmd: The shell command template to execute.
+        allow_params: Whether parameters are allowed to be formatted.
+        params: Dictionary of parameters for the command.
+
+    Returns:
+        Dict[str, Any]: Dictionary containing returncode, stdout, and stderr.
     """
     cmd_str = cmd
     if allow_params:
         shell_params = params.get('shell_params', [''])
-        if shell_params == []:
+        if not shell_params:
             shell_params = ['']
         _validate_shell_params(shell_params)
         cmd_str = cmd.format(*shell_params)

--- a/orc8r/gateway/python/magma/magmad/generic_command/tests/shell_command_executor_test.py
+++ b/orc8r/gateway/python/magma/magmad/generic_command/tests/shell_command_executor_test.py
@@ -88,7 +88,7 @@ class ShellCommandExecutorTest(unittest.TestCase):
                 'shell_commands': [
                     {
                         'name': 'health',
-                        'command': 'echo {} {}',
+                        'command': 'echo {0} {1}',
                         'allow_params': True,
                     },
                 ],
@@ -133,9 +133,9 @@ class ShellCommandExecutorTest(unittest.TestCase):
         self.service.config = {
             'generic_command_config': {
                 'shell_commands': [
-                    {'name': 'bash', 'command': 'bash {}', 'allow_params': True},
-                    {'name': 'fab', 'command': 'fab {}', 'allow_params': True},
-                    {'name': 'echo', 'command': 'echo {}', 'allow_params': True},
+                    {'name': 'bash', 'command': 'bash {0}', 'allow_params': True},
+                    {'name': 'fab', 'command': 'fab {0}', 'allow_params': True},
+                    {'name': 'echo', 'command': 'echo {0}', 'allow_params': True},
                 ],
             },
         }
@@ -163,7 +163,7 @@ class ShellCommandExecutorTest(unittest.TestCase):
                 'shell_commands': [
                     {
                         'name': 'health',
-                        'command': 'health_cli.py {}',
+                        'command': 'health_cli.py {0}',
                         'allow_params': True,
                     },
                 ],


### PR DESCRIPTION
## Summary

Address wemake-python-styleguide and flake8 failures in the shell command executor and its corresponding test suite. These changes satisfy the strict CI requirements needed to unblock the PR.

- Fix WPS527 by using a tuple instead of a set for frozenset arguments.
- Fix WPS520 by replacing explicit empty list comparisons with 'not'.
- Resolve P103 by adding positional indices ({0}) to all format strings.
- Update docstrings to Google-style format to satisfy D102, DAR101, and DAR201 requirements.
- Rewrite docstring summaries to use imperative mood (D401).

Refs: #15847 #15834

Note on Docstrings: I have updated several docstrings to satisfy D102/DAR/D401 errors. As I explained in [this comment in #15852](https://github.com/magma/magma/pull/15852#issuecomment-4118949389), these were triggered by the CI re-validating the blocks after the logic refactor.