### PR TITLE
chore(deps): upgrade Bazel external dependencies and Go SDK

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -17,8 +17,9 @@ load("//bazel:third_party_repositories.bzl", "grpc")
 
 http_archive(
     name = "rules_python",
-    sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.5.0/rules_python-0.5.0.tar.gz",
+    sha256 = "dc6e2756130fafb90273587003659cadd1a2dfef3f6464c227794cdc01ebf70e",
+    strip_prefix = "rules_python-0.33.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.33.0/rules_python-0.33.0.tar.gz",
 )
 
 http_archive(
@@ -30,19 +31,19 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb",
+    sha256 = "33acc4ae0f70502db4b893c9fc1dd7a9bf998c23e7ff2c4517741d4049a976f8",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    sha256 = "d76bf7a60fd8b050444090dfa2837a4eaf9829e1165618ee35dceca5cbdf58d5",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.37.0/bazel-gazelle-v0.37.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.37.0/bazel-gazelle-v0.37.0.tar.gz",
     ],
 )
 
@@ -55,20 +56,16 @@ go_repositories()
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.17")
+go_register_toolchains(version = "1.23")
 
-gazelle_dependencies()
-
-# If you use WORKSPACE.bazel, use the following line instead of the bare gazelle_dependencies():
-# gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
 gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+    sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
     urls = [
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
     ],
 )
 
@@ -148,10 +145,10 @@ python_repositories()
 
 http_archive(
     name = "rules_pkg",
-    sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
+    sha256 = "d20c951960ed77cb7b341c2a59488534e494d5ad1d30c4818c736d57772a9fef",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
     ],
 )
 


### PR DESCRIPTION
## Summary

Part of P027 Phase 4 (Dependency Upgrades) — Task 4.4: Bazel External Dependencies.

Upgrades all Bazel rules and the Go SDK toolchain in WORKSPACE.bazel:

| Dependency | Old | New | Notes |
|------------|-----|-----|-------|
| `rules_go` | v0.28.0 | **v0.48.0** | Required for Go 1.23 support |
| `bazel_gazelle` | v0.23.0 | **v0.37.0** | Paired with rules_go |
| `rules_python` | 0.5.0 | **0.33.0** | pip_parse API preserved |
| `bazel_skylib` | 1.0.3 | **1.7.1** | Foundational dependency |
| `rules_pkg` | 0.8.0 | **1.0.1** | |
| Go SDK | **1.17** | **1.23** | Matches go.mod declarations |

### Key fix
The Go SDK was at **1.17** while all go.mod files declare Go 1.23 (from PR #15880). This mismatch meant Bazel Go builds were using an SDK 6 major versions behind the module requirements. `rules_go` v0.28.0 doesn't support Go 1.23, so upgrading rules_go was a prerequisite.

### Cleanup
Removed duplicate `gazelle_dependencies()` call — the second call with `go_repository_default_config` was already overriding the first bare call.

### Verification
All sha256 hashes were computed by downloading release archives locally.

Related: #15836 (Phase 4 tracking), #15828 (P027 tracking)
Depends on: #15880 (Go module upgrades)

## Test plan
- [ ] Bazel build succeeds: `bazel build //...`
- [ ] Bazel tests pass: `bazel test //...`
- [ ] CI AGW Bazel builds pass
- [ ] Go SDK 1.23 resolves correctly in Bazel sandbox