### PR TITLE
docs: add deprecation notices and fix stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The Magma materials are provided in accordance with the licenses made available 
 
 ## Security
 
-Responsible disclosures from independent researchers are gratefully accepted. See the [Security Policy](/magma/magma/security/policy) for submission details and [Security Overview for Contributors](https://github.com/magma/magma/wiki/Security-Overview-for-Contributors) to learn about other ways of contributing.
+Responsible disclosures from independent researchers are gratefully accepted. See the [Security Policy](https://github.com/magma/magma/security/policy) for submission details and [Security Overview for Contributors](https://github.com/magma/magma/wiki/Security-Overview-for-Contributors) to learn about other ways of contributing.
 
 We appreciate very much the valuable disclosures (and often fixes) from the following security researchers:
 

--- a/docs/docusaurus/versioned_docs/version-1.7.0/general/cloudstrapper_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/general/cloudstrapper_install.md
@@ -5,6 +5,10 @@ hide_title: true
 original_id: aws_cloudstrapper
 ---
 
+> **Deprecation Notice:** The Cloudstrapper tool under `experimental/cloudstrapper/`
+> is deprecated and scheduled for removal. This documentation is retained for
+> historical reference only.
+
 # Deploying Magma via Cloudstrapper
 
 There are two basic options for setting up Magma Cloudstrapper within Amazon Web Services: Marketplace or via private image.

--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/hil_tests.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/hil_tests.md
@@ -5,6 +5,10 @@ hide_title: true
 original_id: HIL_AGW_tests
 ---
 
+> **Deprecation Notice:** The HIL (Hardware in Loop) testing infrastructure
+> is deprecated and scheduled for removal. This documentation is retained
+> for historical reference only.
+
 # Hardware In Loop Tests
 
 Current testing workflow for HIL testing is using Spirent test center to emulate eNodeB, UE and Network host to run scale and performance tests. HIL is focusing on Magma AGW.

--- a/docs/docusaurus/versioned_docs/version-1.8.0/general/cloudstrapper_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/general/cloudstrapper_install.md
@@ -5,6 +5,10 @@ hide_title: true
 original_id: aws_cloudstrapper
 ---
 
+> **Deprecation Notice:** The Cloudstrapper tool under `experimental/cloudstrapper/`
+> is deprecated and scheduled for removal. This documentation is retained for
+> historical reference only.
+
 # Deploying Magma via Cloudstrapper
 
 There are two basic options for setting up Magma Cloudstrapper within Amazon Web Services: Marketplace or via private image.

--- a/docs/readmes/general/cloudstrapper_install.md
+++ b/docs/readmes/general/cloudstrapper_install.md
@@ -4,6 +4,11 @@ title: AWS Cloudstrapper Install
 hide_title: true
 ---
 
+> **Deprecation Notice:** The Cloudstrapper tool under `experimental/cloudstrapper/`
+> is deprecated and scheduled for removal. This documentation is retained for
+> historical reference only. For current deployment options, see the
+> [Install Guide](https://magma.github.io/magma/docs/basics/introduction.html).
+
 # Deploying Magma via Cloudstrapper
 
 There are two basic options for setting up Magma Cloudstrapper within Amazon Web Services: Marketplace or via private image.

--- a/experimental/cloudstrapper/README.md
+++ b/experimental/cloudstrapper/README.md
@@ -1,4 +1,7 @@
 
+> **Deprecation Notice:** The Cloudstrapper tool is deprecated and scheduled
+> for removal. This documentation is retained for historical reference only.
+
 # Chapter 1
 
 ## 0. Prerequisites

--- a/hil_testing/README.md
+++ b/hil_testing/README.md
@@ -1,3 +1,7 @@
+> **Deprecation Notice:** The HIL (Hardware in Loop) testing infrastructure
+> is deprecated and scheduled for removal. This documentation is retained
+> for historical reference only.
+
 # Magma Spirent Testing
 
 NOTE: The code is submited as-is. At the time of writing this README file, the SANITY test suite was fully functional. As long as the architecture  described in this readme is replicated, the expectation is that the test cases will continue to function.

--- a/lte/gateway/docker/README.md
+++ b/lte/gateway/docker/README.md
@@ -19,7 +19,7 @@ On an Arm architecture with the 5.4 kernel, the images can be built with `cd $MA
 ## Deploying the containerized AGW on AWS
 
 - Build the docker images and push them to a registry of your choice
-- Look at [the cloudstrapper readme](../../../experimental/cloudstrapper/README.md) for an AWS setup
+- Look at [the cloudstrapper readme](../../../experimental/cloudstrapper/README.md) for an AWS setup (note: Cloudstrapper is deprecated and scheduled for removal)
     - If you are only interested in running the AGW, you only need steps 1 and 5.1
         - Step 1 will produce required AWS resources like security groups, S3 buckets, and a keypair, and download the keypair to a local directory that you specify
         - Step 5.1 will start and customize an Ubuntu machine and create an AMI snapshot of that machine. The machine stays running after the snapshot is taken.


### PR DESCRIPTION
## Summary

Add deprecation notices to stale documentation and fix broken references.

### Changes
- Added deprecation notices to Cloudstrapper docs (being removed in Phase 5)
- Added deprecation notices to HIL testing docs (being removed in Phase 5)
- Fixed stale Security Policy link in root `README.md` to use absolute GitHub URL
- Marked cloudstrapper reference as deprecated in `lte/gateway/docker/README.md`

### Files affected (8)
- `docs/readmes/general/cloudstrapper_install.md`
- `experimental/cloudstrapper/README.md`
- `docs/docusaurus/versioned_docs/version-1.7.0/general/cloudstrapper_install.md`
- `docs/docusaurus/versioned_docs/version-1.8.0/general/cloudstrapper_install.md`
- `docs/docusaurus/versioned_docs/version-1.7.0/lte/hil_tests.md`
- `hil_testing/README.md`
- `lte/gateway/docker/README.md`
- `README.md`

Part of P027 Phase 7 (#15839) / P027 tracking (#15828)

## Test plan
- [x] Documentation-only changes
- [x] No functional code modified