### PR TITLE
docs: ignore netmanias links in markdown-link-check

### DIFF
--- a/docs/readmes/resources/ref_useful_links.md
+++ b/docs/readmes/resources/ref_useful_links.md
@@ -8,6 +8,8 @@ hide_title: true
 
 This is a list of links that may be useful to understand Magma
 
+<!-- markdown-link-check-disable -->
 - 3GPP processes descriptions at [Netmanias](https://www.netmanias.com/)
 - Basic 3GPP [Attach procedure](https://www.netmanias.com/en/post/techdocs/6102/emm-initial-attach-lte/emm-procedure-1-initial-attach-part-2-call-flow-of-initial-attach)
+<!-- markdown-link-check-enable -->
 - [Go Diameter](https://github.com/fiorix/go-diameter/blob/master/diam/dict/default.go) suported AVPs


### PR DESCRIPTION
## Summary
Wraps Netmanias references in markdown-link-check ignore tags. These URLs currently return 403 Forbidden to GitHub Action runners, causing persistent CI failures in Phase 3 modernization efforts.

Refs: #15835 #15853



