### PR TITLE
chore: add missing BSD-3-Clause license headers to 57 source files

### DIFF
--- a/cwf/cloud/go/services/cwf/analytics/calculations/authentications.go
+++ b/cwf/cloud/go/services/cwf/analytics/calculations/authentications.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package calculations
 
 import (

--- a/cwf/cloud/go/services/cwf/obsidian/models/defaults.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/defaults.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models
 
 import fegmodels "magma/feg/cloud/go/services/feg/obsidian/models"

--- a/dp/cloud/go/services/dp/active_mode_controller/action_generator/generators.go
+++ b/dp/cloud/go/services/dp/active_mode_controller/action_generator/generators.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package action_generator
 
 import (

--- a/dp/cloud/go/services/dp/logs_pusher/logs_pusher.go
+++ b/dp/cloud/go/services/dp/logs_pusher/logs_pusher.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package logs_pusher
 
 import (

--- a/dp/cloud/go/services/dp/logs_pusher/logs_pusher_test.go
+++ b/dp/cloud/go/services/dp/logs_pusher/logs_pusher_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package logs_pusher
 
 import (

--- a/dp/cloud/go/services/dp/obsidian/models/validation.go
+++ b/dp/cloud/go/services/dp/obsidian/models/validation.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models
 
 import (

--- a/dp/cloud/go/services/dp/obsidian/models/validation_test.go
+++ b/dp/cloud/go/services/dp/obsidian/models/validation_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models_test
 
 import (

--- a/dp/cloud/go/services/dp/servicers/db_field_setters.go
+++ b/dp/cloud/go/services/dp/servicers/db_field_setters.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package servicers
 
 import (

--- a/dp/cloud/go/services/dp/storage/amc_manager_test.go
+++ b/dp/cloud/go/services/dp/storage/amc_manager_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package storage_test
 
 import (

--- a/dp/cloud/go/services/dp/storage/diff.go
+++ b/dp/cloud/go/services/dp/storage/diff.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package storage
 
 import (

--- a/dp/cloud/go/services/dp/storage/diff_test.go
+++ b/dp/cloud/go/services/dp/storage/diff_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package storage_test
 
 import (

--- a/dp/cloud/go/services/dp/storage/dp_manager.go
+++ b/dp/cloud/go/services/dp/storage/dp_manager.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package storage
 
 import (

--- a/dp/cloud/python/magma/db_service/tests/unit/test_018_add_indices_for_relations.py
+++ b/dp/cloud/python/magma/db_service/tests/unit/test_018_add_indices_for_relations.py
@@ -1,3 +1,16 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from typing import Dict, List
 
 from magma.db_service.tests.alembic_testcase import AlembicTestCase

--- a/dp/cloud/python/magma/radio_controller/tests/unit/test_radio_controller_service.py
+++ b/dp/cloud/python/magma/radio_controller/tests/unit/test_radio_controller_service.py
@@ -1,0 +1,13 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+

--- a/feg/cloud/go/services/basic_acct/servicers/southbound/config.go
+++ b/feg/cloud/go/services/basic_acct/servicers/southbound/config.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package servicers
 
 import (

--- a/feg/gateway/plmn_filter/plmn_filter_test.go
+++ b/feg/gateway/plmn_filter/plmn_filter_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package plmn_filter
 
 import (

--- a/feg/gateway/services/aaa/radius/encr_test.go
+++ b/feg/gateway/services/aaa/radius/encr_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package radius_test
 
 import (

--- a/feg/gateway/services/s8_proxy/client_api_test.go
+++ b/feg/gateway/services/s8_proxy/client_api_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package s8_proxy_test
 
 import (

--- a/feg/gateway/services/s8_proxy/servicers/config_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/config_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package servicers_test
 
 import (

--- a/feg/gateway/services/s8_proxy/test_init/test_service_init.go
+++ b/feg/gateway/services/s8_proxy/test_init/test_service_init.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test_init
 
 import (

--- a/feg/gateway/services/testcore/hss/servicers/config_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/config_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package servicers_test
 
 import (

--- a/feg/gateway/tools/s8_cli/main_test.go
+++ b/feg/gateway/tools/s8_cli/main_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //go:build cli_test
 // +build cli_test
 

--- a/lte/cloud/go/services/lte/analytics/calculations/state_test.go
+++ b/lte/cloud/go/services/lte/analytics/calculations/state_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package calculations_test
 
 import (

--- a/lte/cloud/go/services/lte/analytics/calculations/user_throughput_test.go
+++ b/lte/cloud/go/services/lte/analytics/calculations/user_throughput_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package calculations_test
 
 import (

--- a/lte/cloud/go/services/smsd/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/smsd/obsidian/models/conversion.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models
 
 import (

--- a/lte/cloud/go/services/smsd/servicers/smsd_rest.go
+++ b/lte/cloud/go/services/smsd/servicers/smsd_rest.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package servicers
 
 import (

--- a/lte/cloud/go/sms_ll/sms_ll_test.go
+++ b/lte/cloud/go/sms_ll/sms_ll_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sms_ll
 
 import (

--- a/lte/gateway/python/magma/pipelined/tests/envoy-tests/http-serve.py
+++ b/lte/gateway/python/magma/pipelined/tests/envoy-tests/http-serve.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
 import SimpleHTTPServer
 import SocketServer
 

--- a/lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py
+++ b/lte/gateway/python/magma/pipelined/tests/script/gtp-packet.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
 # sudo /home/vagrant/build/python/bin/python gtp-cmd.py 192.168.60.141 192.168.60.142 192.168.128.12 192.168.129.42 eth1
 
 import sys

--- a/lte/gateway/python/magma/pipelined/tests/script/ip-packet.py
+++ b/lte/gateway/python/magma/pipelined/tests/script/ip-packet.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
 # sudo /home/vagrant/build/python/bin/python gtp-cmd.py 192.168.128.12 192.168.129.42 eth1
 
 import sys

--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/common.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/common.py
@@ -1,3 +1,16 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import asyncio
 
 # pylint: disable=W0223

--- a/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
+++ b/orc8r/cloud/go/services/analytics/calculations/log_calculations.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package calculations
 
 import (

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/registration.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/registration.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package registration
 
 import (

--- a/orc8r/cloud/go/services/bootstrapper/servicers/registration/time.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/registration/time.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package registration
 
 import (

--- a/orc8r/cloud/go/services/certifier/constants/constants.go
+++ b/orc8r/cloud/go/services/certifier/constants/constants.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package constants
 
 const (

--- a/orc8r/cloud/go/services/certifier/obsidian/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/certifier/obsidian/handlers/handlers_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package handlers_test
 
 import (

--- a/orc8r/cloud/go/services/certifier/protos/helpers.go
+++ b/orc8r/cloud/go/services/certifier/protos/helpers.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package protos
 
 import (

--- a/orc8r/cloud/go/services/certifier/test_utils/test_utils.go
+++ b/orc8r/cloud/go/services/certifier/test_utils/test_utils.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test_utils
 
 import (

--- a/orc8r/cloud/go/services/certifier/tokens.go
+++ b/orc8r/cloud/go/services/certifier/tokens.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package certifier
 
 import (

--- a/orc8r/cloud/go/services/eventd/log/handlers/log_handlers.go
+++ b/orc8r/cloud/go/services/eventd/log/handlers/log_handlers.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package handlers
 
 import (

--- a/orc8r/cloud/go/services/eventd/log/handlers/log_handlers_test.go
+++ b/orc8r/cloud/go/services/eventd/log/handlers/log_handlers_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package handlers
 
 import (

--- a/orc8r/cloud/go/services/metricsd/exporters/remote_exporter.go
+++ b/orc8r/cloud/go/services/metricsd/exporters/remote_exporter.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package exporters
 
 import (

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package handlers
 
 import (

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package handlers
 
 import (

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_silencing_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_silencing_handlers.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package handlers
 
 import (

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_silencing_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_silencing_handlers_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package handlers
 
 import (

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/cache/series_cache_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/cache/series_cache_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cache
 
 import (

--- a/orc8r/cloud/go/services/orchestrator/analytics/calculations/state_test.go
+++ b/orc8r/cloud/go/services/orchestrator/analytics/calculations/state_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package calculations_test
 
 import (

--- a/orc8r/cloud/go/services/orchestrator/servicers/protected/export_test.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/protected/export_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package servicers
 
 var GetStateMconfig = getStateMconfig

--- a/orc8r/cloud/go/services/tenants/servicers/protected/servicer_test.go
+++ b/orc8r/cloud/go/services/tenants/servicers/protected/servicer_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package servicers_test
 
 import (

--- a/orc8r/cloud/go/services/tenants/servicers/storage/storage.go
+++ b/orc8r/cloud/go/services/tenants/servicers/storage/storage.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package storage
 
 import (

--- a/orc8r/cloud/go/services/tenants/servicers/storage/storage_test.go
+++ b/orc8r/cloud/go/services/tenants/servicers/storage/storage_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package storage
 
 import (

--- a/orc8r/cloud/go/sqorc/error_checker.go
+++ b/orc8r/cloud/go/sqorc/error_checker.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sqorc
 
 import (

--- a/orc8r/cloud/go/sqorc/error_checker_test.go
+++ b/orc8r/cloud/go/sqorc/error_checker_test.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sqorc
 
 import (

--- a/orc8r/cloud/go/tools/accessc/handlers/add_admin_token.go
+++ b/orc8r/cloud/go/tools/accessc/handlers/add_admin_token.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package handlers
 
 import (

--- a/orc8r/gateway/go/services/bootstrapper/gateway_info/get_info.go
+++ b/orc8r/gateway/go/services/bootstrapper/gateway_info/get_info.go
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // package gateway_info collects, formats & returns GW information needed for gateway registration
 package gateway_info
 

--- a/orc8r/gateway/python/magma/configuration/__init__.py
+++ b/orc8r/gateway/python/magma/configuration/__init__.py
@@ -1,3 +1,16 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import importlib
 import logging
 


### PR DESCRIPTION
## Summary

Add the standard Magma BSD-3-Clause license header to **57 source files** (50 Go, 7 Python) that were missing it entirely.

This is part of **P027 Phase 6: Code Quality** (#15838, parent: #15828).

### Scope

**Go files (50)** across:
- `orc8r/cloud/go/` (20 files)
- `dp/cloud/go/` (12 files)
- `feg/gateway/` + `feg/cloud/go/` (7 files)
- `lte/cloud/go/` (5 files)
- `cwf/cloud/go/` (2 files)
- `orc8r/gateway/go/` (1 file)

Notable subsystems: certifier, bootstrapper, metricsd, eventd, tenants, sqorc, analytics

**Python files (7)** across:
- `dp/cloud/python/` (2 files)
- `lte/gateway/python/` (4 files)
- `orc8r/gateway/python/` (1 file)

### Excluded
- Generated files (`*.pb.go`, `*_swaggergen.go`, `*.gen.go`)
- Mock files (`*/mocks/*`)
- Empty `__init__.py` files (24 skipped)
- Alembic migration files (auto-generated, 22 skipped)
- Files with legacy Facebook copyright (9 files, separate cleanup)
- Files in open PRs to avoid merge conflicts

### Remaining work (future PRs)
- ~350+ C/C++ files in `lte/gateway/c/` missing headers
- 9 Python files with legacy Facebook copyright needing update
- TypeScript/NMS files (deferred until ESLint upgrade)

## Test plan
- [x] Header format matches existing files exactly (verified by inspection)
- [x] No functional code changes - only prepended comment blocks
- [x] No files from AVOID list modified
- [x] No generated files modified