### PR TITLE
chore: remove obsolete __future__ imports and unused typing import

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -40,13 +40,6 @@ during it's life cycle in the IP allocator:
         to age IPs for a certain period of time before freeing.
 """
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import ipaddress
 import logging
 import threading
@@ -68,11 +61,9 @@ from .mobility_store import MobilityStore
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 
-
 class IPAddressManager:
     """ A thread-safe IP allocator: all mutating functions are protected by a
     re-entrant lock.
-
 
     The IPAllocator maintains IP life cycle, as well as the mapping between
     SubscriberID (SID) and IPs. For now, only one-to-one mapping is supported

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
@@ -11,13 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from abc import ABC, abstractmethod
 from typing import List
 
@@ -25,7 +18,6 @@ from magma.mobilityd.ip_descriptor import IPDesc
 from magma.mobilityd.utils import IPAddress, IPNetwork
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
-
 
 class IPAllocator(ABC):
 
@@ -57,12 +49,10 @@ class IPAllocator(ABC):
     def release_ip(self, ip_desc: IPDesc):
         ...
 
-
 class OverlappedIPBlocksError(Exception):
     """ Exception thrown when a given IP block overlaps with existing ones
     """
     pass
-
 
 class IPBlockNotFoundError(Exception):
     """ Exception thrown when listing an IP block that is not found in the ip
@@ -70,19 +60,16 @@ class IPBlockNotFoundError(Exception):
     """
     pass
 
-
 class NoAvailableIPError(Exception):
     """ Exception thrown when no IP is available in the free list for an ip
     allocation request
     """
     pass
 
-
 class DuplicatedIPAllocationError(Exception):
     """ Exception thrown when an IP has already been allocated to a UE
     """
     pass
-
 
 class DuplicateIPAssignmentError(Exception):
     """ Exception thrown when underlying IP allocator assigns duplicate
@@ -91,13 +78,11 @@ class DuplicateIPAssignmentError(Exception):
     """
     pass
 
-
 class IPNotInUseError(Exception):
     """ Exception thrown when releasing an IP address that is not found in the
     used list
     """
     pass
-
 
 class MappingNotFoundError(Exception):
     """ Exception thrown when releasing a non-exising SID-IP mapping """

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -13,13 +13,6 @@ limitations under the License.
 Allocates IP address as per DHCP server in the uplink network.
 """
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import json
 import logging
 import subprocess
@@ -47,7 +40,6 @@ DHCP_HELPER_CLI = "dhcp_helper_cli.py"
 LOG = logging.getLogger('mobilityd.dhcp.alloc')
 
 DHCP_ACTIVE_STATES = [DHCPState.ACK, DHCPState.OFFER]
-
 
 class IPAllocatorDHCP(IPAllocator):
 
@@ -471,7 +463,6 @@ class IPAllocatorDHCP(IPAllocator):
                         "and moving on.", ip_desc.ip,
                     )
                     oldest_proc.kill()
-
 
 def dhcp_allocated_ip(dhcp_desc: DHCPDescriptor) -> bool:
     return dhcp_desc.ip_is_allocated()

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
@@ -15,13 +15,6 @@ The IP allocator accepts IP blocks (range of IP addresses), and supports
 allocating and releasing IP addresses from the assigned IP blocks.
 """
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from typing import List
 
 from magma.mobilityd.ip_allocator_base import IPAllocator
@@ -31,7 +24,6 @@ from magma.mobilityd.subscriberdb_client import SubscriberDbClient
 from magma.mobilityd.utils import IPAddress, IPNetwork
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
-
 
 class IPAllocatorMultiAPNWrapper(IPAllocator):
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -15,13 +15,6 @@ The IP allocator accepts IP blocks (range of IP addresses), and supports
 allocating and releasing IP addresses from the assigned IP blocks.
 """
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import logging
 from copy import deepcopy
 from typing import List
@@ -38,7 +31,6 @@ from .mobility_store import MobilityStore
 from .utils import IPAddress, IPNetwork
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
-
 
 class IpAllocatorPool(IPAllocator):
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -15,13 +15,6 @@ The IP allocator accepts IP blocks (range of IP addresses), and supports
 allocating and releasing IP addresses from the assigned IP blocks.
 """
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import logging
 from ipaddress import ip_network
 from typing import List, Optional
@@ -37,7 +30,6 @@ from magma.mobilityd.subscriberdb_client import SubscriberDbClient
 from magma.mobilityd.utils import IPAddress, IPNetwork, log_error_and_raise
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
-
 
 class IPAllocatorStaticWrapper(IPAllocator):
 

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor_map.py
@@ -32,13 +32,6 @@ during it's life cycle in the IP allocator:
         to age IPs for a certain period of time before freeing.
 """
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from ipaddress import ip_address
 from typing import Dict, List, MutableMapping, Optional, Set
 
@@ -46,7 +39,6 @@ from magma.mobilityd.ip_descriptor import IPDesc, IPState
 from magma.mobilityd.utils import IPAddress, IPNetwork
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
-
 
 class IpDescriptorMap:
 

--- a/lte/gateway/python/magma/pipelined/qos/tc_ops.py
+++ b/lte/gateway/python/magma/pipelined/qos/tc_ops.py
@@ -12,16 +12,8 @@ limitations under the License.
 """
 # pylint: disable=unnecessary-ellipsis
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from abc import ABC, abstractmethod
 from typing import Optional
-
 
 class TcOpsBase(ABC):
     """

--- a/orc8r/gateway/python/scripts/register.py
+++ b/orc8r/gateway/python/scripts/register.py
@@ -17,7 +17,6 @@ import os
 import sys
 import textwrap
 import time
-from typing import List
 
 import checkin_cli
 import snowflake


### PR DESCRIPTION
## Summary

Remove unused Python imports from 9 files across the codebase.

This is part of **P027 Phase 6: Code Quality** (#15838, parent: #15828).

### Changes

**Obsolete `__future__` imports removed (8 files):**

The following Python 2 compatibility imports are no-ops in Python 3 and have been removed:
```python
from __future__ import absolute_import, division, print_function, unicode_literals
```

Files:
- `lte/gateway/python/magma/mobilityd/ip_address_man.py`
- `lte/gateway/python/magma/mobilityd/ip_allocator_base.py`
- `lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py`
- `lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py`
- `lte/gateway/python/magma/mobilityd/ip_allocator_pool.py`
- `lte/gateway/python/magma/mobilityd/ip_allocator_static.py`
- `lte/gateway/python/magma/mobilityd/ip_descriptor_map.py`
- `lte/gateway/python/magma/pipelined/qos/tc_ops.py`

**Unused typing import removed (1 file):**
- `orc8r/gateway/python/scripts/register.py` - removed unused `from typing import List`

### Not changed (false positives verified)
- `orc8r/gateway/python/magma/configuration/service_configs.py` - `Dict` used in type comment
- `orc8r/gateway/python/magma/ctraced/rpc_servicer.py` - `EndTraceResult` used in type comment

## Test plan
- [x] Used AST-based analysis to detect unused imports
- [x] Manually verified each removal is safe
- [x] Confirmed type-comment usages are preserved
- [x] No files from AVOID list modified
- [x] No re-export `__init__.py` files modified