### PR TITLE
build(lte): silence deprecation warnings for HEConfig remediation

### DIFF
--- a/lte/gateway/c/core/BUILD.bazel
+++ b/lte/gateway/c/core/BUILD.bazel
@@ -1164,6 +1164,7 @@ cc_library(
         "-DCMAKE_BUILD_TYPE=\\\"CMAKE_BUILD_TYPE\\\"",  # TODO(#11897): needs alternative approach or deprecation
         "-DEMBEDDED_SGW=1",
         "-DS6A_OVER_GRPC=1",
+        "-Wno-deprecated-declarations",
     ],
     deps = MME_DEPS + AGW_OF_DEPS,
 )
@@ -1177,6 +1178,7 @@ cc_library(
         "-DCMAKE_BUILD_TYPE=\\\"CMAKE_BUILD_TYPE\\\"",  # TODO(#11897): needs alternative approach or deprecation
         "-DEMBEDDED_SGW=0",
         "-DS6A_OVER_GRPC=0",
+        "-Wno-deprecated-declarations",
     ],
     tags = TAG_MME_OAI,
     deps = MME_DEPS,


### PR DESCRIPTION
## Summary
Marking RC4 and MD5 as [deprecated = true] in HEConfig.proto triggered 17+ compilation failures because the AGW C++ build treats all warnings as errors (-Werror).

This change adds -Wno-deprecated-declarations to the copts of lib_agw_of and lib_mme_oai in the core BUILD.bazel. This silences the build-blocking warnings while preserving the deprecation annotations in the proto files for future cleanup.

Verified locally: successful 2080-action build and 100% pass rate across 50 core unit tests.

```text
INFO: Elapsed time: 231.507s, Critical Path: 25.36s
INFO: 3847 processes: 8 internal, 3839 processwrapper-sandbox.
INFO: Build completed successfully, 3847 total actions
```
```text
INFO: Elapsed time: 211.031s, Critical Path: 62.76s
INFO: 2080 processes: 660 internal, 1420 processwrapper-sandbox.
INFO: Build completed successfully, 2080 total actions
//lte/gateway/c/core/oai/test/amf:amf_algorithm_selection_test           PASSED in 0.5s
//lte/gateway/c/core/oai/test/amf:amf_common_utils_test                  PASSED in 4.2s
//lte/gateway/c/core/oai/test/amf:amf_encode_decode_test                 PASSED in 0.6s
//lte/gateway/c/core/oai/test/amf:amf_map_test                           PASSED in 0.6s
//lte/gateway/c/core/oai/test/amf:amf_procedures_test                    PASSED in 0.3s
//lte/gateway/c/core/oai/test/amf:amf_stateless_test                     PASSED in 0.6s
//lte/gateway/c/core/oai/test/gtpv2-c:gtpv2_fteid_test                   PASSED in 0.4s
//lte/gateway/c/core/oai/test/itti:itti_test                             PASSED in 4.5s
//lte/gateway/c/core/oai/test/lib:lib_3gpp_test                          PASSED in 0.5s
//lte/gateway/c/core/oai/test/lib:lib_bstr_test                          PASSED in 0.4s
//lte/gateway/c/core/oai/test/lib:lib_ula_subdata_test                   PASSED in 0.5s
//lte/gateway/c/core/oai/test/lib/mme_app:lib_mme_app_map_test           PASSED in 0.5s
//lte/gateway/c/core/oai/test/mme_app_task:apn_aggregate_maximum_bit_rate_test PASSED in 0.4s
//lte/gateway/c/core/oai/test/mme_app_task:eps_quality_of_service_test   PASSED in 0.4s
//lte/gateway/c/core/oai/test/mme_app_task:mme_app_config_test           PASSED in 0.6s
//lte/gateway/c/core/oai/test/mme_app_task:mme_app_emm_encode_decode_test PASSED in 0.5s
//lte/gateway/c/core/oai/test/mme_app_task:mme_app_esm_encode_decode_test PASSED in 0.4s
//lte/gateway/c/core/oai/test/mme_app_task:mme_app_nas_encode_decode_test PASSED in 0.5s
//lte/gateway/c/core/oai/test/mme_app_task:mme_app_ue_context_test       PASSED in 0.7s
//lte/gateway/c/core/oai/test/mme_app_task:mme_procedures_mobile_reachability_timer_test PASSED in 4.2s
//lte/gateway/c/core/oai/test/mme_app_task:mme_procedures_nas_timer_test PASSED in 1.3s
//lte/gateway/c/core/oai/test/mme_app_task:mme_procedures_network_initiated_test PASSED in 13.8s
//lte/gateway/c/core/oai/test/mme_app_task:mme_procedures_test           PASSED in 32.7s
//lte/gateway/c/core/oai/test/mme_app_task:mme_procedures_x2_handover_test PASSED in 2.0s
//lte/gateway/c/core/oai/test/mme_app_task:sgw_config_test               PASSED in 0.6s
//lte/gateway/c/core/oai/test/n11:n11_auth_service_client_test           PASSED in 0.5s
//lte/gateway/c/core/oai/test/n11:n11_smf_service_client_test            PASSED in 0.6s
//lte/gateway/c/core/oai/test/nas:nas_converter_test                     PASSED in 0.5s
//lte/gateway/c/core/oai/test/ngap:ngap_encode_decode_test               PASSED in 0.6s
//lte/gateway/c/core/oai/test/ngap:ngap_flows_test                       PASSED in 0.4s
//lte/gateway/c/core/oai/test/ngap:ngap_handle_new_association_test      PASSED in 0.5s
//lte/gateway/c/core/oai/test/ngap:ngap_state_converter_test             PASSED in 0.5s
//lte/gateway/c/core/oai/test/openflow:gtp_app_test                      PASSED in 0.5s
//lte/gateway/c/core/oai/test/openflow:imsi_encoder_test                 PASSED in 0.4s
//lte/gateway/c/core/oai/test/openflow:openflow_controller_test          PASSED in 0.5s
//lte/gateway/c/core/oai/test/pipelined_client:pipelined_client_test     PASSED in 0.5s
//lte/gateway/c/core/oai/test/s1ap_task:s1ap_handle_new_association_test PASSED in 0.4s
//lte/gateway/c/core/oai/test/s1ap_task:s1ap_mme_handlers_test           PASSED in 49.2s
//lte/gateway/c/core/oai/test/s1ap_task:s1ap_mme_handlers_with_injected_state_test PASSED in 7.6s
//lte/gateway/c/core/oai/test/s1ap_task:s1ap_state_manager_test          PASSED in 0.5s
//lte/gateway/c/core/oai/test/s6a_task:s6a_recv_async_grpc_messages_test PASSED in 2.8s
//lte/gateway/c/core/oai/test/sgw_s8_task:sgw_dedicated_bearer_test      PASSED in 9.4s
//lte/gateway/c/core/oai/test/sgw_s8_task:sgw_s8_recv_grpc_messages_test PASSED in 3.3s
//lte/gateway/c/core/oai/test/sgw_s8_task:sgw_s8_test_attach_proc_test   PASSED in 10.7s
//lte/gateway/c/core/oai/test/spgw_task:pgw_pco_test                     PASSED in 0.6s
//lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_dedicated_bearer_test PASSED in 18.6s
//lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_session_test     PASSED in 12.6s
//lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_test             PASSED in 16.3s
//lte/gateway/c/core/oai/test/spgw_task:spgw_procedures_with_injected_state_test PASSED in 21.5s
//lte/gateway/c/core/oai/test/spgw_task:spgw_service_impl_test           PASSED in 0.4s

Executed 50 out of 50 tests: 50 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see 
INFO: Build completed successfully, 2080 total actions
```

Refs: #15849 #15834