### PR TITLE
test(pipelined): Add eBPF GTP-U E2E test suite

### DIFF
--- a/lte/gateway/python/magma/pipelined/ebpf/tests/README.md
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/README.md
@@ -8,6 +8,7 @@ The tests compile, load, and exercise the **actual production code**:
 
 - `ebpf_gtp_decap.c` -- `gtp_decap_handler()` on TC ingress
 - `ebpf_gtp_encap.c` -- `gtp_encap_handler()` on TC egress
+- `ebpf_gtp_veth0_mark.c` -- `gtp_veth0_mark_handler()` on TC ingress
 - `EbpfGtpMap.h` -- shared structs and map definitions
 
 Each test creates a veth pair, attaches the production eBPF program, populates
@@ -28,6 +29,7 @@ tests/
 +-- test_gtpu_packets.py           # GTP-U packet unit tests (no root)
 +-- test_production_decap.py       # E2E decap tests against ebpf_gtp_decap.c
 +-- test_production_encap.py       # E2E encap tests against ebpf_gtp_encap.c
++-- test_production_mark.py        # E2E mark tests against ebpf_gtp_veth0_mark.c
 +-- README.md
 ```
 
@@ -88,10 +90,26 @@ sudo venv/bin/python -m pytest . -v -s
 | test_06_double_encap_avoided | Already-GTP packets not re-encapsulated |
 | test_07_multiple_ue_sessions | Different UEs get correct TEIDs |
 | test_08_encap_double_encap_with_ipv4_options | **EXPECTED FAIL** -- Finding 4: double-encap detection broken with IPv4 options |
-| test_09_encap_missing_sgi_ip | **EXPECTED FAIL** -- Finding 5: silent 0.0.0.0 source IP |
+| test_09_encap_missing_sgi_ip | **EXPECTED FAIL** -- Finding 5: missing CONFIG_SGI_IP must fail closed; current implementation emits 0.0.0.0 |
 | test_10_encap_qfi_values | QFI boundary: default (0→9), normal (1), max (63) |
 | test_11_encap_non_ipv4_passthrough | ARP passes through without encapsulation |
 | test_12_encap_teid_zero | teid_dl_out=0 treated as inactive, packet dropped |
+
+### test_production_mark.py
+
+| Test | What it validates |
+| ---- | ----------------- |
+| test_01_compiles | `ebpf_gtp_veth0_mark.c` compiles with production cflags |
+| test_02_has_mark_handler | `gtp_veth0_mark_handler` function loadable |
+| test_03-04_has_maps | `ue_session_map`, `stats_map` exist |
+| test_01_attach_to_tc | Attaches to TC ingress |
+| test_02_mark_restoration | Active session gets correct metadata_mark from compute_ue_mark |
+| test_03_mark_session_miss | Unknown UE triggers STATS_VETH0_SESSION_MISS, packet passes |
+| test_04_mark_inactive_session | Inactive session: no mark restored, metadata_mark stays 0 |
+| test_05_mark_non_ipv4_passthrough | ARP passes through, no mark/miss counters |
+| test_06_mark_multiple_ues | Different UEs get distinct correct marks |
+| test_07_mark_computation_correctness | Boundary IPs match Python compute_ue_mark() exactly |
+| test_08_skb_mark_verified | Chained verifier probe confirms actual skb->mark value |
 
 ## Known Findings
 
@@ -102,3 +120,4 @@ See `.tmp/ebpf_review/FINDINGS.md` for details.
 - **Finding 3**: `STATS_PKT_DROPPED` incremented for non-IPv4 `TC_ACT_OK` traffic (misleading counter)
 - **Finding 4**: Encap double-encap detection broken with IPv4 options (hardcoded UDP port offsets)
 - **Finding 5**: Missing `CONFIG_SGI_IP` causes silent 0.0.0.0 outer source IP (no error counter)
+- **Finding 6**: Mark handler uses network byte order for session lookup — never finds sessions on little-endian

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/README.md
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/README.md
@@ -1,0 +1,104 @@
+# eBPF GTP Test Suite
+
+Tests for the production eBPF GTP-U encapsulation/decapsulation programs.
+
+## What Gets Tested
+
+The tests compile, load, and exercise the **actual production code**:
+
+- `ebpf_gtp_decap.c` -- `gtp_decap_handler()` on TC ingress
+- `ebpf_gtp_encap.c` -- `gtp_encap_handler()` on TC egress
+- `EbpfGtpMap.h` -- shared structs and map definitions
+
+Each test creates a veth pair, attaches the production eBPF program, populates
+the session and config maps with the real 160-byte `ue_session_info` struct,
+sends real packets, and validates the output.
+
+## Directory Structure
+
+```text
+tests/
++-- lib/                           # Reusable test utilities
+|   +-- config.py                  # Production struct helpers, golden functions
+|   +-- gtpu.py                    # GTP-U packet building (Scapy)
+|   +-- network.py                 # veth pairs, TC setup
+|   +-- capture.py                 # Packet capture
+|
++-- test_prerequisites.py          # System requirements check
++-- test_gtpu_packets.py           # GTP-U packet unit tests (no root)
++-- test_production_decap.py       # E2E decap tests against ebpf_gtp_decap.c
++-- test_production_encap.py       # E2E encap tests against ebpf_gtp_encap.c
++-- README.md
+```
+
+## Requirements
+
+```bash
+sudo apt-get install python3-bpfcc python3-venv iproute2 ethtool linux-headers-$(uname -r)
+sudo modprobe ip_tunnel vxlan  # Required for bpf_skb_set_tunnel_key (Finding 1)
+```
+
+## Running
+
+```bash
+cd lte/gateway/python/magma/pipelined/ebpf/tests
+python3 -m venv venv --system-site-packages
+source venv/bin/activate
+pip install -r requirements.txt
+sudo venv/bin/python -m pytest . -v -s
+```
+
+## Test Coverage
+
+### test_production_decap.py
+
+| Test | What it validates |
+| ---- | ----------------- |
+| test_01_compiles | `ebpf_gtp_decap.c` compiles with production cflags |
+| test_02_has_decap_handler | `gtp_decap_handler` function loadable |
+| test_03-05_has_maps | `ue_session_map`, `config_map`, `stats_map` exist |
+| test_01_attach_to_tc | Attaches to TC ingress |
+| test_02_decap_golden_model | Full field-by-field validation: MACs, inner IP, payload, session counters, metadata_mark, no GTP leakage |
+| test_03_decap_no_session | Dropped + no leak on output |
+| test_04_decap_teid_mismatch | Dropped + no leak on output |
+| test_05_decap_inactive_session | Dropped + no leak on output |
+| test_06_decap_multiple_packets | N packets in, N decapsulated out, classified by GTP/non-GTP |
+| test_07_decap_non_gtp_passthrough | Non-GTP passes through, not dropped, not decapped |
+| test_08_decap_small_packet | **EXPECTED FAIL** -- Finding 2: packets < 64 bytes dropped |
+| test_09_decap_malformed_gtp | Invalid version/PT/type rejected, no leak |
+| test_10_decap_gtp_with_seq_number | GTP S flag (seq number) decapsulated correctly |
+| test_11_decap_gtp_with_pdu_session_container | E flag + PDU Session Container (0x85) extension |
+| test_12_decap_gtp_with_multiple_extensions | Chained extension headers parsed correctly |
+| test_13_decap_outer_ipv4_options | Outer IPv4 options handled via IHL |
+| test_14_decap_inner_tcp | Inner TCP preserved byte-exact |
+| test_15_decap_inner_icmp | Inner ICMP preserved byte-exact |
+
+### test_production_encap.py
+
+| Test | What it validates |
+| ---- | ----------------- |
+| test_01_compiles | `ebpf_gtp_encap.c` compiles with production cflags |
+| test_02_has_encap_handler | `gtp_encap_handler` function loadable |
+| test_03-05_has_maps | Maps exist |
+| test_01_attach_to_tc | Attaches to TC egress |
+| test_02_encap_golden_model | Full field-by-field: Ether MACs, IP (all fields + checksum), UDP, GTP flags/TEID/length, PDU Session Container QFI, inner packet byte-exact preservation, session counters |
+| test_03_encap_small_packet | **EXPECTED FAIL** -- Finding 2: packets < 64 bytes dropped |
+| test_04_encap_no_session | Dropped + no leak on output |
+| test_05_encap_inactive_session | Dropped + no leak on output |
+| test_06_double_encap_avoided | Already-GTP packets not re-encapsulated |
+| test_07_multiple_ue_sessions | Different UEs get correct TEIDs |
+| test_08_encap_double_encap_with_ipv4_options | **EXPECTED FAIL** -- Finding 4: double-encap detection broken with IPv4 options |
+| test_09_encap_missing_sgi_ip | **EXPECTED FAIL** -- Finding 5: silent 0.0.0.0 source IP |
+| test_10_encap_qfi_values | QFI boundary: default (0→9), normal (1), max (63) |
+| test_11_encap_non_ipv4_passthrough | ARP passes through without encapsulation |
+| test_12_encap_teid_zero | teid_dl_out=0 treated as inactive, packet dropped |
+
+## Known Findings
+
+See `.tmp/ebpf_review/FINDINGS.md` for details.
+
+- **Finding 1**: `bpf_skb_set_tunnel_key()` requires `ip_tunnel`/`vxlan` kernel modules (undocumented)
+- **Finding 2**: Both handlers drop packets < 64 bytes via `bpf_skb_load_bytes(64)` (affects TCP ACKs, ICMP, small DNS)
+- **Finding 3**: `STATS_PKT_DROPPED` incremented for non-IPv4 `TC_ACT_OK` traffic (misleading counter)
+- **Finding 4**: Encap double-encap detection broken with IPv4 options (hardcoded UDP port offsets)
+- **Finding 5**: Missing `CONFIG_SGI_IP` causes silent 0.0.0.0 outer source IP (no error counter)

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/__init__.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/__init__.py
@@ -1,0 +1,1 @@
+# Phase 1 eBPF GTP Tests

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/lib/__init__.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/lib/__init__.py
@@ -1,0 +1,42 @@
+# eBPF GTP Test Library
+#
+# Reusable utilities for testing the production eBPF GTP implementation
+
+from .config import (
+    GTPUTestConfig,
+    PRODUCTION_CFLAGS,
+    DECAP_SOURCE,
+    ENCAP_SOURCE,
+    load_production_source,
+    populate_session,
+    set_config,
+    read_stat,
+    ip_to_host_order,
+    compute_ue_mark,
+    attach_tc,
+    detach_tc,
+    has_map,
+)
+from .gtpu import GTPUConstants, build_gtpu_packet, parse_gtpu_packet
+from .network import veth_pair, setup_tc_qdisc, get_ifindex, get_mac_address
+from .capture import PacketCapture
+
+__all__ = [
+    'GTPUTestConfig',
+    'PRODUCTION_CFLAGS',
+    'DECAP_SOURCE',
+    'ENCAP_SOURCE',
+    'load_production_source',
+    'populate_session',
+    'set_config',
+    'read_stat',
+    'ip_to_host_order',
+    'GTPUConstants',
+    'build_gtpu_packet',
+    'parse_gtpu_packet',
+    'veth_pair',
+    'setup_tc_qdisc',
+    'get_ifindex',
+    'get_mac_address',
+    'PacketCapture',
+]

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/lib/capture.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/lib/capture.py
@@ -1,0 +1,255 @@
+"""
+Packet Capture Module
+
+Utilities for capturing and analyzing packets during tests.
+"""
+
+import time
+import threading
+from typing import List, Optional, Callable
+
+from scapy.all import Packet, sniff, AsyncSniffer, conf
+
+# Disable scapy verbosity
+conf.verb = 0
+
+
+class CaptureError(Exception):
+    """Packet capture error"""
+    pass
+
+
+class PacketCapture:
+    """
+    Async packet capture with filtering.
+
+    Usage:
+        cap = PacketCapture("eth0", filter="udp port 2152")
+        cap.start()
+        # ... send packets ...
+        packets = cap.stop()
+    """
+
+    def __init__(
+        self,
+        iface: str,
+        filter: str = "",
+        timeout: float = 10.0,
+        count: int = 0
+    ):
+        """
+        Initialize packet capture.
+
+        Args:
+            iface: Interface to capture on
+            filter: BPF filter string (e.g., "udp port 2152")
+            timeout: Maximum capture time in seconds
+            count: Stop after capturing this many packets (0 = no limit)
+        """
+        self.iface = iface
+        self.filter = filter
+        self.timeout = timeout
+        self.count = count
+
+        self._sniffer: Optional[AsyncSniffer] = None
+        self._packets: List[Packet] = []
+        self._lock = threading.Lock()
+
+    def _packet_handler(self, pkt: Packet) -> None:
+        """Handle captured packet"""
+        with self._lock:
+            self._packets.append(pkt)
+
+    def start(self) -> None:
+        """Start capturing packets asynchronously"""
+        with self._lock:
+            self._packets = []
+
+        self._sniffer = AsyncSniffer(
+            iface=self.iface,
+            filter=self.filter if self.filter else None,
+            prn=self._packet_handler,
+            store=False,
+            count=self.count if self.count > 0 else 0
+        )
+        self._sniffer.start()
+
+        # Give sniffer time to initialize
+        time.sleep(0.1)
+
+    def stop(self) -> List[Packet]:
+        """
+        Stop capturing and return captured packets.
+
+        Returns:
+            List of captured Scapy Packet objects
+        """
+        if self._sniffer:
+            self._sniffer.stop()
+            time.sleep(0.1)  # Allow final packets to be processed
+            self._sniffer = None
+
+        with self._lock:
+            return list(self._packets)
+
+    def get_packets(self) -> List[Packet]:
+        """
+        Get currently captured packets without stopping.
+
+        Returns:
+            List of captured packets so far
+        """
+        with self._lock:
+            return list(self._packets)
+
+    def wait_for_packet(
+        self,
+        match: Callable[[Packet], bool],
+        timeout: Optional[float] = None
+    ) -> Optional[Packet]:
+        """
+        Wait for a packet matching the given condition.
+
+        Args:
+            match: Function that returns True for matching packet
+            timeout: Timeout in seconds (default: self.timeout)
+
+        Returns:
+            Matching packet or None if timeout
+        """
+        timeout = timeout or self.timeout
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            with self._lock:
+                for pkt in self._packets:
+                    if match(pkt):
+                        return pkt
+            time.sleep(0.05)
+
+        return None
+
+    def clear(self) -> None:
+        """Clear captured packets"""
+        with self._lock:
+            self._packets = []
+
+
+def capture_packets(
+    iface: str,
+    duration: float,
+    filter: str = "",
+    count: int = 0
+) -> List[Packet]:
+    """
+    Capture packets synchronously for a duration.
+
+    Args:
+        iface: Interface to capture on
+        duration: Capture duration in seconds
+        filter: BPF filter string
+        count: Stop after this many packets (0 = no limit)
+
+    Returns:
+        List of captured packets
+    """
+    return sniff(
+        iface=iface,
+        filter=filter if filter else None,
+        timeout=duration,
+        count=count if count > 0 else 0
+    )
+
+
+def find_packet(
+    packets: List[Packet],
+    match: Callable[[Packet], bool]
+) -> Optional[Packet]:
+    """
+    Find first packet matching condition.
+
+    Args:
+        packets: List of packets to search
+        match: Function that returns True for matching packet
+
+    Returns:
+        First matching packet or None
+    """
+    for pkt in packets:
+        if match(pkt):
+            return pkt
+    return None
+
+
+def find_all_packets(
+    packets: List[Packet],
+    match: Callable[[Packet], bool]
+) -> List[Packet]:
+    """
+    Find all packets matching condition.
+
+    Args:
+        packets: List of packets to search
+        match: Function that returns True for matching packets
+
+    Returns:
+        List of matching packets
+    """
+    return [pkt for pkt in packets if match(pkt)]
+
+
+def packet_contains_payload(pkt: Packet, payload: bytes) -> bool:
+    """
+    Check if packet contains the given payload.
+
+    Args:
+        pkt: Scapy packet
+        payload: Payload bytes to search for
+
+    Returns:
+        True if payload found in packet
+    """
+    try:
+        pkt_bytes = bytes(pkt)
+        return payload in pkt_bytes
+    except:
+        return False
+
+
+def packets_summary(packets: List[Packet]) -> str:
+    """
+    Generate summary of captured packets.
+
+    Args:
+        packets: List of packets
+
+    Returns:
+        Summary string
+    """
+    from scapy.all import IP, UDP, TCP
+
+    lines = [f"Captured {len(packets)} packets:"]
+
+    for i, pkt in enumerate(packets):
+        summary = f"  [{i+1}] "
+
+        if IP in pkt:
+            ip = pkt[IP]
+            summary += f"{ip.src} -> {ip.dst}"
+
+            if UDP in pkt:
+                udp = pkt[UDP]
+                summary += f" UDP {udp.sport}->{udp.dport}"
+            elif TCP in pkt:
+                tcp = pkt[TCP]
+                summary += f" TCP {tcp.sport}->{tcp.dport}"
+            else:
+                summary += f" proto={ip.proto}"
+
+            summary += f" len={len(pkt)}"
+        else:
+            summary += f"Non-IP packet, len={len(pkt)}"
+
+        lines.append(summary)
+
+    return "\n".join(lines)

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/lib/config.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/lib/config.py
@@ -1,0 +1,309 @@
+"""
+Test Configuration Module
+
+Centralized configuration for eBPF GTP tests.
+Matches production struct layouts from ebpf_gtp_decap.c / ebpf_gtp_encap.c.
+"""
+
+import os
+import socket
+import struct
+import subprocess
+from dataclasses import dataclass
+
+
+# Path to production eBPF source files
+# __file__ = tests/lib/config.py -> dirname x3 = ebpf/
+EBPF_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DECAP_SOURCE = os.path.join(EBPF_DIR, 'ebpf_gtp_decap.c')
+ENCAP_SOURCE = os.path.join(EBPF_DIR, 'ebpf_gtp_encap.c')
+
+# Compilation flags matching production (ebpf_gtp_manager.py line 1239)
+PRODUCTION_CFLAGS = ['-I', EBPF_DIR, '-DDISABLE_DEBUG', '-O2']
+
+# Stats counter indices (from ebpf_gtp_decap.c / ebpf_gtp_encap.c)
+STATS_UL_PACKETS = 0
+STATS_UL_BYTES = 1
+STATS_DL_PACKETS = 2
+STATS_DL_BYTES = 3
+STATS_UL_ERRORS = 4
+STATS_DL_ERRORS = 5
+STATS_SESSION_MISS = 6
+STATS_TEID_MISMATCH = 7
+STATS_GTP_DECAP_SUCCESS = 8
+STATS_GTP_ENCAP_SUCCESS = 9
+STATS_PKT_TOO_SHORT = 10
+STATS_INVALID_GTP = 11
+STATS_ADJUST_HEAD_FAIL = 12
+STATS_TOTAL_PROCESSED = 13
+STATS_UE_ATTACH = 14
+STATS_UE_DETACH = 15
+STATS_PKT_FORWARDED = 16
+STATS_PKT_DROPPED = 17
+STATS_SESSION_ACTIVE = 18
+STATS_QOS_APPLIED = 19
+STATS_INACTIVE_SESSION = 20
+STATS_DOUBLE_ENCAP_AVOIDED = 21
+
+# Config map keys (from production code)
+CONFIG_S1U_IFINDEX = 0
+CONFIG_SGI_IFINDEX = 1
+CONFIG_OVS_IFINDEX = 2
+CONFIG_DEBUG_LEVEL = 3
+CONFIG_SGI_IP = 4
+CONFIG_EBPF_VETH_IFINDEX = 5
+
+
+def ip_to_host_order(ip_str: str) -> int:
+    """Convert IP string to host-order integer (as used in production BPF maps)"""
+    return struct.unpack("!I", socket.inet_aton(ip_str))[0]
+
+
+def mac_str_to_bytes(mac_str: str) -> bytes:
+    """Convert MAC string (aa:bb:cc:dd:ee:ff) to bytes"""
+    return bytes(int(b, 16) for b in mac_str.split(':'))
+
+
+@dataclass
+class GTPUTestConfig:
+    """Configuration for GTP-U eBPF tests"""
+
+    # Network interfaces (veth pair)
+    tx_iface: str = "ebpf_test_tx"   # Simulates gtp_veth1 (S1-U side)
+    rx_iface: str = "ebpf_test_rx"   # Simulates gtp_veth0 (OVS side)
+
+    # IP addresses
+    enb_ip: str = "10.0.2.1"         # eNodeB IP (GTP tunnel endpoint)
+    sgw_ip: str = "10.0.2.2"         # SGW IP (our side, GTP source for encap)
+    ue_ip: str = "192.168.128.100"   # UE IP address
+    external_ip: str = "8.8.8.8"     # External destination (internet)
+
+    # GTP tunnel identifiers
+    teid_ul: int = 0x12345678        # Uplink TEID (eNB -> SGW)
+    teid_dl: int = 0x87654321        # Downlink TEID (SGW -> eNB)
+
+    # Test parameters
+    payload_size: int = 64
+    capture_timeout: float = 2.0
+    num_test_packets: int = 5
+
+    def __post_init__(self):
+        if self.tx_iface == self.rx_iface:
+            raise ValueError("TX and RX interfaces must be different")
+        if self.teid_ul == 0 or self.teid_dl == 0:
+            raise ValueError("TEIDs cannot be zero (reserved)")
+
+
+def compute_ue_mark(ue_ip_int: int) -> int:
+    """
+    Python port of compute_ue_mark() from ebpf_gtp_decap.c.
+
+    Used to validate the metadata_mark the eBPF program writes to the session.
+    """
+    safe_mark = ue_ip_int & 0x7FFFFFFE
+    if safe_mark == 0x7FFFFFFF or safe_mark == 0:
+        safe_mark = (ue_ip_int >> 8) | 0x12345600
+    if safe_mark < 0x10000000:
+        safe_mark |= 0x12000000
+    return safe_mark
+
+
+def load_production_source(path: str) -> str:
+    """Read production eBPF source file"""
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def populate_session(bpf, ue_ip_str, enb_ip_str, teid_ul_in, teid_dl_out,
+                     s1u_ifindex=0, sgi_ifindex=0, ovs_ifindex=0,
+                     mac_src=None, mac_dst=None, bearer_id=5, qfi=9,
+                     active=True):
+    """
+    Add a UE session to the production ue_session_map.
+
+    Uses BCC auto-generated ctypes to match the exact struct layout.
+    All IPs stored in host byte order (matching production code).
+    """
+    session_map = bpf.get_table("ue_session_map")
+
+    key = session_map.Key()
+    key.ue_ip = ip_to_host_order(ue_ip_str)
+
+    val = session_map.Leaf()
+    val.enb_ip = ip_to_host_order(enb_ip_str)
+    val.teid_ul_in = teid_ul_in
+    val.teid_ul_out = teid_ul_in  # Same for testing
+    val.teid_dl_in = teid_dl_out
+    val.teid_dl_out = teid_dl_out
+    val.s1u_ifindex = s1u_ifindex
+    val.sgi_ifindex = sgi_ifindex
+    val.ovs_ifindex = ovs_ifindex
+    val.bearer_id = bearer_id
+    val.session_flags = 1 if active else 0
+    val.qfi = qfi
+
+    if mac_src:
+        mac_bytes = mac_str_to_bytes(mac_src)
+        for i in range(6):
+            val.ul_mac_src[i] = mac_bytes[i]
+
+    if mac_dst:
+        mac_bytes = mac_str_to_bytes(mac_dst)
+        for i in range(6):
+            val.ul_mac_dst[i] = mac_bytes[i]
+
+    session_map[key] = val
+    return key, val
+
+
+def set_config(bpf, key_id, value):
+    """Set a value in the production config_map"""
+    config_map = bpf.get_table("config_map")
+    k = config_map.Key()
+    k.key = key_id
+    v = config_map.Leaf()
+    v.value = value
+    config_map[k] = v
+
+
+def read_stat(bpf, counter_id):
+    """Read a counter from stats_map"""
+    stats = bpf.get_table("stats_map")
+    import ctypes
+    key = ctypes.c_uint32(counter_id)
+    try:
+        val = stats[key]
+        return val.value if hasattr(val, 'value') else int(val)
+    except KeyError:
+        return 0
+
+
+def attach_tc(bpf, iface, func_name, direction):
+    """
+    Attach eBPF function to TC hook via pyroute2 netlink.
+
+    Matches production code (ebpf_gtp_manager.py _attach_tc_program).
+    The tc CLI can't pass raw fds — only netlink can.
+    """
+    from bcc import BPF as _BPF
+    from pyroute2 import IPRoute
+
+    fn = bpf.load_func(func_name, _BPF.SCHED_CLS)
+    ipr = IPRoute()
+    try:
+        ifindex = ipr.link_lookup(ifname=iface)[0]
+        parent = "ffff:fff2" if direction == "ingress" else "ffff:fff3"
+        ipr.tc("add-filter", "bpf", ifindex, ":1",
+               fd=fn.fd, name=fn.name, parent=parent,
+               classid=1, direct_action=True)
+    finally:
+        ipr.close()
+
+
+def detach_tc(iface, direction):
+    """Remove all TC filters from an interface direction."""
+    subprocess.run(
+        ['tc', 'filter', 'del', 'dev', iface, direction],
+        capture_output=True, check=False,
+    )
+
+
+def has_map(bpf, map_name):
+    """Check if a BPF map exists (compatible with all BCC versions)."""
+    try:
+        bpf.get_table(map_name)
+        return True
+    except Exception:
+        return False
+
+
+def golden_decap(gtp_packet_bytes, session_mac_src, session_mac_dst):
+    """Build expected decap output using Scapy as independent oracle.
+
+    The eBPF decap handler should produce:
+      Ether(session MACs, type=0x0800) / inner_ip_packet
+
+    Args:
+        gtp_packet_bytes: Raw bytes of the input GTP-U packet (with Ether)
+        session_mac_src: MAC address the handler writes as Ether src
+        session_mac_dst: MAC address the handler writes as Ether dst
+
+    Returns:
+        Expected output packet as raw bytes
+    """
+    from scapy.all import Ether, IP, Raw
+    from scapy.contrib.gtp import GTP_U_Header
+
+    pkt = Ether(gtp_packet_bytes)
+    # Extract inner IP: everything after GTP_U_Header
+    gtp = pkt[GTP_U_Header]
+    inner_ip_bytes = bytes(gtp.payload)
+
+    # Build expected output
+    expected = (
+        Ether(src=session_mac_src, dst=session_mac_dst, type=0x0800) /
+        Raw(load=inner_ip_bytes)
+    )
+    return bytes(expected)
+
+
+def golden_encap(ip_packet_bytes, session_mac_src, session_mac_dst,
+                 sgw_ip, enb_ip, teid_dl, qfi=9):
+    """Build expected encap output using Scapy as independent oracle.
+
+    The eBPF encap handler should produce:
+      Ether(session MACs) / IP(sgw->enb) / UDP(2152) /
+      GTP_U_Header(teid, E=1) / optional(seq,npdu,next_ext=0x85) /
+      PDU_Session_Container(qfi) / original_inner_ip
+
+    Args:
+        ip_packet_bytes: Raw bytes of inner IP packet (WITHOUT Ether header)
+        session_mac_src: MAC from session ul_mac_src
+        session_mac_dst: MAC from session ul_mac_dst
+        sgw_ip: SGW IP (outer source)
+        enb_ip: eNB IP (outer destination)
+        teid_dl: Downlink TEID
+        qfi: QoS Flow Identifier
+
+    Returns:
+        Expected output packet as raw bytes
+    """
+    from scapy.all import Ether, IP, UDP, Raw
+
+    inner_len = len(ip_packet_bytes)
+
+    # GTP extension: 4 bytes optional fields + 4 bytes PDU Session Container
+    gtp_ext = bytes([
+        0x00, 0x00,  # Seq number
+        0x00,        # N-PDU
+        0x85,        # Next ext: PDU Session Container
+        0x01,        # Ext length (1 = 4 bytes)
+        0x10,        # PDU Type: DL PDU SESSION INFO
+        qfi & 0x3F,  # QFI
+        0x00,        # Next ext: none
+    ])
+
+    gtp_payload_len = len(gtp_ext) + inner_len  # 8 + inner
+
+    # GTP header: flags=0x34 (V1, PT, E), type=0xFF
+    gtp_hdr = struct.pack('!BBHI',
+                          0x34,           # flags
+                          0xFF,           # type (T-PDU)
+                          gtp_payload_len,
+                          teid_dl)
+
+    udp_payload = gtp_hdr + gtp_ext + ip_packet_bytes
+    udp_len = 8 + len(udp_payload)
+    total_ip_len = 20 + udp_len
+
+    expected = (
+        Ether(src=session_mac_src, dst=session_mac_dst, type=0x0800) /
+        IP(src=sgw_ip, dst=enb_ip, ttl=64, id=0, flags='DF',
+           proto=17, len=total_ip_len) /
+        UDP(sport=2152, dport=2152, len=udp_len, chksum=0) /
+        Raw(load=gtp_hdr + gtp_ext + ip_packet_bytes)
+    )
+
+    # Let Scapy calculate the IP checksum
+    expected_bytes = bytes(expected)
+    return expected_bytes

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/lib/config.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/lib/config.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 EBPF_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 DECAP_SOURCE = os.path.join(EBPF_DIR, 'ebpf_gtp_decap.c')
 ENCAP_SOURCE = os.path.join(EBPF_DIR, 'ebpf_gtp_encap.c')
+MARK_SOURCE = os.path.join(EBPF_DIR, 'ebpf_gtp_veth0_mark.c')
 
 # Compilation flags matching production (ebpf_gtp_manager.py line 1239)
 PRODUCTION_CFLAGS = ['-I', EBPF_DIR, '-DDISABLE_DEBUG', '-O2']
@@ -44,6 +45,12 @@ STATS_SESSION_ACTIVE = 18
 STATS_QOS_APPLIED = 19
 STATS_INACTIVE_SESSION = 20
 STATS_DOUBLE_ENCAP_AVOIDED = 21
+
+# Mark handler stats (from ebpf_gtp_veth0_mark.c)
+STATS_VETH0_PACKETS_PROCESSED = 50
+STATS_VETH0_MARK_RESTORED = 51
+STATS_VETH0_MARK_FALLBACK = 52
+STATS_VETH0_SESSION_MISS = 53
 
 # Config map keys (from production code)
 CONFIG_S1U_IFINDEX = 0

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/lib/gtpu.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/lib/gtpu.py
@@ -1,0 +1,396 @@
+"""
+GTP-U Protocol Module
+
+Spec-compliant GTP-U packet building and parsing using Scapy.
+Based on 3GPP TS 29.281 v16.2.0
+
+Reference: .tmp/ebpf_review/reference/3gpp_ts_29.281_v16.2.0.md
+"""
+
+import struct
+import socket
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+# Scapy imports
+from scapy.all import Ether, IP, UDP, Raw, Packet
+from scapy.contrib.gtp import GTP_U_Header
+
+
+class GTPUConstants:
+    """
+    GTP-U constants per 3GPP TS 29.281
+
+    Section 5.1: Header format
+    Section 6.1: Message types (Table 6.1-1)
+    Section 4.4.2.1: UDP port
+    """
+    # UDP Port (Section 4.4.2.1)
+    PORT = 2152
+
+    # Version (Section 5.1) - must be 1 for GTPv1-U
+    VERSION = 1
+
+    # Protocol Type (Section 5.1) - 1 = GTP, 0 = GTP'
+    PT_GTP = 1
+    PT_GTP_PRIME = 0
+
+    # Message Types (Table 6.1-1)
+    MSG_ECHO_REQUEST = 1
+    MSG_ECHO_RESPONSE = 2
+    MSG_ERROR_INDICATION = 26
+    MSG_SUPPORTED_EXT_HDR = 31
+    MSG_END_MARKER = 254
+    MSG_GPDU = 255  # G-PDU: User data
+
+    # Header lengths
+    HEADER_MIN_LEN = 8   # Minimum header (no optional fields)
+    HEADER_OPT_LEN = 12  # With optional fields (seq, npdu, ext)
+
+
+@dataclass
+class GTPUHeaderInfo:
+    """Parsed GTP-U header information"""
+    version: int
+    pt: int              # Protocol Type
+    e_flag: bool         # Extension header flag
+    s_flag: bool         # Sequence number flag
+    pn_flag: bool        # N-PDU number flag
+    msg_type: int
+    length: int          # Payload length (excludes first 8 bytes)
+    teid: int
+    seq_num: Optional[int] = None
+    npdu_num: Optional[int] = None
+    next_ext: Optional[int] = None
+    header_len: int = 8  # Actual header length
+
+
+@dataclass
+class GTPUPacketInfo:
+    """Parsed GTP-U packet information"""
+    header: GTPUHeaderInfo
+    outer_src_ip: str
+    outer_dst_ip: str
+    inner_payload: bytes
+    inner_src_ip: Optional[str] = None
+    inner_dst_ip: Optional[str] = None
+
+
+def build_gtpu_header(
+    teid: int,
+    payload_len: int,
+    msg_type: int = GTPUConstants.MSG_GPDU,
+    seq_num: Optional[int] = None,
+    npdu_num: Optional[int] = None,
+    next_ext: Optional[int] = None,
+) -> bytes:
+    """
+    Build GTP-U header per 3GPP TS 29.281 Section 5.1
+
+    Octet 1: |Version(3)|PT(1)|*(1)|E(1)|S(1)|PN(1)|
+    Octet 2: Message Type
+    Octet 3-4: Length
+    Octet 5-8: TEID
+    [Octet 9-12: Seq Num, N-PDU, Next Ext - if any flag set]
+
+    Args:
+        teid: Tunnel Endpoint Identifier
+        payload_len: Length of payload after GTP header
+        msg_type: Message type (default: G-PDU = 255)
+        seq_num: Optional sequence number (sets S flag)
+        npdu_num: Optional N-PDU number (sets PN flag)
+        next_ext: Optional next extension header type (sets E flag)
+
+    Returns:
+        GTP-U header bytes
+    """
+    # Determine flags
+    e_flag = 1 if next_ext is not None else 0
+    s_flag = 1 if seq_num is not None else 0
+    pn_flag = 1 if npdu_num is not None else 0
+
+    # Build flags byte: Version(3) | PT(1) | *(1) | E(1) | S(1) | PN(1)
+    flags = (GTPUConstants.VERSION << 5) | \
+            (GTPUConstants.PT_GTP << 4) | \
+            (0 << 3) | \
+            (e_flag << 2) | \
+            (s_flag << 1) | \
+            pn_flag
+
+    # If any optional flag is set, include optional fields
+    if e_flag or s_flag or pn_flag:
+        length = payload_len + 4  # Optional fields are part of "payload" length
+        header = struct.pack('!BBHI',
+            flags,
+            msg_type,
+            length,
+            teid
+        )
+        # Add optional fields
+        seq = seq_num if seq_num is not None else 0
+        npdu = npdu_num if npdu_num is not None else 0
+        ext = next_ext if next_ext is not None else 0
+        header += struct.pack('!HBB', seq, npdu, ext)
+    else:
+        # Minimum 8-byte header
+        header = struct.pack('!BBHI',
+            flags,
+            msg_type,
+            payload_len,
+            teid
+        )
+
+    return header
+
+
+def parse_gtpu_header(data: bytes) -> Optional[GTPUHeaderInfo]:
+    """
+    Parse GTP-U header per 3GPP TS 29.281 Section 5.1
+
+    Args:
+        data: Raw bytes starting at GTP-U header
+
+    Returns:
+        GTPUHeaderInfo or None if invalid
+    """
+    if len(data) < GTPUConstants.HEADER_MIN_LEN:
+        return None
+
+    flags, msg_type, length, teid = struct.unpack('!BBHI', data[:8])
+
+    version = (flags >> 5) & 0x07
+    pt = (flags >> 4) & 0x01
+    e_flag = bool((flags >> 2) & 0x01)
+    s_flag = bool((flags >> 1) & 0x01)
+    pn_flag = bool(flags & 0x01)
+
+    result = GTPUHeaderInfo(
+        version=version,
+        pt=pt,
+        e_flag=e_flag,
+        s_flag=s_flag,
+        pn_flag=pn_flag,
+        msg_type=msg_type,
+        length=length,
+        teid=teid,
+        header_len=8
+    )
+
+    # Parse optional fields if any flag is set
+    if e_flag or s_flag or pn_flag:
+        if len(data) < GTPUConstants.HEADER_OPT_LEN:
+            return None
+        seq_num, npdu_num, next_ext = struct.unpack('!HBB', data[8:12])
+        result.seq_num = seq_num if s_flag else None
+        result.npdu_num = npdu_num if pn_flag else None
+        result.next_ext = next_ext if e_flag else None
+        result.header_len = 12
+
+    return result
+
+
+def build_gtpu_packet(
+    outer_src_ip: str,
+    outer_dst_ip: str,
+    inner_src_ip: str,
+    inner_dst_ip: str,
+    teid: int,
+    payload: bytes,
+    inner_sport: int = 12345,
+    inner_dport: int = 80,
+    src_mac: str = "02:00:00:00:00:01",
+    dst_mac: str = "02:00:00:00:00:02",
+) -> Tuple[bytes, bytes]:
+    """
+    Build complete GTP-U encapsulated packet using Scapy.
+
+    Packet structure:
+        Ethernet | Outer IP | UDP(2152) | GTP-U | Inner IP | Inner UDP | Payload
+
+    Args:
+        outer_src_ip: Outer IP source (e.g., eNB IP)
+        outer_dst_ip: Outer IP destination (e.g., SGW IP)
+        inner_src_ip: Inner IP source (e.g., UE IP)
+        inner_dst_ip: Inner IP destination (e.g., external IP)
+        teid: GTP Tunnel Endpoint Identifier
+        payload: User payload data
+        inner_sport: Inner UDP source port
+        inner_dport: Inner UDP destination port
+        src_mac: Source MAC address
+        dst_mac: Destination MAC address
+
+    Returns:
+        Tuple of (complete_packet_bytes, original_payload)
+    """
+    # Build inner packet (what the UE "sent")
+    inner_pkt = IP(src=inner_src_ip, dst=inner_dst_ip) / \
+                UDP(sport=inner_sport, dport=inner_dport) / \
+                Raw(load=payload)
+
+    # Build outer packet with GTP-U header
+    # Using Scapy's GTP_U_Header
+    outer_pkt = Ether(src=src_mac, dst=dst_mac) / \
+                IP(src=outer_src_ip, dst=outer_dst_ip) / \
+                UDP(sport=GTPUConstants.PORT, dport=GTPUConstants.PORT) / \
+                GTP_U_Header(teid=teid, gtp_type=GTPUConstants.MSG_GPDU) / \
+                inner_pkt
+
+    return bytes(outer_pkt), payload
+
+
+def build_gtpu_packet_raw(
+    outer_src_ip: str,
+    outer_dst_ip: str,
+    inner_src_ip: str,
+    inner_dst_ip: str,
+    teid: int,
+    payload: bytes,
+    inner_sport: int = 12345,
+    inner_dport: int = 80,
+    src_mac: str = "02:00:00:00:00:01",
+    dst_mac: str = "02:00:00:00:00:02",
+) -> Tuple[bytes, bytes]:
+    """
+    Build GTP-U packet using raw header construction.
+
+    Use this when you need precise control over the GTP header
+    or when testing header parsing.
+
+    Returns:
+        Tuple of (complete_packet_bytes, original_payload)
+    """
+    # Build inner packet
+    inner_pkt = IP(src=inner_src_ip, dst=inner_dst_ip) / \
+                UDP(sport=inner_sport, dport=inner_dport) / \
+                Raw(load=payload)
+    inner_bytes = bytes(inner_pkt)
+
+    # Build GTP-U header manually
+    gtpu_hdr = build_gtpu_header(teid, len(inner_bytes))
+
+    # Build outer packet
+    outer_pkt = Ether(src=src_mac, dst=dst_mac) / \
+                IP(src=outer_src_ip, dst=outer_dst_ip) / \
+                UDP(sport=GTPUConstants.PORT, dport=GTPUConstants.PORT) / \
+                Raw(load=gtpu_hdr + inner_bytes)
+
+    return bytes(outer_pkt), payload
+
+
+def parse_gtpu_packet(pkt: Packet) -> Optional[GTPUPacketInfo]:
+    """
+    Parse a GTP-U packet (Scapy Packet object).
+
+    Args:
+        pkt: Scapy packet object
+
+    Returns:
+        GTPUPacketInfo or None if not a valid GTP-U packet
+    """
+    if IP not in pkt:
+        return None
+
+    outer_ip = pkt[IP]
+
+    if UDP not in pkt:
+        return None
+
+    udp = pkt[UDP]
+    if udp.dport != GTPUConstants.PORT and udp.sport != GTPUConstants.PORT:
+        return None
+
+    # Try to parse GTP-U header
+    if GTP_U_Header in pkt:
+        gtp = pkt[GTP_U_Header]
+        header = GTPUHeaderInfo(
+            version=gtp.version,
+            pt=gtp.PT,
+            e_flag=bool(gtp.E),
+            s_flag=bool(gtp.S),
+            pn_flag=bool(gtp.PN),
+            msg_type=gtp.gtp_type,
+            length=gtp.length,
+            teid=gtp.teid,
+            header_len=8 if not (gtp.E or gtp.S or gtp.PN) else 12
+        )
+
+        # Extract inner payload
+        inner_payload = bytes(gtp.payload) if gtp.payload else b''
+
+        # Try to parse inner IP
+        inner_src = None
+        inner_dst = None
+        if len(inner_payload) >= 20:
+            # Check if it looks like an IP packet
+            version = (inner_payload[0] >> 4) & 0x0F
+            if version == 4:
+                inner_src = socket.inet_ntoa(inner_payload[12:16])
+                inner_dst = socket.inet_ntoa(inner_payload[16:20])
+
+        return GTPUPacketInfo(
+            header=header,
+            outer_src_ip=outer_ip.src,
+            outer_dst_ip=outer_ip.dst,
+            inner_payload=inner_payload,
+            inner_src_ip=inner_src,
+            inner_dst_ip=inner_dst
+        )
+
+    # Fallback: parse from raw UDP payload
+    if Raw in pkt:
+        raw_data = bytes(pkt[Raw])
+        header = parse_gtpu_header(raw_data)
+        if header is None:
+            return None
+
+        inner_payload = raw_data[header.header_len:]
+
+        inner_src = None
+        inner_dst = None
+        if len(inner_payload) >= 20:
+            version = (inner_payload[0] >> 4) & 0x0F
+            if version == 4:
+                inner_src = socket.inet_ntoa(inner_payload[12:16])
+                inner_dst = socket.inet_ntoa(inner_payload[16:20])
+
+        return GTPUPacketInfo(
+            header=header,
+            outer_src_ip=outer_ip.src,
+            outer_dst_ip=outer_ip.dst,
+            inner_payload=inner_payload,
+            inner_src_ip=inner_src,
+            inner_dst_ip=inner_dst
+        )
+
+    return None
+
+
+def extract_inner_payload(pkt: Packet) -> Optional[bytes]:
+    """
+    Extract the innermost payload from a packet.
+
+    Works for both GTP-U encapsulated and plain packets.
+
+    Args:
+        pkt: Scapy packet
+
+    Returns:
+        Inner payload bytes or None
+    """
+    # Check for GTP-U first
+    gtpu_info = parse_gtpu_packet(pkt)
+    if gtpu_info:
+        # Find the actual user payload inside inner packet
+        inner = gtpu_info.inner_payload
+        if len(inner) > 28:  # IP(20) + UDP(8) minimum
+            # Skip inner IP and UDP headers to get raw payload
+            ip_hlen = (inner[0] & 0x0F) * 4
+            udp_offset = ip_hlen + 8
+            return inner[udp_offset:]
+        return inner
+
+    # Not GTP-U, try to find Raw payload
+    if Raw in pkt:
+        return bytes(pkt[Raw])
+
+    return None

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/lib/network.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/lib/network.py
@@ -1,0 +1,313 @@
+"""
+Network Device Management Module
+
+Utilities for creating and managing network interfaces for testing.
+"""
+
+import os
+import subprocess
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Optional, List, Generator
+
+
+@dataclass
+class VethPairInfo:
+    """Information about a veth pair"""
+    name_a: str
+    name_b: str
+    ifindex_a: int
+    ifindex_b: int
+
+
+class NetworkError(Exception):
+    """Network operation error"""
+    pass
+
+
+def run_cmd(
+    cmd: List[str],
+    check: bool = True,
+    capture: bool = True
+) -> subprocess.CompletedProcess:
+    """
+    Run a shell command.
+
+    Args:
+        cmd: Command and arguments as list
+        check: Raise exception on non-zero exit
+        capture: Capture stdout/stderr
+
+    Returns:
+        CompletedProcess result
+    """
+    return subprocess.run(
+        cmd,
+        capture_output=capture,
+        text=True,
+        check=check
+    )
+
+
+def check_root() -> bool:
+    """Check if running as root"""
+    return os.geteuid() == 0
+
+
+def require_root():
+    """Raise exception if not running as root"""
+    if not check_root():
+        raise NetworkError("Root privileges required for network operations")
+
+
+def interface_exists(iface: str) -> bool:
+    """Check if network interface exists"""
+    return os.path.exists(f'/sys/class/net/{iface}')
+
+
+def get_ifindex(iface: str) -> int:
+    """
+    Get interface index.
+
+    Args:
+        iface: Interface name
+
+    Returns:
+        Interface index
+
+    Raises:
+        NetworkError: If interface doesn't exist
+    """
+    path = f'/sys/class/net/{iface}/ifindex'
+    if not os.path.exists(path):
+        raise NetworkError(f"Interface {iface} does not exist")
+
+    with open(path, 'r') as f:
+        return int(f.read().strip())
+
+
+def get_mac_address(iface: str) -> str:
+    """
+    Get interface MAC address.
+
+    Args:
+        iface: Interface name
+
+    Returns:
+        MAC address as string (xx:xx:xx:xx:xx:xx)
+    """
+    path = f'/sys/class/net/{iface}/address'
+    if not os.path.exists(path):
+        raise NetworkError(f"Interface {iface} does not exist")
+
+    with open(path, 'r') as f:
+        return f.read().strip()
+
+
+def create_veth_pair(name_a: str, name_b: str) -> VethPairInfo:
+    """
+    Create a veth pair.
+
+    Args:
+        name_a: First interface name
+        name_b: Second interface name (peer)
+
+    Returns:
+        VethPairInfo with interface details
+
+    Raises:
+        NetworkError: If creation fails
+    """
+    require_root()
+
+    # Delete if exists
+    delete_interface(name_a)
+
+    try:
+        # Create veth pair
+        run_cmd(['ip', 'link', 'add', name_a, 'type', 'veth', 'peer', 'name', name_b])
+
+        # Bring both interfaces up
+        run_cmd(['ip', 'link', 'set', name_a, 'up'])
+        run_cmd(['ip', 'link', 'set', name_b, 'up'])
+
+        # Disable checksum offloading (important for raw packet testing)
+        run_cmd(['ethtool', '-K', name_a, 'tx', 'off', 'rx', 'off'], check=False)
+        run_cmd(['ethtool', '-K', name_b, 'tx', 'off', 'rx', 'off'], check=False)
+
+        return VethPairInfo(
+            name_a=name_a,
+            name_b=name_b,
+            ifindex_a=get_ifindex(name_a),
+            ifindex_b=get_ifindex(name_b)
+        )
+
+    except subprocess.CalledProcessError as e:
+        raise NetworkError(f"Failed to create veth pair: {e.stderr}")
+
+
+def delete_interface(iface: str) -> bool:
+    """
+    Delete a network interface.
+
+    Args:
+        iface: Interface name
+
+    Returns:
+        True if deleted, False if didn't exist
+    """
+    if not interface_exists(iface):
+        return False
+
+    try:
+        run_cmd(['ip', 'link', 'del', iface], check=False)
+        return True
+    except:
+        return False
+
+
+def configure_interface(
+    iface: str,
+    ip_addr: Optional[str] = None,
+    mtu: Optional[int] = None,
+    up: bool = True
+) -> None:
+    """
+    Configure interface parameters.
+
+    Args:
+        iface: Interface name
+        ip_addr: IP address with prefix (e.g., "10.0.0.1/24")
+        mtu: MTU value
+        up: Bring interface up
+    """
+    require_root()
+
+    if not interface_exists(iface):
+        raise NetworkError(f"Interface {iface} does not exist")
+
+    if ip_addr:
+        # Flush existing addresses
+        run_cmd(['ip', 'addr', 'flush', 'dev', iface], check=False)
+        # Add new address
+        run_cmd(['ip', 'addr', 'add', ip_addr, 'dev', iface])
+
+    if mtu:
+        run_cmd(['ip', 'link', 'set', iface, 'mtu', str(mtu)])
+
+    if up:
+        run_cmd(['ip', 'link', 'set', iface, 'up'])
+
+
+def setup_tc_qdisc(iface: str) -> None:
+    """
+    Add clsact qdisc to interface for TC eBPF attachment.
+
+    Args:
+        iface: Interface name
+
+    Raises:
+        NetworkError: If setup fails
+    """
+    require_root()
+
+    if not interface_exists(iface):
+        raise NetworkError(f"Interface {iface} does not exist")
+
+    # Remove existing clsact if present
+    run_cmd(['tc', 'qdisc', 'del', 'dev', iface, 'clsact'], check=False)
+
+    # Add clsact qdisc
+    try:
+        run_cmd(['tc', 'qdisc', 'add', 'dev', iface, 'clsact'])
+    except subprocess.CalledProcessError as e:
+        raise NetworkError(f"Failed to add clsact qdisc to {iface}: {e.stderr}")
+
+
+def remove_tc_qdisc(iface: str) -> None:
+    """
+    Remove clsact qdisc from interface.
+
+    Args:
+        iface: Interface name
+    """
+    if interface_exists(iface):
+        run_cmd(['tc', 'qdisc', 'del', 'dev', iface, 'clsact'], check=False)
+
+
+def get_tc_filters(iface: str, direction: str = 'ingress') -> str:
+    """
+    Get TC filters attached to interface.
+
+    Args:
+        iface: Interface name
+        direction: 'ingress' or 'egress'
+
+    Returns:
+        TC filter listing as string
+    """
+    if not interface_exists(iface):
+        return ""
+
+    result = run_cmd(['tc', 'filter', 'show', 'dev', iface, direction], check=False)
+    return result.stdout
+
+
+@contextmanager
+def veth_pair(name_a: str, name_b: str) -> Generator[VethPairInfo, None, None]:
+    """
+    Context manager for veth pair with automatic cleanup.
+
+    Usage:
+        with veth_pair("test_a", "test_b") as veth:
+            print(f"Created {veth.name_a} (idx={veth.ifindex_a})")
+            # ... do tests ...
+        # Automatically cleaned up
+
+    Args:
+        name_a: First interface name
+        name_b: Second interface name
+
+    Yields:
+        VethPairInfo with interface details
+    """
+    veth_info = None
+    try:
+        veth_info = create_veth_pair(name_a, name_b)
+        # Reload Scapy's interface cache so it sees the new ifindexes.
+        # Without this, repeated create/delete of same-name veths causes
+        # "OSError: No such device" because Scapy caches stale ifindexes.
+        try:
+            from scapy.config import conf
+            conf.ifaces.reload()
+        except Exception:
+            pass
+        yield veth_info
+    finally:
+        if veth_info:
+            # Clean up TC first
+            remove_tc_qdisc(name_a)
+            remove_tc_qdisc(name_b)
+            # Then delete interfaces
+            delete_interface(name_a)
+
+
+@contextmanager
+def tc_qdisc(iface: str) -> Generator[None, None, None]:
+    """
+    Context manager for TC qdisc with automatic cleanup.
+
+    Usage:
+        with tc_qdisc("eth0"):
+            # qdisc is set up
+            pass
+        # Automatically cleaned up
+
+    Args:
+        iface: Interface name
+    """
+    try:
+        setup_tc_qdisc(iface)
+        yield
+    finally:
+        remove_tc_qdisc(iface)

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/requirements.txt
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/requirements.txt
@@ -1,0 +1,4 @@
+scapy>=2.4.5
+pytest>=6.0
+bcc
+pyroute2

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/test_gtpu_packets.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/test_gtpu_packets.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+GTP-U Packet Building and Parsing Tests
+
+Tests the lib/gtpu.py module for spec compliance with 3GPP TS 29.281.
+
+These tests do NOT require root - they only test packet construction.
+
+Run: python3 -m pytest test_gtpu_packets.py -v
+"""
+
+import struct
+import unittest
+import hashlib
+import random
+import string
+
+# Import may fail if scapy not installed - tests will be skipped
+try:
+    from scapy.all import Ether, IP, UDP, Raw
+    from scapy.contrib.gtp import GTP_U_Header
+    SCAPY_AVAILABLE = True
+except ImportError:
+    SCAPY_AVAILABLE = False
+
+# Import our library
+try:
+    from lib.gtpu import (
+        GTPUConstants,
+        build_gtpu_header,
+        parse_gtpu_header,
+        build_gtpu_packet,
+        build_gtpu_packet_raw,
+        parse_gtpu_packet,
+        extract_inner_payload,
+    )
+    LIB_AVAILABLE = True
+except ImportError:
+    LIB_AVAILABLE = False
+
+
+def generate_random_payload(size: int = 64) -> bytes:
+    """Generate random payload for testing"""
+    data = ''.join(random.choices(string.ascii_letters + string.digits, k=size))
+    return data.encode('utf-8')
+
+
+@unittest.skipUnless(LIB_AVAILABLE, "lib.gtpu not available")
+class TestGTPUConstants(unittest.TestCase):
+    """Test GTP-U constants match the spec"""
+
+    def test_port_number(self):
+        """TS 29.281 Section 4.4.2.1: UDP port 2152"""
+        self.assertEqual(GTPUConstants.PORT, 2152)
+
+    def test_version(self):
+        """TS 29.281 Section 5.1: Version must be 1"""
+        self.assertEqual(GTPUConstants.VERSION, 1)
+
+    def test_message_types(self):
+        """TS 29.281 Table 6.1-1: Message type values"""
+        self.assertEqual(GTPUConstants.MSG_ECHO_REQUEST, 1)
+        self.assertEqual(GTPUConstants.MSG_ECHO_RESPONSE, 2)
+        self.assertEqual(GTPUConstants.MSG_ERROR_INDICATION, 26)
+        self.assertEqual(GTPUConstants.MSG_END_MARKER, 254)
+        self.assertEqual(GTPUConstants.MSG_GPDU, 255)
+
+    def test_header_lengths(self):
+        """TS 29.281 Section 5.1: Minimum header is 8 bytes"""
+        self.assertEqual(GTPUConstants.HEADER_MIN_LEN, 8)
+        self.assertEqual(GTPUConstants.HEADER_OPT_LEN, 12)
+
+
+@unittest.skipUnless(LIB_AVAILABLE, "lib.gtpu not available")
+class TestGTPUHeaderBuilding(unittest.TestCase):
+    """Test GTP-U header construction"""
+
+    def test_minimal_header(self):
+        """Build minimal 8-byte header"""
+        teid = 0x12345678
+        payload_len = 100
+
+        header = build_gtpu_header(teid, payload_len)
+
+        self.assertEqual(len(header), 8)
+
+        # Parse and verify
+        flags, msg_type, length, parsed_teid = struct.unpack('!BBHI', header)
+
+        # Check version = 1 (bits 5-7)
+        version = (flags >> 5) & 0x07
+        self.assertEqual(version, 1)
+
+        # Check PT = 1 (bit 4)
+        pt = (flags >> 4) & 0x01
+        self.assertEqual(pt, 1)
+
+        # Check E/S/PN flags are 0
+        self.assertEqual(flags & 0x07, 0)
+
+        # Check message type (G-PDU)
+        self.assertEqual(msg_type, 255)
+
+        # Check length
+        self.assertEqual(length, payload_len)
+
+        # Check TEID
+        self.assertEqual(parsed_teid, teid)
+
+    def test_header_with_sequence_number(self):
+        """Build header with sequence number (S flag)"""
+        teid = 0xDEADBEEF
+        payload_len = 50
+        seq_num = 12345
+
+        header = build_gtpu_header(teid, payload_len, seq_num=seq_num)
+
+        # Should be 12 bytes with optional fields
+        self.assertEqual(len(header), 12)
+
+        flags = header[0]
+
+        # S flag should be set
+        s_flag = (flags >> 1) & 0x01
+        self.assertEqual(s_flag, 1)
+
+        # Parse sequence number
+        seq_parsed = struct.unpack('!H', header[8:10])[0]
+        self.assertEqual(seq_parsed, seq_num)
+
+    def test_header_with_extension(self):
+        """Build header with extension header flag"""
+        teid = 0x11223344
+        payload_len = 64
+        next_ext = 0x85  # PDU Session Container
+
+        header = build_gtpu_header(teid, payload_len, next_ext=next_ext)
+
+        self.assertEqual(len(header), 12)
+
+        flags = header[0]
+
+        # E flag should be set
+        e_flag = (flags >> 2) & 0x01
+        self.assertEqual(e_flag, 1)
+
+        # Parse next extension header type
+        ext_parsed = header[11]
+        self.assertEqual(ext_parsed, next_ext)
+
+
+@unittest.skipUnless(LIB_AVAILABLE, "lib.gtpu not available")
+class TestGTPUHeaderParsing(unittest.TestCase):
+    """Test GTP-U header parsing"""
+
+    def test_parse_minimal_header(self):
+        """Parse minimal 8-byte header"""
+        # Build a header
+        header = build_gtpu_header(0x12345678, 100)
+
+        # Parse it
+        info = parse_gtpu_header(header)
+
+        self.assertIsNotNone(info)
+        self.assertEqual(info.version, 1)
+        self.assertEqual(info.pt, 1)
+        self.assertFalse(info.e_flag)
+        self.assertFalse(info.s_flag)
+        self.assertFalse(info.pn_flag)
+        self.assertEqual(info.msg_type, 255)
+        self.assertEqual(info.teid, 0x12345678)
+        self.assertEqual(info.header_len, 8)
+
+    def test_parse_header_with_options(self):
+        """Parse header with optional fields"""
+        header = build_gtpu_header(0xAABBCCDD, 200, seq_num=9999)
+
+        info = parse_gtpu_header(header)
+
+        self.assertIsNotNone(info)
+        self.assertTrue(info.s_flag)
+        self.assertEqual(info.seq_num, 9999)
+        self.assertEqual(info.header_len, 12)
+
+    def test_parse_invalid_header(self):
+        """Parsing too-short data returns None"""
+        info = parse_gtpu_header(b'\x00\x00\x00')  # Too short
+
+        self.assertIsNone(info)
+
+    def test_roundtrip(self):
+        """Build and parse roundtrip"""
+        teid = 0x99887766
+        payload_len = 512
+        seq_num = 42
+
+        header = build_gtpu_header(teid, payload_len, seq_num=seq_num)
+        info = parse_gtpu_header(header)
+
+        self.assertEqual(info.teid, teid)
+        self.assertEqual(info.length, payload_len + 4)  # +4 for optional fields
+        self.assertEqual(info.seq_num, seq_num)
+
+
+@unittest.skipUnless(SCAPY_AVAILABLE and LIB_AVAILABLE, "scapy or lib not available")
+class TestGTPUPacketBuilding(unittest.TestCase):
+    """Test complete GTP-U packet construction"""
+
+    def test_build_packet_scapy(self):
+        """Build packet using Scapy GTP"""
+        payload = b"Hello GTP-U!"
+
+        pkt_bytes, orig_payload = build_gtpu_packet(
+            outer_src_ip="10.0.2.1",
+            outer_dst_ip="10.0.2.2",
+            inner_src_ip="192.168.128.100",
+            inner_dst_ip="8.8.8.8",
+            teid=0x12345678,
+            payload=payload
+        )
+
+        self.assertIsInstance(pkt_bytes, bytes)
+        self.assertEqual(orig_payload, payload)
+
+        # Parse to verify structure
+        from scapy.all import Ether
+        pkt = Ether(pkt_bytes)
+
+        self.assertIn(IP, pkt)
+        self.assertIn(UDP, pkt)
+        self.assertIn(GTP_U_Header, pkt)
+
+        # Check outer IP
+        outer_ip = pkt[IP]
+        self.assertEqual(outer_ip.src, "10.0.2.1")
+        self.assertEqual(outer_ip.dst, "10.0.2.2")
+
+        # Check UDP port
+        udp = pkt[UDP]
+        self.assertEqual(udp.dport, 2152)
+
+        # Check GTP header
+        gtp = pkt[GTP_U_Header]
+        self.assertEqual(gtp.teid, 0x12345678)
+        self.assertEqual(gtp.gtp_type, 255)
+
+    def test_build_packet_raw(self):
+        """Build packet using raw header construction"""
+        payload = b"Raw packet test"
+
+        pkt_bytes, orig_payload = build_gtpu_packet_raw(
+            outer_src_ip="10.0.2.1",
+            outer_dst_ip="10.0.2.2",
+            inner_src_ip="192.168.128.100",
+            inner_dst_ip="8.8.8.8",
+            teid=0xDEADBEEF,
+            payload=payload
+        )
+
+        # Verify it's a valid packet
+        from scapy.all import Ether
+        pkt = Ether(pkt_bytes)
+
+        self.assertIn(IP, pkt)
+        self.assertIn(UDP, pkt)
+
+        # Payload should be somewhere in the packet
+        self.assertIn(payload, pkt_bytes)
+
+    def test_payload_preserved(self):
+        """Original payload preserved through build"""
+        payload = generate_random_payload(128)
+        payload_hash = hashlib.md5(payload).hexdigest()
+
+        pkt_bytes, returned_payload = build_gtpu_packet(
+            outer_src_ip="10.0.0.1",
+            outer_dst_ip="10.0.0.2",
+            inner_src_ip="192.168.1.1",
+            inner_dst_ip="1.1.1.1",
+            teid=0x11111111,
+            payload=payload
+        )
+
+        # Returned payload should match
+        self.assertEqual(returned_payload, payload)
+
+        # Hash should match
+        self.assertEqual(hashlib.md5(returned_payload).hexdigest(), payload_hash)
+
+        # Payload should be in packet bytes
+        self.assertIn(payload, pkt_bytes)
+
+
+@unittest.skipUnless(SCAPY_AVAILABLE and LIB_AVAILABLE, "scapy or lib not available")
+class TestGTPUPacketParsing(unittest.TestCase):
+    """Test GTP-U packet parsing"""
+
+    def test_parse_gtpu_packet(self):
+        """Parse a GTP-U packet"""
+        payload = b"Test payload data"
+
+        pkt_bytes, _ = build_gtpu_packet(
+            outer_src_ip="10.0.2.1",
+            outer_dst_ip="10.0.2.2",
+            inner_src_ip="192.168.128.100",
+            inner_dst_ip="8.8.8.8",
+            teid=0x12345678,
+            payload=payload
+        )
+
+        pkt = Ether(pkt_bytes)
+        info = parse_gtpu_packet(pkt)
+
+        self.assertIsNotNone(info)
+        self.assertEqual(info.outer_src_ip, "10.0.2.1")
+        self.assertEqual(info.outer_dst_ip, "10.0.2.2")
+        self.assertEqual(info.header.teid, 0x12345678)
+        self.assertEqual(info.inner_src_ip, "192.168.128.100")
+        self.assertEqual(info.inner_dst_ip, "8.8.8.8")
+
+    def test_extract_inner_payload(self):
+        """Extract inner payload from GTP-U packet"""
+        payload = b"Extract me!"
+
+        pkt_bytes, _ = build_gtpu_packet(
+            outer_src_ip="10.0.2.1",
+            outer_dst_ip="10.0.2.2",
+            inner_src_ip="192.168.128.100",
+            inner_dst_ip="8.8.8.8",
+            teid=0x12345678,
+            payload=payload
+        )
+
+        pkt = Ether(pkt_bytes)
+        extracted = extract_inner_payload(pkt)
+
+        self.assertIsNotNone(extracted)
+        self.assertEqual(extracted, payload)
+
+    def test_non_gtpu_packet(self):
+        """Parsing non-GTP-U packet returns None"""
+        # Build a plain IP packet
+        pkt = Ether() / IP(src="1.1.1.1", dst="2.2.2.2") / UDP(sport=1234, dport=80) / Raw(b"plain")
+
+        info = parse_gtpu_packet(pkt)
+        self.assertIsNone(info)
+
+
+@unittest.skipUnless(LIB_AVAILABLE, "lib.gtpu not available")
+class TestEdgeCases(unittest.TestCase):
+    """Test edge cases and boundary conditions"""
+
+    def test_zero_teid_rejected_in_config(self):
+        """TEID 0 is reserved per spec (except for Echo)"""
+        # Note: We don't reject TEID 0 in header building,
+        # but config validation should catch it
+        from lib.config import GTPUTestConfig
+
+        with self.assertRaises(ValueError):
+            GTPUTestConfig(teid_ul=0)
+
+    def test_large_payload(self):
+        """Handle large payloads"""
+        payload = generate_random_payload(1400)  # Near MTU
+
+        header = build_gtpu_header(0x12345678, len(payload))
+        info = parse_gtpu_header(header)
+
+        self.assertEqual(info.length, len(payload))
+
+    def test_min_payload(self):
+        """Handle minimum payload"""
+        payload = b"X"
+
+        header = build_gtpu_header(0x12345678, len(payload))
+        info = parse_gtpu_header(header)
+
+        self.assertEqual(info.length, 1)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/test_prerequisites.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/test_prerequisites.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""
+System Prerequisites Validation Tests
+
+Validates that the system has all required components for eBPF GTP testing:
+- Root access
+- Kernel version >= 4.18
+- BCC library
+- Scapy with GTP support
+- Network capabilities
+
+These tests can be run without root to check non-privileged requirements,
+but full validation requires root access.
+
+Run: python3 -m pytest test_prerequisites.py -v
+"""
+
+import os
+import re
+import unittest
+import subprocess
+import platform
+
+
+class TestKernelSupport(unittest.TestCase):
+    """Test kernel requirements for eBPF TC programs"""
+
+    def test_kernel_version_minimum(self):
+        """Kernel must be >= 4.18 for TC eBPF support"""
+        release = platform.release()
+        parts = release.split('.')
+
+        try:
+            major = int(parts[0])
+            minor = int(parts[1].split('-')[0])
+        except (IndexError, ValueError) as e:
+            self.fail(f"Cannot parse kernel version '{release}': {e}")
+
+        # TC eBPF requires kernel >= 4.18
+        is_supported = major > 4 or (major == 4 and minor >= 18)
+
+        self.assertTrue(
+            is_supported,
+            f"Kernel {release} not supported. eBPF TC requires >= 4.18"
+        )
+
+    def test_kernel_config_bpf(self):
+        """Check kernel has BPF support compiled in"""
+        # Check /proc/config.gz or /boot/config-*
+        config_paths = [
+            '/proc/config.gz',
+            f'/boot/config-{platform.release()}',
+        ]
+
+        config_content = None
+        for path in config_paths:
+            if os.path.exists(path):
+                try:
+                    if path.endswith('.gz'):
+                        import gzip
+                        with gzip.open(path, 'rt') as f:
+                            config_content = f.read()
+                    else:
+                        with open(path, 'r') as f:
+                            config_content = f.read()
+                    break
+                except Exception:
+                    continue
+
+        if config_content is None:
+            self.skipTest("Cannot read kernel config - assuming BPF is enabled")
+
+        # Check for BPF configs
+        required_configs = [
+            'CONFIG_BPF=y',
+            'CONFIG_BPF_SYSCALL=y',
+        ]
+
+        for cfg in required_configs:
+            cfg_name = cfg.split('=')[0]
+            # Match exactly "CONFIG_X=y" or "CONFIG_X=m" at start of line.
+            # Rejects "# CONFIG_X is not set" and substring matches.
+            if not re.search(rf'^{cfg_name}=[ym]', config_content,
+                             re.MULTILINE):
+                self.skipTest(f"Cannot verify {cfg_name} is enabled")
+
+    def test_bpf_filesystem_mounted(self):
+        """BPF filesystem should be mounted"""
+        # Check if bpf fs is mounted
+        try:
+            result = subprocess.run(
+                ['mount'],
+                capture_output=True,
+                text=True
+            )
+            if 'bpf' in result.stdout:
+                return  # Found BPF mount
+
+            # Check standard location
+            if os.path.exists('/sys/fs/bpf'):
+                return
+
+            self.skipTest("BPF filesystem not detected - may need to mount")
+        except Exception as e:
+            self.skipTest(f"Cannot check BPF filesystem: {e}")
+
+
+class TestTunnelSupport(unittest.TestCase):
+    """Test kernel tunnel module requirements for bpf_skb_set_tunnel_key.
+
+    Finding 1: The decap handler requires ip_tunnel/vxlan kernel modules
+    for bpf_skb_set_tunnel_key(). Without them, all uplink GTP-U traffic
+    is silently dropped.
+    """
+
+    def test_ip_tunnel_module(self):
+        """ip_tunnel kernel module must be loaded"""
+        if os.path.exists('/sys/module/ip_tunnel'):
+            return
+        try:
+            with open('/proc/modules', 'r') as f:
+                modules = f.read()
+            if 'ip_tunnel' in modules:
+                return
+        except Exception:
+            pass
+        self.skipTest(
+            "ip_tunnel module not loaded — run: sudo modprobe ip_tunnel")
+
+    def test_vxlan_module(self):
+        """vxlan kernel module must be loaded"""
+        if os.path.exists('/sys/module/vxlan'):
+            return
+        try:
+            with open('/proc/modules', 'r') as f:
+                modules = f.read()
+            if 'vxlan' in modules:
+                return
+        except Exception:
+            pass
+        self.skipTest(
+            "vxlan module not loaded — run: sudo modprobe vxlan")
+
+    def test_lwtunnel_config(self):
+        """CONFIG_LWTUNNEL must be enabled for bpf_skb_set_tunnel_key"""
+        config_content = None
+        for path in [f'/boot/config-{platform.release()}',
+                     '/proc/config.gz']:
+            if os.path.exists(path):
+                try:
+                    if path.endswith('.gz'):
+                        import gzip
+                        with gzip.open(path, 'rt') as f:
+                            config_content = f.read()
+                    else:
+                        with open(path, 'r') as f:
+                            config_content = f.read()
+                    break
+                except Exception:
+                    continue
+        if config_content is None:
+            self.skipTest("Cannot read kernel config")
+        if re.search(r'^CONFIG_LWTUNNEL=[ym]', config_content,
+                     re.MULTILINE):
+            return
+        if re.search(r'^# CONFIG_LWTUNNEL is not set',
+                     config_content, re.MULTILINE):
+            self.fail("CONFIG_LWTUNNEL is disabled — "
+                      "bpf_skb_set_tunnel_key will fail")
+        self.skipTest("Cannot verify CONFIG_LWTUNNEL")
+
+    def test_net_ip_tunnel_config(self):
+        """CONFIG_NET_IP_TUNNEL must be enabled for ip_tunnel support"""
+        config_content = None
+        for path in [f'/boot/config-{platform.release()}',
+                     '/proc/config.gz']:
+            if os.path.exists(path):
+                try:
+                    if path.endswith('.gz'):
+                        import gzip
+                        with gzip.open(path, 'rt') as f:
+                            config_content = f.read()
+                    else:
+                        with open(path, 'r') as f:
+                            config_content = f.read()
+                    break
+                except Exception:
+                    continue
+        if config_content is None:
+            self.skipTest("Cannot read kernel config")
+        if re.search(r'^CONFIG_NET_IP_TUNNEL=[ym]', config_content,
+                     re.MULTILINE):
+            return
+        if re.search(r'^# CONFIG_NET_IP_TUNNEL is not set',
+                     config_content, re.MULTILINE):
+            self.fail("CONFIG_NET_IP_TUNNEL is disabled — "
+                      "ip_tunnel module unavailable")
+        self.skipTest("Cannot verify CONFIG_NET_IP_TUNNEL")
+
+
+class TestBCCLibrary(unittest.TestCase):
+    """Test BCC (BPF Compiler Collection) availability"""
+
+    def test_bcc_import(self):
+        """BCC library must be importable"""
+        try:
+            from bcc import BPF
+            self.assertIsNotNone(BPF)
+        except ImportError as e:
+            self.fail(
+                f"BCC library not available: {e}\n"
+                "Install with: apt-get install python3-bpfcc"
+            )
+
+    def test_bcc_version(self):
+        """Check BCC version"""
+        try:
+            from bcc import __version__ as bcc_version
+            print(f"\n  BCC version: {bcc_version}")
+            # Any version should work, but log it
+        except ImportError:
+            try:
+                from bcc import BPF
+                # BCC available but no version info
+                print("\n  BCC available (version unknown)")
+            except ImportError:
+                self.skipTest("BCC not available")
+
+    def test_bcc_compile_simple(self):
+        """Test BCC can compile a simple program"""
+        try:
+            from bcc import BPF
+
+            # Minimal eBPF program
+            prog = """
+            int test(void *ctx) {
+                return 0;
+            }
+            """
+
+            # This will compile the program
+            b = BPF(text=prog)
+            self.assertIsNotNone(b)
+        except ImportError:
+            self.skipTest("BCC not available")
+        except Exception as e:
+            self.fail(f"BCC compilation failed: {e}")
+
+
+class TestScapySupport(unittest.TestCase):
+    """Test Scapy and GTP support"""
+
+    def test_scapy_import(self):
+        """Scapy must be importable"""
+        try:
+            from scapy.all import Ether, IP, UDP, Raw
+            self.assertIsNotNone(Ether)
+            self.assertIsNotNone(IP)
+        except ImportError as e:
+            self.fail(
+                f"Scapy not available: {e}\n"
+                "Install with: pip install scapy"
+            )
+
+    def test_scapy_gtp_support(self):
+        """Scapy GTP contrib module must be available"""
+        try:
+            from scapy.contrib.gtp import GTP_U_Header
+            self.assertIsNotNone(GTP_U_Header)
+        except ImportError as e:
+            self.fail(
+                f"Scapy GTP support not available: {e}\n"
+                "GTP support should be built into Scapy"
+            )
+
+    def test_scapy_build_gtp_packet(self):
+        """Test building a GTP-U packet with Scapy"""
+        try:
+            from scapy.all import Ether, IP, UDP, Raw
+            from scapy.contrib.gtp import GTP_U_Header
+
+            # Build a complete GTP-U packet
+            pkt = (
+                Ether() /
+                IP(src="10.0.2.1", dst="10.0.2.2") /
+                UDP(sport=2152, dport=2152) /
+                GTP_U_Header(teid=0x12345678) /
+                IP(src="192.168.1.1", dst="8.8.8.8") /
+                UDP(sport=1234, dport=80) /
+                Raw(b"test payload")
+            )
+
+            # Convert to bytes
+            pkt_bytes = bytes(pkt)
+
+            # Should be a valid packet
+            self.assertGreater(len(pkt_bytes), 0)
+
+            # Parse it back
+            parsed = Ether(pkt_bytes)
+            self.assertIn(GTP_U_Header, parsed)
+            self.assertEqual(parsed[GTP_U_Header].teid, 0x12345678)
+
+        except ImportError:
+            self.skipTest("Scapy or GTP not available")
+
+
+class TestNetworkCapabilities(unittest.TestCase):
+    """Test network-related capabilities"""
+
+    def test_ip_command_available(self):
+        """ip command must be available"""
+        try:
+            result = subprocess.run(
+                ['ip', '-V'],
+                capture_output=True,
+                text=True
+            )
+            self.assertEqual(result.returncode, 0)
+            print(f"\n  {result.stdout.strip()}")
+        except FileNotFoundError:
+            self.fail("'ip' command not found - install iproute2")
+
+    def test_tc_command_available(self):
+        """tc command must be available"""
+        try:
+            result = subprocess.run(
+                ['tc', '-V'],
+                capture_output=True,
+                text=True
+            )
+            # tc -V may return non-zero but still output version
+            self.assertIn('tc', result.stdout.lower() + result.stderr.lower())
+        except FileNotFoundError:
+            self.fail("'tc' command not found - install iproute2")
+
+    def test_ethtool_available(self):
+        """ethtool should be available (optional but recommended)"""
+        try:
+            result = subprocess.run(
+                ['ethtool', '--version'],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode != 0:
+                self.skipTest("ethtool not working properly")
+        except FileNotFoundError:
+            self.skipTest("ethtool not found - checksum offload tests may fail")
+
+
+@unittest.skipUnless(os.geteuid() == 0, "Root access required")
+class TestRootCapabilities(unittest.TestCase):
+    """Tests that require root access"""
+
+    def test_can_create_veth(self):
+        """Test we can create veth pairs"""
+        import random
+        suffix = random.randint(1000, 9999)
+        name_a = f"prereq_a_{suffix}"
+        name_b = f"prereq_b_{suffix}"
+
+        try:
+            # Create veth pair
+            result = subprocess.run(
+                ['ip', 'link', 'add', name_a, 'type', 'veth', 'peer', 'name', name_b],
+                capture_output=True,
+                text=True
+            )
+            self.assertEqual(result.returncode, 0, f"Failed to create veth: {result.stderr}")
+
+            # Verify interfaces exist
+            self.assertTrue(os.path.exists(f'/sys/class/net/{name_a}'))
+            self.assertTrue(os.path.exists(f'/sys/class/net/{name_b}'))
+
+        finally:
+            # Cleanup
+            subprocess.run(['ip', 'link', 'del', name_a], capture_output=True)
+
+    def test_can_add_tc_qdisc(self):
+        """Test we can add TC qdisc for eBPF attachment"""
+        import random
+        suffix = random.randint(1000, 9999)
+        name_a = f"tc_test_a_{suffix}"
+        name_b = f"tc_test_b_{suffix}"
+
+        try:
+            # Create veth pair
+            subprocess.run(
+                ['ip', 'link', 'add', name_a, 'type', 'veth', 'peer', 'name', name_b],
+                capture_output=True
+            )
+
+            # Bring up interface
+            subprocess.run(['ip', 'link', 'set', name_a, 'up'], capture_output=True)
+
+            # Add clsact qdisc
+            result = subprocess.run(
+                ['tc', 'qdisc', 'add', 'dev', name_a, 'clsact'],
+                capture_output=True,
+                text=True
+            )
+            self.assertEqual(result.returncode, 0, f"Failed to add clsact: {result.stderr}")
+
+            # Verify qdisc exists
+            result = subprocess.run(
+                ['tc', 'qdisc', 'show', 'dev', name_a],
+                capture_output=True,
+                text=True
+            )
+            self.assertIn('clsact', result.stdout)
+
+        finally:
+            # Cleanup
+            subprocess.run(['ip', 'link', 'del', name_a], capture_output=True)
+
+    def test_can_load_bpf_program(self):
+        """Test we can load an eBPF program"""
+        try:
+            from bcc import BPF
+
+            # Minimal TC program
+            prog = """
+            #include <linux/bpf.h>
+            #include <linux/pkt_cls.h>
+
+            int test_prog(struct __sk_buff *skb) {
+                return TC_ACT_OK;
+            }
+            """
+
+            b = BPF(text=prog)
+            fn = b.load_func("test_prog", BPF.SCHED_CLS)
+            self.assertIsNotNone(fn)
+
+        except ImportError:
+            self.skipTest("BCC not available")
+        except Exception as e:
+            self.fail(f"Failed to load eBPF program: {e}")
+
+
+class TestLibraryAvailability(unittest.TestCase):
+    """Test that our test library modules are available"""
+
+    def test_lib_config(self):
+        """lib.config module must be importable"""
+        try:
+            from lib.config import GTPUTestConfig, populate_session
+            self.assertIsNotNone(GTPUTestConfig)
+            self.assertIsNotNone(populate_session)
+
+            # Test default config
+            cfg = GTPUTestConfig()
+            self.assertIsNotNone(cfg.tx_iface)
+            self.assertIsNotNone(cfg.ue_ip)
+        except ImportError as e:
+            self.fail(f"lib.config not available: {e}")
+
+    def test_lib_gtpu(self):
+        """lib.gtpu module must be importable"""
+        try:
+            from lib.gtpu import (
+                GTPUConstants,
+                build_gtpu_header,
+                parse_gtpu_header,
+                build_gtpu_packet,
+            )
+            self.assertIsNotNone(GTPUConstants)
+            self.assertEqual(GTPUConstants.PORT, 2152)
+        except ImportError as e:
+            self.fail(f"lib.gtpu not available: {e}")
+
+    def test_lib_network(self):
+        """lib.network module must be importable"""
+        try:
+            from lib.network import (
+                veth_pair,
+                setup_tc_qdisc,
+                get_ifindex,
+                check_root,
+            )
+            self.assertIsNotNone(veth_pair)
+            self.assertIsNotNone(setup_tc_qdisc)
+        except ImportError as e:
+            self.fail(f"lib.network not available: {e}")
+
+    def test_lib_capture(self):
+        """lib.capture module must be importable"""
+        try:
+            from lib.capture import (
+                PacketCapture,
+                capture_packets,
+                packet_contains_payload,
+            )
+            self.assertIsNotNone(PacketCapture)
+        except ImportError as e:
+            self.fail(f"lib.capture not available: {e}")
+
+    def test_lib_config_production_paths(self):
+        """lib.config must know production eBPF source paths"""
+        try:
+            from lib.config import (
+                DECAP_SOURCE,
+                ENCAP_SOURCE,
+                PRODUCTION_CFLAGS,
+                populate_session,
+                set_config,
+                read_stat,
+            )
+            self.assertIsNotNone(DECAP_SOURCE)
+            self.assertIsNotNone(ENCAP_SOURCE)
+            self.assertIsInstance(PRODUCTION_CFLAGS, list)
+        except ImportError as e:
+            self.fail(f"lib.config production helpers not available: {e}")
+
+
+def print_system_info():
+    """Print system information for debugging"""
+    print("\n" + "=" * 60)
+    print("SYSTEM INFORMATION")
+    print("=" * 60)
+
+    # OS Info
+    print(f"\nOS: {platform.system()} {platform.release()}")
+    print(f"Architecture: {platform.machine()}")
+    print(f"Python: {platform.python_version()}")
+
+    # Root status
+    print(f"Running as root: {os.geteuid() == 0}")
+
+    # BCC version
+    try:
+        from bcc import __version__ as bcc_version
+        print(f"BCC version: {bcc_version}")
+    except ImportError:
+        print("BCC: NOT INSTALLED")
+
+    # Scapy version
+    try:
+        import scapy
+        print(f"Scapy version: {scapy.__version__}")
+    except ImportError:
+        print("Scapy: NOT INSTALLED")
+
+    print("=" * 60 + "\n")
+
+
+if __name__ == '__main__':
+    print_system_info()
+    unittest.main(verbosity=2)

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/test_production_decap.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/test_production_decap.py
@@ -1,0 +1,1191 @@
+#!/usr/bin/env python3
+"""
+Production eBPF GTP Decapsulation Tests
+
+Tests the ACTUAL ebpf_gtp_decap.c program — compiles it with BCC,
+loads it, attaches to a veth pair, sends real GTP-U packets, and
+verifies decapsulated output.
+
+Topology:
+    [send GTP-U] --> s1u_veth --[gtp_decap_handler ingress]--> ovs_veth --> [capture inner IP]
+
+The decap handler strips outer IP/UDP/GTP headers, reconstructs the
+Ethernet header using MACs from the session map, and redirects the
+inner IP packet to the OVS-side veth via bpf_redirect().
+
+Requirements:
+- Root access (sudo)
+- BCC library (python3-bpfcc)
+- Scapy with GTP support
+- Linux kernel >= 4.18
+- Production ebpf_gtp_decap.c in parent directory
+
+Run: sudo python3 -m pytest test_production_decap.py -v -s
+"""
+
+import os
+import sys
+import time
+import unittest
+import random
+import string
+import struct
+
+if os.geteuid() != 0:
+    raise unittest.SkipTest("Root access required")
+
+try:
+    from bcc import BPF
+    BCC_AVAILABLE = True
+except ImportError:
+    BCC_AVAILABLE = False
+
+try:
+    from scapy.all import Ether, IP, UDP, TCP, ICMP, Raw, sendp, conf
+    from scapy.contrib.gtp import GTP_U_Header
+    conf.verb = 0
+    SCAPY_AVAILABLE = True
+except ImportError:
+    SCAPY_AVAILABLE = False
+
+try:
+    from lib.config import (
+        GTPUTestConfig, DECAP_SOURCE, PRODUCTION_CFLAGS,
+        load_production_source, populate_session, set_config, read_stat,
+        ip_to_host_order, compute_ue_mark, golden_decap,
+        attach_tc, detach_tc, has_map,
+        STATS_TOTAL_PROCESSED, STATS_GTP_DECAP_SUCCESS, STATS_SESSION_MISS,
+        STATS_TEID_MISMATCH, STATS_PKT_FORWARDED, STATS_PKT_DROPPED,
+        STATS_PKT_TOO_SHORT, STATS_INACTIVE_SESSION, STATS_UL_ERRORS,
+        CONFIG_OVS_IFINDEX,
+    )
+    from lib.network import veth_pair, setup_tc_qdisc, get_ifindex, get_mac_address
+    from lib.capture import PacketCapture
+    LIB_AVAILABLE = True
+except ImportError as e:
+    LIB_AVAILABLE = False
+    IMPORT_ERROR = str(e)
+
+
+def _generate_payload(size=64):
+    data = ''.join(random.choices(string.ascii_letters + string.digits, k=size))
+    return data.encode('utf-8')
+
+
+@unittest.skipUnless(BCC_AVAILABLE, "BCC not available")
+class TestDecapCompilation(unittest.TestCase):
+    """Test that the production decap program compiles and has expected maps"""
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(DECAP_SOURCE):
+            raise unittest.SkipTest(f"Production source not found: {DECAP_SOURCE}")
+        cls.source = load_production_source(DECAP_SOURCE)
+
+    def test_01_compiles(self):
+        """ebpf_gtp_decap.c compiles with production cflags"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        self.assertIsNotNone(bpf)
+
+    def test_02_has_decap_handler(self):
+        """gtp_decap_handler function exists and is loadable"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        fn = bpf.load_func("gtp_decap_handler", BPF.SCHED_CLS)
+        self.assertIsNotNone(fn)
+
+    def test_03_has_session_map(self):
+        """ue_session_map exists"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        bpf.load_func("gtp_decap_handler", BPF.SCHED_CLS)
+        self.assertTrue(has_map(bpf, "ue_session_map"))
+
+    def test_04_has_config_map(self):
+        """config_map exists"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        bpf.load_func("gtp_decap_handler", BPF.SCHED_CLS)
+        self.assertTrue(has_map(bpf, "config_map"))
+
+    def test_05_has_stats_map(self):
+        """stats_map exists"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        bpf.load_func("gtp_decap_handler", BPF.SCHED_CLS)
+        self.assertTrue(has_map(bpf, "stats_map"))
+
+
+@unittest.skipUnless(LIB_AVAILABLE, "Test library not available")
+@unittest.skipUnless(BCC_AVAILABLE, "BCC not available")
+@unittest.skipUnless(SCAPY_AVAILABLE, "Scapy not available")
+class TestDecapEndToEnd(unittest.TestCase):
+    """
+    End-to-end tests of the production GTP decapsulation program.
+
+    Each test:
+    1. Creates veth pair (s1u_veth <-> ovs_veth)
+    2. Compiles and attaches gtp_decap_handler on s1u_veth ingress
+    3. Configures session and config maps
+    4. Sends packets on s1u_veth
+    5. Captures on ovs_veth
+    6. Validates results
+    """
+
+    _test_counter = 0
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(DECAP_SOURCE):
+            raise unittest.SkipTest(f"Production source not found: {DECAP_SOURCE}")
+        cls.source = load_production_source(DECAP_SOURCE)
+
+    def setUp(self):
+        """Use unique veth names per test to avoid kernel state conflicts."""
+        TestDecapEndToEnd._test_counter += 1
+        n = TestDecapEndToEnd._test_counter
+        self.config = GTPUTestConfig(
+            tx_iface=f"dec_s1u{n}",
+            rx_iface=f"dec_ovs{n}",
+        )
+
+    def _setup_decap(self):
+        """Compile, load, attach decap program. Returns BPF object."""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        attach_tc(bpf, self.config.tx_iface, "gtp_decap_handler", "ingress")
+        return bpf
+
+    def _add_session(self, bpf, ovs_ifindex, mac_src=None, mac_dst=None,
+                     active=True, teid_ul=None):
+        """Add a UE session pointing redirect to ovs_veth."""
+        if mac_src is None:
+            mac_src = get_mac_address(self.config.rx_iface)
+        if mac_dst is None:
+            mac_dst = get_mac_address(self.config.rx_iface)
+
+        populate_session(
+            bpf,
+            ue_ip_str=self.config.ue_ip,
+            enb_ip_str=self.config.enb_ip,
+            teid_ul_in=teid_ul or self.config.teid_ul,
+            teid_dl_out=self.config.teid_dl,
+            ovs_ifindex=ovs_ifindex,
+            mac_src=mac_src,
+            mac_dst=mac_dst,
+            active=active,
+        )
+
+    def _build_gtp_packet(self, payload, teid=None, inner_src=None, inner_dst=None):
+        """Build a GTP-U encapsulated packet using Scapy."""
+        pkt = (
+            Ether(dst="ff:ff:ff:ff:ff:ff") /
+            IP(src=self.config.enb_ip, dst=self.config.sgw_ip) /
+            UDP(sport=2152, dport=2152) /
+            GTP_U_Header(teid=teid or self.config.teid_ul) /
+            IP(src=inner_src or self.config.ue_ip,
+               dst=inner_dst or self.config.external_ip) /
+            UDP(sport=12345, dport=80) /
+            Raw(load=payload)
+        )
+        return pkt
+
+    def _send_to_ingress(self, pkt):
+        """Send packet so it arrives on tx_iface INGRESS.
+
+        TC ingress fires on packets arriving at the interface.
+        On a veth pair a<->b, sending from b makes the packet arrive
+        on a's ingress. So we send from rx_iface (ovs side) to hit
+        the ingress handler on tx_iface (s1u side).
+        """
+        sendp(pkt, iface=self.config.rx_iface, verbose=False)
+
+    def test_01_attach_to_tc(self):
+        """Production decap attaches to TC ingress"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+            try:
+                import subprocess
+                result = subprocess.run(
+                    ['tc', 'filter', 'show', 'dev', self.config.tx_iface, 'ingress'],
+                    capture_output=True, text=True
+                )
+                self.assertIn('bpf', result.stdout.lower())
+                print(f"\n  Attached gtp_decap_handler to {self.config.tx_iface} ingress")
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_02_decap_golden_model(self):
+        """Golden model: validate every output field against Scapy reference"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+
+                # Use known MACs so we can verify the reconstructed Ethernet header
+                session_mac_src = "02:aa:bb:cc:dd:01"
+                session_mac_dst = "02:aa:bb:cc:dd:02"
+                self._add_session(bpf, ovs_ifindex,
+                                  mac_src=session_mac_src,
+                                  mac_dst=session_mac_dst)
+
+                payload = _generate_payload(64)
+
+                cap = PacketCapture(self.config.rx_iface, filter="ip")
+                cap.start()
+                time.sleep(0.1)
+
+                pkt = self._build_gtp_packet(payload)
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                # --- Stats validation ---
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+                forwarded = read_stat(bpf, STATS_PKT_FORWARDED)
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                ul_errors = read_stat(bpf, STATS_UL_ERRORS)
+                print(f"\n  Stats: total={total}, decap_ok={decap_ok}, forwarded={forwarded}, ul_errors={ul_errors}")
+
+                # If ul_errors > 0 and decap_ok == 0, bpf_skb_set_tunnel_key()
+                # failed at line 392 of ebpf_gtp_decap.c. This kernel helper
+                # requires CONFIG_LWTUNNEL / CONFIG_NET_IP_TUNNEL. Try:
+                #   sudo modprobe ip_tunnel && sudo modprobe vxlan
+                if decap_ok == 0 and ul_errors > 0:
+                    self.fail(
+                        f"bpf_skb_set_tunnel_key() failed (ul_errors={ul_errors}). "
+                        f"Ensure kernel has lightweight tunnel support: "
+                        f"modprobe ip_tunnel vxlan")
+
+                self.assertGreater(decap_ok, 0, "Decap success counter not incremented")
+                self.assertGreater(forwarded, 0, "Forwarded counter not incremented")
+                self.assertGreater(len(packets), 0, "No packets captured")
+
+                # --- Classify all captured packets ---
+                # pcap on rx_iface sees TWO things:
+                #   1. Our TX: the original GTP packet we sent from rx_iface
+                #   2. Redirect RX: the decapsulated inner IP from bpf_redirect
+                # In production, only (2) would appear on gtp_veth0 because
+                # GTP arrives from eth1, not gtp_veth0. We verify both are
+                # present and correctly formed.
+                gtp_packets = []    # Our sent GTP (TX on capture iface)
+                decap_packets = []  # Decapsulated output (RX via redirect)
+
+                for p in packets:
+                    p_bytes = bytes(p)
+                    if payload not in p_bytes:
+                        continue
+                    parsed = Ether(p_bytes)
+                    if UDP in parsed and parsed[UDP].dport == 2152:
+                        gtp_packets.append(parsed)
+                    else:
+                        decap_packets.append(parsed)
+
+                print(f"  Captured: {len(gtp_packets)} GTP (our TX) + "
+                      f"{len(decap_packets)} decapsulated (redirect RX)")
+
+                # Must have exactly 1 GTP (our send) and 1 decapsulated (redirect)
+                self.assertEqual(len(gtp_packets), 1,
+                                 f"Expected 1 GTP TX packet, got {len(gtp_packets)}")
+                self.assertEqual(len(decap_packets), 1,
+                                 f"Expected 1 decapsulated packet, got {len(decap_packets)} "
+                                 f"— eBPF may be leaking or duplicating packets")
+
+                decap_pkt = decap_packets[0]
+
+                # --- Ethernet header validation ---
+                # eBPF reconstructs Ethernet with MACs from session map
+                self.assertEqual(
+                    decap_pkt[Ether].dst, session_mac_dst,
+                    f"Dst MAC mismatch: {decap_pkt[Ether].dst} != {session_mac_dst}")
+                self.assertEqual(
+                    decap_pkt[Ether].src, session_mac_src,
+                    f"Src MAC mismatch: {decap_pkt[Ether].src} != {session_mac_src}")
+                self.assertEqual(
+                    decap_pkt[Ether].type, 0x0800,
+                    f"EtherType not IPv4: 0x{decap_pkt[Ether].type:04x}")
+
+                # --- GTP outer headers must be GONE ---
+                self.assertNotIn(
+                    GTP_U_Header, decap_pkt,
+                    "GTP-U header still present after decap")
+                if UDP in decap_pkt:
+                    self.assertNotEqual(
+                        decap_pkt[UDP].dport, 2152,
+                        "UDP port 2152 still present — outer headers not stripped")
+
+                # --- Inner IP header validation ---
+                self.assertIn(IP, decap_pkt, "No IP layer in decapsulated packet")
+                inner_ip = decap_pkt[IP]
+
+                self.assertEqual(
+                    inner_ip.src, self.config.ue_ip,
+                    f"Inner src IP: {inner_ip.src} != {self.config.ue_ip}")
+                self.assertEqual(
+                    inner_ip.dst, self.config.external_ip,
+                    f"Inner dst IP: {inner_ip.dst} != {self.config.external_ip}")
+                self.assertEqual(
+                    inner_ip.version, 4,
+                    f"Inner IP version: {inner_ip.version} != 4")
+                self.assertEqual(
+                    inner_ip.proto, 17,
+                    f"Inner IP protocol: {inner_ip.proto} != 17 (UDP)")
+
+                # --- Inner transport validation ---
+                self.assertIn(UDP, decap_pkt, "No UDP layer in decapsulated packet")
+                inner_udp = decap_pkt[UDP]
+                self.assertEqual(inner_udp.sport, 12345, "Inner UDP sport mismatch")
+                self.assertEqual(inner_udp.dport, 80, "Inner UDP dport mismatch")
+
+                # --- Payload validation ---
+                self.assertIn(Raw, decap_pkt, "No Raw payload in decapsulated packet")
+                self.assertEqual(
+                    decap_pkt[Raw].load, payload,
+                    "Payload bytes don't match original")
+
+                # --- Session counter validation ---
+                session_map = bpf.get_table("ue_session_map")
+                key = session_map.Key()
+                key.ue_ip = ip_to_host_order(self.config.ue_ip)
+                session = session_map[key]
+
+                self.assertGreater(session.ul_packets, 0,
+                                   "Session ul_packets not incremented")
+                self.assertGreater(session.ul_bytes, 0,
+                                   "Session ul_bytes not incremented")
+                self.assertGreater(session.last_seen, 0,
+                                   "Session last_seen not updated")
+
+                # --- Metadata mark validation ---
+                ue_ip_int = ip_to_host_order(self.config.ue_ip)
+                expected_mark = compute_ue_mark(ue_ip_int)
+                self.assertEqual(
+                    session.metadata_mark, expected_mark,
+                    f"metadata_mark 0x{session.metadata_mark:08x} != "
+                    f"expected 0x{expected_mark:08x}")
+
+                # --- Golden model byte-exact comparison ---
+                expected_bytes = golden_decap(
+                    bytes(pkt), session_mac_src, session_mac_dst)
+                actual_bytes = bytes(decap_pkt)
+                self.assertEqual(
+                    actual_bytes, expected_bytes,
+                    f"Decap output does not match golden model. "
+                    f"Actual {len(actual_bytes)} bytes vs "
+                    f"expected {len(expected_bytes)} bytes")
+
+                print(f"  Ethernet: dst={decap_pkt[Ether].dst} src={decap_pkt[Ether].src}")
+                print(f"  Inner IP: {inner_ip.src} -> {inner_ip.dst} proto={inner_ip.proto}")
+                print(f"  Payload: {len(payload)} bytes verified")
+                print(f"  Golden model: byte-exact match")
+                print(f"  Session: ul_pkts={session.ul_packets} ul_bytes={session.ul_bytes}")
+                print(f"  Mark: 0x{session.metadata_mark:08x} (expected 0x{expected_mark:08x})")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_03_decap_no_session(self):
+        """Packet with unknown UE IP is dropped — verify no leak"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+
+                marker = b"NO_SESSION_MARKER"
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                pkt = self._build_gtp_packet(marker, inner_src="172.16.99.99")
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                miss = read_stat(bpf, STATS_SESSION_MISS)
+                dropped = read_stat(bpf, STATS_PKT_DROPPED)
+                print(f"\n  Stats: session_miss={miss}, dropped={dropped}")
+
+                self.assertGreater(miss, 0, "Session miss counter not incremented")
+                self.assertGreater(dropped, 0, "Drop counter not incremented")
+
+                # Verify no decapsulated packet leaked to OVS side
+                # (only our TX should appear, classified as GTP)
+                leaked = []
+                for p in packets:
+                    parsed = Ether(bytes(p))
+                    if marker in bytes(p) and not (UDP in parsed and parsed[UDP].dport == 2152):
+                        leaked.append(p)
+                self.assertEqual(len(leaked), 0,
+                                 f"{len(leaked)} decapsulated packets leaked — "
+                                 f"handler should drop unknown sessions")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_04_decap_teid_mismatch(self):
+        """Packet with wrong TEID is dropped — verify no leak"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+                self._add_session(bpf, ovs_ifindex, teid_ul=0xAAAA0001)
+
+                marker = b"TEID_MISMATCH_MARKER"
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                pkt = self._build_gtp_packet(marker, teid=0xBBBB0002)
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                mismatch = read_stat(bpf, STATS_TEID_MISMATCH)
+                dropped = read_stat(bpf, STATS_PKT_DROPPED)
+                print(f"\n  Stats: teid_mismatch={mismatch}, dropped={dropped}")
+
+                self.assertGreater(mismatch, 0, "TEID mismatch counter not incremented")
+                self.assertGreater(dropped, 0, "Drop counter not incremented for TEID mismatch")
+
+                leaked = []
+                for p in packets:
+                    parsed = Ether(bytes(p))
+                    if marker in bytes(p) and not (UDP in parsed and parsed[UDP].dport == 2152):
+                        leaked.append(p)
+                self.assertEqual(len(leaked), 0,
+                                 f"{len(leaked)} decapsulated packets leaked — "
+                                 f"handler should drop TEID mismatches")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_05_decap_inactive_session(self):
+        """Packet for inactive session is dropped — verify no leak"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+                self._add_session(bpf, ovs_ifindex, active=False)
+
+                marker = b"INACTIVE_MARKER"
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                pkt = self._build_gtp_packet(marker)
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                inactive = read_stat(bpf, STATS_INACTIVE_SESSION)
+                dropped = read_stat(bpf, STATS_PKT_DROPPED)
+                print(f"\n  Stats: inactive_session={inactive}, dropped={dropped}")
+
+                self.assertGreater(inactive, 0, "Inactive session counter not incremented")
+                self.assertGreater(dropped, 0, "Drop counter not incremented for inactive session")
+
+                leaked = []
+                for p in packets:
+                    parsed = Ether(bytes(p))
+                    if marker in bytes(p) and not (UDP in parsed and parsed[UDP].dport == 2152):
+                        leaked.append(p)
+                self.assertEqual(len(leaked), 0,
+                                 f"{len(leaked)} decapsulated packets leaked — "
+                                 f"handler should drop inactive sessions")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_06_decap_multiple_packets(self):
+        """Multiple GTP-U packets are all decapsulated — classify output"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+                self._add_session(bpf, ovs_ifindex)
+
+                num_packets = 5
+                payloads = [_generate_payload(64) for _ in range(num_packets)]
+
+                cap = PacketCapture(self.config.rx_iface, filter="ip")
+                cap.start()
+                time.sleep(0.1)
+
+                for payload in payloads:
+                    pkt = self._build_gtp_packet(payload)
+                    self._send_to_ingress(pkt)
+                    time.sleep(0.05)
+
+                time.sleep(0.1)
+                packets = cap.stop()
+
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+
+                # Classify captured packets for each payload
+                decap_count = 0
+                for payload in payloads:
+                    for p in packets:
+                        p_bytes = bytes(p)
+                        if payload not in p_bytes:
+                            continue
+                        parsed = Ether(p_bytes)
+                        # Only count non-GTP packets (actual decap output)
+                        if not (UDP in parsed and parsed[UDP].dport == 2152):
+                            decap_count += 1
+                            break
+
+                print(f"\n  Sent {num_packets}, decap_ok={decap_ok}, "
+                      f"decap_captured={decap_count}")
+
+                self.assertEqual(decap_ok, num_packets,
+                                 f"decap_ok={decap_ok} != {num_packets} sent")
+                self.assertEqual(decap_count, num_packets,
+                                 f"Only {decap_count}/{num_packets} decapsulated "
+                                 f"packets captured — output missing")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_07_decap_non_gtp_passthrough(self):
+        """Non-GTP UDP packets pass through — not dropped, not decapped.
+
+        TC_ACT_OK on ingress means the packet continues into the local
+        kernel stack on tx_iface. It is NOT redirected to rx_iface, so
+        we cannot capture it. We verify passthrough by checking that:
+        - No GTP counters fired (decap_ok, session_miss)
+        - No drop counter incremented
+        - The handler processed it (total incremented)
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+
+                # Let initial ARP/NDP from veth creation settle before
+                # capturing baselines (Finding 3: non-IPv4 increments
+                # STATS_PKT_DROPPED even though TC_ACT_OK passes them).
+                time.sleep(0.1)
+
+                initial_total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                initial_dropped = read_stat(bpf, STATS_PKT_DROPPED)
+
+                # Non-GTP packet (UDP port 80, not 2152)
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src="1.1.1.1", dst="2.2.2.2") /
+                    UDP(sport=1234, dport=80) /
+                    Raw(load=b"NOT_GTP_TRAFFIC_MARKER_PAD" * 3)
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+                miss = read_stat(bpf, STATS_SESSION_MISS)
+                dropped = read_stat(bpf, STATS_PKT_DROPPED)
+                print(f"\n  Stats: total={total}, decap_ok={decap_ok}, "
+                      f"session_miss={miss}, dropped={dropped}")
+
+                # Handler must have processed the packet
+                self.assertGreater(total, initial_total,
+                                   "Handler did not process the non-GTP packet")
+
+                # Non-GTP IPv4/UDP should not trigger any GTP processing
+                self.assertEqual(decap_ok, 0,
+                                 "Non-GTP packet should not increment decap_ok")
+                self.assertEqual(miss, 0,
+                                 "Non-GTP packet should not trigger session_miss")
+                self.assertEqual(dropped - initial_dropped, 0,
+                                 "IPv4/UDP packet should not increment "
+                                 "STATS_PKT_DROPPED")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_08_decap_small_packet(self):
+        """Small packets arriving on GTP port must not be silently dropped.
+
+        Finding 2: The handler calls bpf_skb_load_bytes(skb, 0, pkt_data, 64)
+        which drops packets under 64 bytes as PKT_TOO_SHORT before any GTP
+        parsing begins. A truncated or minimal GTP packet on port 2152 should
+        be parsed or explicitly rejected as invalid GTP — not silently dropped
+        at a generic size check.
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                # Small UDP packet to GTP port (2152).
+                # Ether(14) + IP(20) + UDP(8) + Raw(5) = 47 bytes < 64.
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src="10.0.0.1", dst="10.0.0.2") /
+                    UDP(sport=2152, dport=2152) /
+                    Raw(load=b"SMALL")
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                too_short = read_stat(bpf, STATS_PKT_TOO_SHORT)
+                print(f"\n  Stats: total={total}, too_short={too_short}")
+
+                self.assertEqual(too_short, 0,
+                                 f"FINDING 2: Packet silently dropped as too short. "
+                                 f"bpf_skb_load_bytes(64) rejects packets < 64 bytes "
+                                 f"before GTP parsing. Should handle gracefully.")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_09_decap_malformed_gtp(self):
+        """Malformed GTP packets are rejected — not decapsulated, not leaked"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+                self._add_session(bpf, ovs_ifindex)
+
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                # Craft malformed GTP packets using raw bytes after UDP.
+                # Valid GTP flags = 0x30 (V1=1, PT=1), type = 0xFF (G-PDU)
+                inner_ip = bytes(
+                    IP(src=self.config.ue_ip, dst=self.config.external_ip) /
+                    UDP(sport=12345, dport=80) /
+                    Raw(load=b"MALFORMED_GTP_TEST_PAYLOAD_PAD" * 3)
+                )
+
+                cases = [
+                    # (description, gtp_flags, gtp_type)
+                    ("GTP version 2 (not v1)", 0x40, 0xFF),   # V=2, PT=0
+                    ("PT flag not set",        0x20, 0xFF),   # V=1, PT=0
+                    ("Echo Request type",      0x30, 0x01),   # V=1, PT=1, type=Echo
+                    ("End Marker type",        0x30, 0xFE),   # V=1, PT=1, type=EndMarker
+                ]
+
+                for desc, flags, msg_type in cases:
+                    # Build: Ether/IP/UDP(2152)/raw_GTP/inner_IP
+                    teid = self.config.teid_ul
+                    gtp_len = len(inner_ip)
+                    gtp_hdr = struct.pack('!BBHI', flags, msg_type, gtp_len, teid)
+
+                    pkt = (
+                        Ether(dst="ff:ff:ff:ff:ff:ff") /
+                        IP(src=self.config.enb_ip, dst=self.config.sgw_ip) /
+                        UDP(sport=2152, dport=2152) /
+                        Raw(load=gtp_hdr + inner_ip)
+                    )
+                    self._send_to_ingress(pkt)
+                    time.sleep(0.05)
+
+                time.sleep(0.1)
+                packets = cap.stop()
+
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                print(f"\n  Stats: total={total}, decap_ok={decap_ok}")
+                print(f"  Sent {len(cases)} malformed GTP packets")
+
+                # Verify handler actually processed the packets
+                self.assertGreaterEqual(total, len(cases),
+                                        f"Handler only processed {total}/{len(cases)} "
+                                        f"packets — malformed packets may not have "
+                                        f"reached the TC pipeline")
+
+                # None should be decapsulated
+                self.assertEqual(decap_ok, 0,
+                                 f"Malformed GTP packets should not be decapsulated "
+                                 f"(decap_ok={decap_ok})")
+
+                # No decapsulated packets should appear on output
+                marker = b"MALFORMED_GTP_TEST_PAYLOAD_PAD"
+                leaked = []
+                for p in packets:
+                    parsed = Ether(bytes(p))
+                    if marker in bytes(p) and not (UDP in parsed and parsed[UDP].dport == 2152):
+                        leaked.append(p)
+                self.assertEqual(len(leaked), 0,
+                                 f"{len(leaked)} malformed packets leaked as decapsulated")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_10_decap_gtp_with_seq_number(self):
+        """GTP with S flag (sequence number) decapsulates correctly.
+
+        S flag adds 4 optional bytes (seq, NPDU, next-ext-type) at
+        ebpf_gtp_decap.c:314-319. Inner packet offset shifts by 4.
+        Real eNBs commonly set this flag.
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+
+                session_mac_src = "02:de:ca:00:10:01"
+                session_mac_dst = "02:de:ca:00:10:02"
+                self._add_session(bpf, ovs_ifindex,
+                                  mac_src=session_mac_src,
+                                  mac_dst=session_mac_dst)
+
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                # GTP with S flag: adds seq_num(2) + npdu(1) + next_ext(1)
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.enb_ip, dst=self.config.sgw_ip) /
+                    UDP(sport=2152, dport=2152) /
+                    GTP_U_Header(teid=self.config.teid_ul, S=1,
+                                 seq=0x1234) /
+                    IP(src=self.config.ue_ip,
+                       dst=self.config.external_ip) /
+                    UDP(sport=12345, dport=80) /
+                    Raw(load=b"SEQ_NUMBER_TEST_PAYLOAD")
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+                print(f"\n  Stats: decap_ok={decap_ok}")
+
+                self.assertGreater(decap_ok, 0,
+                                   "GTP with S flag should be decapsulated")
+
+                # Find decapped packet (non-GTP with our marker)
+                marker = b"SEQ_NUMBER_TEST_PAYLOAD"
+                decapped = [p for p in packets
+                            if marker in bytes(p) and
+                            not (UDP in Ether(bytes(p)) and
+                                 Ether(bytes(p))[UDP].dport == 2152)]
+                self.assertEqual(len(decapped), 1,
+                                 "Expected exactly 1 decapsulated packet")
+
+                # Verify inner packet preserved via golden model
+                expected = golden_decap(bytes(pkt),
+                                        session_mac_src, session_mac_dst)
+                actual = bytes(decapped[0])
+                self.assertEqual(
+                    len(actual), len(expected),
+                    f"Decap output length {len(actual)} != "
+                    f"golden model {len(expected)}")
+                self.assertEqual(actual, expected,
+                                 "Decap output does not match golden model "
+                                 "for GTP with S flag")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_11_decap_gtp_with_pdu_session_container(self):
+        """GTP with E flag and PDU Session Container (0x85) extension.
+
+        Extension parsing loop at ebpf_gtp_decap.c:336-371.
+        PDU Session Container is the standard 5G extension.
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+
+                session_mac_src = "02:de:ca:00:11:01"
+                session_mac_dst = "02:de:ca:00:11:02"
+                self._add_session(bpf, ovs_ifindex,
+                                  mac_src=session_mac_src,
+                                  mac_dst=session_mac_dst)
+
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                # Build GTP with E flag + PDU Session Container manually
+                inner_ip = bytes(
+                    IP(src=self.config.ue_ip,
+                       dst=self.config.external_ip) /
+                    UDP(sport=12345, dport=80) /
+                    Raw(load=b"PDU_SESSION_CONTAINER_TEST")
+                )
+                teid = self.config.teid_ul
+                # GTP flags: V1=1, PT=1, E=1 → 0x34
+                gtp_flags = 0x34
+                gtp_len = len(inner_ip) + 4 + 4  # +4 opt fields, +4 ext
+                gtp_hdr = struct.pack('!BBHI', gtp_flags, 0xFF,
+                                      gtp_len, teid)
+                # Optional fields: seq=0, npdu=0, next_ext_type=0x85
+                opt_fields = struct.pack('!HBB', 0, 0, 0x85)
+                # PDU Session Container: len=1 (4 bytes), qfi=5, next=0
+                pdu_ext = struct.pack('!BBH', 1, 0x05, 0)
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.enb_ip, dst=self.config.sgw_ip) /
+                    UDP(sport=2152, dport=2152) /
+                    Raw(load=gtp_hdr + opt_fields + pdu_ext + inner_ip)
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+                print(f"\n  Stats: decap_ok={decap_ok}")
+
+                self.assertGreater(decap_ok, 0,
+                                   "GTP with PDU Session Container "
+                                   "should be decapsulated")
+
+                marker = b"PDU_SESSION_CONTAINER_TEST"
+                decapped = [p for p in packets
+                            if marker in bytes(p) and
+                            not (UDP in Ether(bytes(p)) and
+                                 Ether(bytes(p))[UDP].dport == 2152)]
+                self.assertEqual(len(decapped), 1,
+                                 "Expected 1 decapsulated packet")
+
+                # Strict golden comparison (raw GTP, so build expected
+                # directly instead of using golden_decap which needs
+                # Scapy GTP_U_Header layer)
+                expected = (bytes(Ether(src=session_mac_src,
+                                        dst=session_mac_dst,
+                                        type=0x0800)) +
+                            inner_ip)
+                actual = bytes(decapped[0])
+                self.assertEqual(
+                    len(actual), len(expected),
+                    f"Decap output length {len(actual)} != "
+                    f"golden model {len(expected)}")
+                self.assertEqual(actual, expected,
+                                 "PDU Session Container decap output "
+                                 "does not match golden model")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_12_decap_gtp_with_multiple_extensions(self):
+        """GTP with chained extension headers decapsulates correctly.
+
+        Extension loop at ebpf_gtp_decap.c:336 processes up to 5 extensions.
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+
+                session_mac_src = "02:de:ca:00:12:01"
+                session_mac_dst = "02:de:ca:00:12:02"
+                self._add_session(bpf, ovs_ifindex,
+                                  mac_src=session_mac_src,
+                                  mac_dst=session_mac_dst)
+
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                inner_ip = bytes(
+                    IP(src=self.config.ue_ip,
+                       dst=self.config.external_ip) /
+                    UDP(sport=12345, dport=80) /
+                    Raw(load=b"MULTI_EXTENSION_TEST_PAD_PAD")
+                )
+                teid = self.config.teid_ul
+                # GTP flags: V1=1, PT=1, E=1 → 0x34
+                gtp_flags = 0x34
+                # Extension 1: PDU Session Container (0x85), 4 bytes
+                ext1 = struct.pack('!BBH', 1, 0x05, 0)  # next=0 placeholder
+                # Extension 2: Generic extension (type 0x40), 4 bytes
+                ext2 = struct.pack('!BBH', 1, 0x00, 0)  # next=0, end chain
+                # Fix chain: ext1 next_type = 0x40
+                ext1 = struct.pack('!BBBB', 1, 0x05, 0, 0x40)
+                # ext2 next_type = 0 (end)
+                ext2 = struct.pack('!BBBB', 1, 0x00, 0, 0x00)
+                opt_fields = struct.pack('!HBB', 0, 0, 0x85)  # next=0x85
+                gtp_len = len(inner_ip) + 4 + len(ext1) + len(ext2)
+                gtp_hdr = struct.pack('!BBHI', gtp_flags, 0xFF,
+                                      gtp_len, teid)
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.enb_ip, dst=self.config.sgw_ip) /
+                    UDP(sport=2152, dport=2152) /
+                    Raw(load=gtp_hdr + opt_fields + ext1 + ext2 +
+                        inner_ip)
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+                print(f"\n  Stats: decap_ok={decap_ok}")
+
+                self.assertGreater(decap_ok, 0,
+                                   "GTP with chained extensions "
+                                   "should be decapsulated")
+
+                marker = b"MULTI_EXTENSION_TEST_PAD_PAD"
+                decapped = [p for p in packets
+                            if marker in bytes(p) and
+                            not (UDP in Ether(bytes(p)) and
+                                 Ether(bytes(p))[UDP].dport == 2152)]
+                self.assertEqual(len(decapped), 1,
+                                 "Expected 1 decapsulated packet")
+
+                # Strict golden comparison
+                expected = (bytes(Ether(src=session_mac_src,
+                                        dst=session_mac_dst,
+                                        type=0x0800)) +
+                            inner_ip)
+                actual = bytes(decapped[0])
+                self.assertEqual(
+                    len(actual), len(expected),
+                    f"Decap output length {len(actual)} != "
+                    f"golden model {len(expected)}")
+                self.assertEqual(actual, expected,
+                                 "Multi-extension decap output "
+                                 "does not match golden model")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_13_decap_outer_ipv4_options(self):
+        """Outer IPv4 with options — decap uses IHL correctly.
+
+        Unlike encap, the decap handler correctly computes ip_hlen from
+        the IHL field (ebpf_gtp_decap.c:266-268). This test verifies
+        that outer IPv4 options do not break decapsulation.
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+
+                session_mac_src = "02:de:ca:00:13:01"
+                session_mac_dst = "02:de:ca:00:13:02"
+                self._add_session(bpf, ovs_ifindex,
+                                  mac_src=session_mac_src,
+                                  mac_dst=session_mac_dst)
+
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                from scapy.all import IPOption
+                inner_payload = b"OUTER_OPTIONS_TEST_PAYLOAD_XX"
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.enb_ip, dst=self.config.sgw_ip,
+                       options=[IPOption(b'\x01')] * 4) /
+                    UDP(sport=2152, dport=2152) /
+                    GTP_U_Header(teid=self.config.teid_ul) /
+                    IP(src=self.config.ue_ip,
+                       dst=self.config.external_ip) /
+                    UDP(sport=12345, dport=80) /
+                    Raw(load=inner_payload)
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+                print(f"\n  Stats: decap_ok={decap_ok}")
+
+                self.assertGreater(decap_ok, 0,
+                                   "Decap with outer IPv4 options should "
+                                   "succeed (handler uses IHL correctly)")
+
+                decapped = [p for p in packets
+                            if inner_payload in bytes(p) and
+                            not (UDP in Ether(bytes(p)) and
+                                 Ether(bytes(p))[UDP].dport == 2152)]
+                self.assertEqual(len(decapped), 1,
+                                 "Expected 1 decapsulated packet")
+
+                # Strict golden comparison
+                expected = golden_decap(bytes(pkt),
+                                        session_mac_src, session_mac_dst)
+                actual = bytes(decapped[0])
+                self.assertEqual(
+                    len(actual), len(expected),
+                    f"Decap output length {len(actual)} != "
+                    f"golden model {len(expected)}")
+                self.assertEqual(actual, expected,
+                                 "Outer IPv4 options decap output "
+                                 "does not match golden model")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_14_decap_inner_tcp(self):
+        """Inner TCP packet preserved byte-exact after decapsulation"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+
+                session_mac_src = "02:de:ca:00:14:01"
+                session_mac_dst = "02:de:ca:00:14:02"
+                self._add_session(bpf, ovs_ifindex,
+                                  mac_src=session_mac_src,
+                                  mac_dst=session_mac_dst)
+
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                inner_payload = b"TCP_INNER_TEST_PAYLOAD_DATA_XX"
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.enb_ip, dst=self.config.sgw_ip) /
+                    UDP(sport=2152, dport=2152) /
+                    GTP_U_Header(teid=self.config.teid_ul) /
+                    IP(src=self.config.ue_ip,
+                       dst=self.config.external_ip) /
+                    TCP(sport=80, dport=12345, flags='A') /
+                    Raw(load=inner_payload)
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+                print(f"\n  Stats: decap_ok={decap_ok}")
+
+                self.assertGreater(decap_ok, 0,
+                                   "Inner TCP packet should be decapsulated")
+
+                decapped = [p for p in packets
+                            if inner_payload in bytes(p) and
+                            not (UDP in Ether(bytes(p)) and
+                                 Ether(bytes(p))[UDP].dport == 2152)]
+                self.assertEqual(len(decapped), 1,
+                                 "Expected 1 decapsulated packet")
+
+                # Verify inner IP bytes preserved via golden model
+                expected = golden_decap(bytes(pkt),
+                                        session_mac_src, session_mac_dst)
+                actual = bytes(decapped[0])
+                self.assertEqual(
+                    len(actual), len(expected),
+                    f"Decap output length {len(actual)} != "
+                    f"golden model {len(expected)}")
+                self.assertEqual(actual, expected,
+                                 "Inner TCP packet not preserved "
+                                 "byte-exact after decap")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_15_decap_inner_icmp(self):
+        """Inner ICMP packet preserved after decapsulation"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_decap()
+
+            try:
+                ovs_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_OVS_IFINDEX, ovs_ifindex)
+
+                session_mac_src = "02:de:ca:00:15:01"
+                session_mac_dst = "02:de:ca:00:15:02"
+                self._add_session(bpf, ovs_ifindex,
+                                  mac_src=session_mac_src,
+                                  mac_dst=session_mac_dst)
+
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                inner_payload = b"ICMP_INNER_TEST_PAYLOAD_DATA_X"
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.enb_ip, dst=self.config.sgw_ip) /
+                    UDP(sport=2152, dport=2152) /
+                    GTP_U_Header(teid=self.config.teid_ul) /
+                    IP(src=self.config.ue_ip,
+                       dst=self.config.external_ip) /
+                    ICMP(type=8, code=0, id=0x1234, seq=1) /
+                    Raw(load=inner_payload)
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                decap_ok = read_stat(bpf, STATS_GTP_DECAP_SUCCESS)
+                print(f"\n  Stats: decap_ok={decap_ok}")
+
+                self.assertGreater(decap_ok, 0,
+                                   "Inner ICMP packet should be decapsulated")
+
+                decapped = [p for p in packets
+                            if inner_payload in bytes(p) and
+                            not (UDP in Ether(bytes(p)) and
+                                 Ether(bytes(p))[UDP].dport == 2152)]
+                self.assertEqual(len(decapped), 1,
+                                 "Expected 1 decapsulated packet")
+
+                # Verify inner IP bytes preserved via golden model
+                expected = golden_decap(bytes(pkt),
+                                        session_mac_src, session_mac_dst)
+                actual = bytes(decapped[0])
+                self.assertEqual(
+                    len(actual), len(expected),
+                    f"Decap output length {len(actual)} != "
+                    f"golden model {len(expected)}")
+                self.assertEqual(actual, expected,
+                                 "Inner ICMP packet not preserved "
+                                 "byte-exact after decap")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+
+if __name__ == '__main__':
+    if os.geteuid() != 0:
+        print("ERROR: Must run as root (sudo)")
+        sys.exit(1)
+    unittest.main(verbosity=2)

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/test_production_encap.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/test_production_encap.py
@@ -1,0 +1,932 @@
+#!/usr/bin/env python3
+"""
+Production eBPF GTP Encapsulation Tests
+
+Tests the ACTUAL ebpf_gtp_encap.c program — compiles it with BCC,
+loads it, attaches to a veth pair, sends plain IP packets, and
+verifies GTP-U encapsulated output.
+
+Topology:
+    [send plain IP] --> ovs_veth --[gtp_encap_handler egress]--> s1u_veth --> [capture GTP-U]
+
+The encap handler looks up the UE session by destination IP, adds
+outer IP/UDP/GTP/extension headers (58 bytes total), and redirects
+the encapsulated packet to s1u_ifindex via bpf_redirect().
+
+Requirements:
+- Root access (sudo)
+- BCC library (python3-bpfcc)
+- Scapy with GTP support
+- Linux kernel >= 4.18
+- Production ebpf_gtp_encap.c in parent directory
+
+Run: sudo python3 -m pytest test_production_encap.py -v -s
+"""
+
+import os
+import sys
+import time
+import unittest
+import random
+import string
+import struct
+
+if os.geteuid() != 0:
+    raise unittest.SkipTest("Root access required")
+
+try:
+    from bcc import BPF
+    BCC_AVAILABLE = True
+except ImportError:
+    BCC_AVAILABLE = False
+
+try:
+    from scapy.all import Ether, IP, UDP, ARP, Raw, conf
+    from scapy.contrib.gtp import GTP_U_Header
+    conf.verb = 0
+    SCAPY_AVAILABLE = True
+except ImportError:
+    SCAPY_AVAILABLE = False
+
+try:
+    from lib.config import (
+        GTPUTestConfig, ENCAP_SOURCE, PRODUCTION_CFLAGS,
+        load_production_source, populate_session, set_config, read_stat,
+        ip_to_host_order, golden_encap, attach_tc, detach_tc, has_map,
+        STATS_TOTAL_PROCESSED, STATS_GTP_ENCAP_SUCCESS, STATS_SESSION_MISS,
+        STATS_PKT_FORWARDED, STATS_PKT_DROPPED, STATS_PKT_TOO_SHORT,
+        STATS_INACTIVE_SESSION,
+        STATS_DOUBLE_ENCAP_AVOIDED, STATS_DL_ERRORS,
+        CONFIG_SGI_IP,
+    )
+    from lib.network import veth_pair, setup_tc_qdisc, get_ifindex, get_mac_address
+    from lib.capture import PacketCapture
+    LIB_AVAILABLE = True
+except ImportError as e:
+    LIB_AVAILABLE = False
+    IMPORT_ERROR = str(e)
+
+
+def _generate_payload(size=64):
+    data = ''.join(random.choices(string.ascii_letters + string.digits, k=size))
+    return data.encode('utf-8')
+
+
+@unittest.skipUnless(BCC_AVAILABLE, "BCC not available")
+class TestEncapCompilation(unittest.TestCase):
+    """Test that the production encap program compiles and has expected maps"""
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(ENCAP_SOURCE):
+            raise unittest.SkipTest(f"Production source not found: {ENCAP_SOURCE}")
+        cls.source = load_production_source(ENCAP_SOURCE)
+
+    def test_01_compiles(self):
+        """ebpf_gtp_encap.c compiles with production cflags"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        self.assertIsNotNone(bpf)
+
+    def test_02_has_encap_handler(self):
+        """gtp_encap_handler function exists and is loadable"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        fn = bpf.load_func("gtp_encap_handler", BPF.SCHED_CLS)
+        self.assertIsNotNone(fn)
+
+    def test_03_has_session_map(self):
+        """ue_session_map exists"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        bpf.load_func("gtp_encap_handler", BPF.SCHED_CLS)
+        self.assertTrue(has_map(bpf, "ue_session_map"))
+
+    def test_04_has_config_map(self):
+        """config_map exists"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        bpf.load_func("gtp_encap_handler", BPF.SCHED_CLS)
+        self.assertTrue(has_map(bpf, "config_map"))
+
+    def test_05_has_stats_map(self):
+        """stats_map exists"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        bpf.load_func("gtp_encap_handler", BPF.SCHED_CLS)
+        self.assertTrue(has_map(bpf, "stats_map"))
+
+
+@unittest.skipUnless(LIB_AVAILABLE, "Test library not available")
+@unittest.skipUnless(BCC_AVAILABLE, "BCC not available")
+@unittest.skipUnless(SCAPY_AVAILABLE, "Scapy not available")
+class TestEncapEndToEnd(unittest.TestCase):
+    """
+    End-to-end tests of the production GTP encapsulation program.
+
+    Each test:
+    1. Creates veth pair (ovs_veth <-> s1u_veth)
+    2. Compiles and attaches gtp_encap_handler on ovs_veth egress
+    3. Configures session and config maps
+    4. Sends plain IP packets on ovs_veth
+    5. Captures GTP-U packets on s1u_veth
+    6. Validates GTP headers, TEID, outer IPs, extension headers
+    """
+
+    _test_counter = 0
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(ENCAP_SOURCE):
+            raise unittest.SkipTest(f"Production source not found: {ENCAP_SOURCE}")
+        cls.source = load_production_source(ENCAP_SOURCE)
+
+    def setUp(self):
+        """Use unique veth names per test to avoid kernel state conflicts."""
+        TestEncapEndToEnd._test_counter += 1
+        n = TestEncapEndToEnd._test_counter
+        self.config = GTPUTestConfig(
+            tx_iface=f"enc_ovs{n}",
+            rx_iface=f"enc_s1u{n}",
+        )
+
+    def _setup_encap(self):
+        """Compile, load, attach encap program on tx_iface egress."""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        attach_tc(bpf, self.config.tx_iface, "gtp_encap_handler", "egress")
+        return bpf
+
+    def _add_session(self, bpf, s1u_ifindex, mac_src=None, mac_dst=None,
+                     active=True, teid_dl=None, ue_ip=None, enb_ip=None):
+        """Add a UE session for encapsulation."""
+        if mac_src is None:
+            mac_src = get_mac_address(self.config.rx_iface)
+        if mac_dst is None:
+            mac_dst = get_mac_address(self.config.rx_iface)
+
+        populate_session(
+            bpf,
+            ue_ip_str=ue_ip or self.config.ue_ip,
+            enb_ip_str=enb_ip or self.config.enb_ip,
+            teid_ul_in=self.config.teid_ul,
+            teid_dl_out=teid_dl if teid_dl is not None else self.config.teid_dl,
+            s1u_ifindex=s1u_ifindex,
+            mac_src=mac_src,
+            mac_dst=mac_dst,
+            active=active,
+        )
+
+    def test_01_attach_to_tc(self):
+        """Production encap attaches to TC egress"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+            try:
+                import subprocess
+                result = subprocess.run(
+                    ['tc', 'filter', 'show', 'dev', self.config.tx_iface, 'egress'],
+                    capture_output=True, text=True
+                )
+                self.assertIn('bpf', result.stdout.lower())
+                print(f"\n  Attached gtp_encap_handler to {self.config.tx_iface} egress")
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def test_02_encap_golden_model(self):
+        """Golden model: validate every output field against Scapy reference"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                s1u_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_SGI_IP, ip_to_host_order(self.config.sgw_ip))
+
+                session_mac_src = "02:ee:ff:00:11:01"
+                session_mac_dst = "02:ee:ff:00:11:02"
+                test_qfi = 7
+                self._add_session(bpf, s1u_ifindex,
+                                  mac_src=session_mac_src,
+                                  mac_dst=session_mac_dst)
+                # Set QFI on the session
+                session_map = bpf.get_table("ue_session_map")
+                key = session_map.Key()
+                key.ue_ip = ip_to_host_order(self.config.ue_ip)
+                session = session_map[key]
+                session.qfi = test_qfi
+                session_map[key] = session
+
+                payload = _generate_payload(64)
+
+                # Build the input packet and compute its inner IP total length
+                input_pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.external_ip, dst=self.config.ue_ip) /
+                    UDP(sport=80, dport=12345) /
+                    Raw(load=payload)
+                )
+                # Force Scapy to calculate lengths
+                input_pkt = Ether(bytes(input_pkt))
+                inner_ip_total_len = input_pkt[IP].len
+
+                cap = PacketCapture(self.config.rx_iface, filter="udp port 2152")
+                cap.start()
+                time.sleep(0.1)
+
+                self._send_on_egress(input_pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                # --- Stats validation ---
+                encap_ok = read_stat(bpf, STATS_GTP_ENCAP_SUCCESS)
+                forwarded = read_stat(bpf, STATS_PKT_FORWARDED)
+                self.assertGreater(encap_ok, 0, "Encap success counter not incremented")
+                self.assertGreater(len(packets), 0, "No packets captured")
+
+                # Find GTP-U packet
+                encap_pkt = None
+                for p in packets:
+                    if GTP_U_Header in p:
+                        encap_pkt = p
+                        break
+                self.assertIsNotNone(encap_pkt, "No GTP-U packet found")
+
+                # --- Ethernet header ---
+                self.assertEqual(
+                    encap_pkt[Ether].dst, session_mac_dst,
+                    f"Dst MAC: {encap_pkt[Ether].dst} != {session_mac_dst}")
+                self.assertEqual(
+                    encap_pkt[Ether].src, session_mac_src,
+                    f"Src MAC: {encap_pkt[Ether].src} != {session_mac_src}")
+                self.assertEqual(encap_pkt[Ether].type, 0x0800, "EtherType not IPv4")
+
+                # --- Outer IP header ---
+                outer_ip = encap_pkt[IP]
+                self.assertEqual(outer_ip.version, 4, f"IP version: {outer_ip.version}")
+                self.assertEqual(outer_ip.ihl, 5, f"IP IHL: {outer_ip.ihl}")
+                self.assertEqual(outer_ip.tos, 0, f"IP TOS: {outer_ip.tos}")
+                self.assertEqual(outer_ip.id, 0, f"IP ID: {outer_ip.id}")
+                # DF flag: Scapy represents flags as int, DF=0x2
+                self.assertTrue(outer_ip.flags.DF, "DF flag not set")
+                self.assertEqual(outer_ip.frag, 0, f"Frag offset: {outer_ip.frag}")
+                self.assertEqual(outer_ip.ttl, 64, f"TTL: {outer_ip.ttl}")
+                self.assertEqual(outer_ip.proto, 17, f"Protocol: {outer_ip.proto} != UDP(17)")
+                self.assertEqual(
+                    outer_ip.src, self.config.sgw_ip,
+                    f"Outer src IP: {outer_ip.src} != {self.config.sgw_ip}")
+                self.assertEqual(
+                    outer_ip.dst, self.config.enb_ip,
+                    f"Outer dst IP: {outer_ip.dst} != {self.config.enb_ip}")
+
+                # IP total length: 20(IP) + 8(UDP) + 8(GTP) + 8(ext) + inner_ip_total_len
+                expected_ip_len = 20 + 8 + 8 + 8 + inner_ip_total_len
+                self.assertEqual(
+                    outer_ip.len, expected_ip_len,
+                    f"IP total len: {outer_ip.len} != {expected_ip_len}")
+
+                # IP checksum validation: let Scapy recalculate and compare
+                ebpf_checksum = outer_ip.chksum
+                # Rebuild to get Scapy's calculated checksum
+                outer_ip_copy = outer_ip.copy()
+                del outer_ip_copy.chksum
+                outer_ip_recalc = IP(bytes(outer_ip_copy))
+                self.assertEqual(
+                    ebpf_checksum, outer_ip_recalc.chksum,
+                    f"IP checksum: eBPF=0x{ebpf_checksum:04x} != "
+                    f"Scapy=0x{outer_ip_recalc.chksum:04x}")
+
+                # --- UDP header ---
+                udp = encap_pkt[UDP]
+                self.assertEqual(udp.sport, 2152, f"UDP sport: {udp.sport}")
+                self.assertEqual(udp.dport, 2152, f"UDP dport: {udp.dport}")
+                self.assertEqual(udp.chksum, 0, f"UDP checksum: {udp.chksum} (should be 0)")
+
+                # UDP length: 8(UDP) + 8(GTP) + 8(ext) + inner_ip_total_len
+                expected_udp_len = 8 + 8 + 8 + inner_ip_total_len
+                self.assertEqual(
+                    udp.len, expected_udp_len,
+                    f"UDP len: {udp.len} != {expected_udp_len}")
+
+                # --- GTP-U header ---
+                gtp = encap_pkt[GTP_U_Header]
+                self.assertEqual(gtp.gtp_type, 255, f"GTP type: {gtp.gtp_type} != 255 (T-PDU)")
+                self.assertEqual(
+                    gtp.teid, self.config.teid_dl,
+                    f"TEID: 0x{gtp.teid:08X} != 0x{self.config.teid_dl:08X}")
+
+                # GTP length: 8(ext) + inner_ip_total_len
+                expected_gtp_len = 8 + inner_ip_total_len
+                self.assertEqual(
+                    gtp.length, expected_gtp_len,
+                    f"GTP length: {gtp.length} != {expected_gtp_len}")
+
+                # --- GTP extension header (PDU Session Container) ---
+                # Parse raw bytes to validate extension fields
+                pkt_bytes = bytes(encap_pkt)
+                # Find GTP header start: after Ether(14) + IP(20) + UDP(8) = offset 42
+                gtp_offset = 14 + 20 + 8
+                # GTP flags byte
+                gtp_flags = pkt_bytes[gtp_offset]
+                # Flags should be 0x34: version=1(0x20), PT=1(0x10), E=1(0x04)
+                self.assertEqual(
+                    gtp_flags, 0x34,
+                    f"GTP flags: 0x{gtp_flags:02x} != 0x34 "
+                    f"(V={gtp_flags>>5}, PT={(gtp_flags>>4)&1}, E={(gtp_flags>>2)&1})")
+
+                # Optional fields start at gtp_offset + 8
+                opt_offset = gtp_offset + 8
+                seq_num = struct.unpack("!H", pkt_bytes[opt_offset:opt_offset+2])[0]
+                npdu = pkt_bytes[opt_offset + 2]
+                next_ext = pkt_bytes[opt_offset + 3]
+                self.assertEqual(seq_num, 0, f"Seq num: {seq_num}")
+                self.assertEqual(npdu, 0, f"N-PDU: {npdu}")
+                self.assertEqual(
+                    next_ext, 0x85,
+                    f"Next ext type: 0x{next_ext:02x} != 0x85 (PDU Session Container)")
+
+                # PDU Session Container extension (4 bytes after optional fields)
+                ext_offset = opt_offset + 4
+                ext_len = pkt_bytes[ext_offset]
+                pdu_type = pkt_bytes[ext_offset + 1]
+                qfi_byte = pkt_bytes[ext_offset + 2]
+                next_ext_end = pkt_bytes[ext_offset + 3]
+
+                self.assertEqual(ext_len, 1, f"Ext length: {ext_len} (should be 1 = 4 bytes)")
+                self.assertEqual(
+                    pdu_type, 0x10,
+                    f"PDU type: 0x{pdu_type:02x} != 0x10 (DL PDU SESSION INFO)")
+                self.assertEqual(
+                    qfi_byte & 0x3F, test_qfi,
+                    f"QFI: {qfi_byte & 0x3F} != {test_qfi}")
+                self.assertEqual(
+                    next_ext_end, 0x00,
+                    f"Final next_ext: 0x{next_ext_end:02x} != 0x00")
+
+                # --- Inner packet byte-exact preservation ---
+                # Extract inner IP from captured output (after GTP extension)
+                inner_offset = ext_offset + 4  # After the 4-byte PDU Session Container
+                captured_inner = pkt_bytes[inner_offset:]
+                # Original inner IP bytes (input packet minus Ethernet header)
+                original_inner = bytes(input_pkt)[14:]  # Skip Ether(14)
+
+                self.assertEqual(
+                    captured_inner, original_inner,
+                    f"Inner packet not preserved byte-for-byte. "
+                    f"Captured {len(captured_inner)} bytes vs "
+                    f"original {len(original_inner)} bytes")
+
+                # --- Session counter validation ---
+                session = session_map[key]
+                self.assertGreater(session.dl_packets, 0,
+                                   "Session dl_packets not incremented")
+                self.assertGreater(session.dl_bytes, 0,
+                                   "Session dl_bytes not incremented")
+                self.assertGreater(session.last_seen, 0,
+                                   "Session last_seen not updated")
+
+                # --- Golden model byte-exact comparison ---
+                expected_bytes = golden_encap(
+                    original_inner,
+                    session_mac_src, session_mac_dst,
+                    self.config.sgw_ip, self.config.enb_ip,
+                    self.config.teid_dl, qfi=test_qfi)
+                # Strict length and content equality
+                self.assertEqual(
+                    len(pkt_bytes), len(expected_bytes),
+                    f"Encap output length {len(pkt_bytes)} != "
+                    f"golden model {len(expected_bytes)}")
+                self.assertEqual(
+                    pkt_bytes, expected_bytes,
+                    "Encap output does not match golden model byte-for-byte")
+
+                print(f"\n  Ethernet: dst={encap_pkt[Ether].dst} src={encap_pkt[Ether].src}")
+                print(f"  Outer IP: {outer_ip.src} -> {outer_ip.dst} len={outer_ip.len} ttl={outer_ip.ttl}")
+                print(f"  IP checksum: eBPF=0x{ebpf_checksum:04x} Scapy=0x{outer_ip_recalc.chksum:04x}")
+                print(f"  UDP: {udp.sport}->{udp.dport} len={udp.len} chksum={udp.chksum}")
+                print(f"  GTP: flags=0x{gtp_flags:02x} type={gtp.gtp_type} len={gtp.length} TEID=0x{gtp.teid:08X}")
+                print(f"  Extension: type=0x85 len={ext_len} pdu_type=0x{pdu_type:02x} QFI={qfi_byte & 0x3F}")
+                print(f"  Golden model: byte-exact match ({len(pkt_bytes)} bytes)")
+                print(f"  Session: dl_pkts={session.dl_packets} dl_bytes={session.dl_bytes}")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def _send_on_egress(self, pkt):
+        """Send packet on tx_iface egress using raw AF_PACKET socket.
+
+        Scapy's L2Socket can fail with ENOBUFS when the TC eBPF handler
+        drops (TC_ACT_SHOT) or redirects (bpf_redirect) on egress, because
+        virtual devices process TC synchronously during send().
+        A raw AF_PACKET socket tolerates this — the packet enters the TC
+        pipeline and the handler runs even if send() returns an error.
+
+        In production, OVS sends via dev_queue_xmit (kernel-internal) which
+        does not surface these errors to userspace.
+        """
+        import socket as _socket
+        raw_bytes = bytes(pkt)
+        s = _socket.socket(_socket.AF_PACKET, _socket.SOCK_RAW,
+                           _socket.htons(0x0003))
+        try:
+            s.bind((self.config.tx_iface, 0))
+            s.send(raw_bytes)
+        except OSError:
+            pass  # TC processes packet before returning error
+        finally:
+            s.close()
+
+    # Padding to ensure packets exceed 64 bytes at L2 for tests that need
+    # to reach the handler's session logic (past the bpf_skb_load_bytes check).
+    _PAD = b'\x00' * 50
+
+    def test_03_encap_small_packet(self):
+        """Small valid IP packets to a known UE must be encapsulated.
+
+        Finding 2: The handler calls bpf_skb_load_bytes(skb, 0, pkt_data, 64)
+        which drops packets under 64 bytes as PKT_TOO_SHORT. This test sends
+        a small but valid IP packet (TCP ACK size) to a UE with an active
+        session. It should be encapsulated — if it's dropped, the
+        implementation has a bug that affects real traffic (TCP ACKs, ICMP,
+        small DNS responses).
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                s1u_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_SGI_IP, ip_to_host_order(self.config.sgw_ip))
+                self._add_session(bpf, s1u_ifindex)
+
+                cap = PacketCapture(self.config.rx_iface, filter="udp port 2152")
+                cap.start()
+                time.sleep(0.1)
+
+                # Small packet — valid IP/UDP to known UE, ~52 bytes at L2
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.external_ip, dst=self.config.ue_ip) /
+                    UDP(sport=80, dport=12345) /
+                    Raw(load=b"SMALL")
+                )
+                self._send_on_egress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                too_short = read_stat(bpf, STATS_PKT_TOO_SHORT)
+                encap_ok = read_stat(bpf, STATS_GTP_ENCAP_SUCCESS)
+                print(f"\n  Stats: total={total}, too_short={too_short}, encap_ok={encap_ok}")
+
+                self.assertEqual(too_short, 0,
+                                 f"FINDING 2: Valid small packet dropped as too short. "
+                                 f"bpf_skb_load_bytes(64) rejects packets < 64 bytes. "
+                                 f"TCP ACKs, ICMP, small DNS would be silently dropped.")
+                self.assertGreater(encap_ok, 0,
+                                   "Small packet with active session should be encapsulated")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def test_04_encap_no_session(self):
+        """Packet for unknown UE is dropped — verify no packet leaks through"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                marker = b"NO_SESSION_MARKER"
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src="1.1.1.1", dst="172.16.99.99") /
+                    UDP(sport=80, dport=12345) /
+                    Raw(load=marker + self._PAD)
+                )
+                self._send_on_egress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                miss = read_stat(bpf, STATS_SESSION_MISS)
+                dropped = read_stat(bpf, STATS_PKT_DROPPED)
+                print(f"\n  Stats: total={total}, session_miss={miss}, dropped={dropped}")
+
+                self.assertGreater(total, 0,
+                                   "Handler never ran — packet didn't reach TC pipeline")
+                self.assertGreater(miss, 0, "Session miss counter not incremented")
+
+                leaked = [p for p in packets if marker in bytes(p)]
+                self.assertEqual(len(leaked), 0,
+                                 f"{len(leaked)} packets leaked through — "
+                                 f"handler should drop unknown sessions")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def test_05_encap_inactive_session(self):
+        """Packet for inactive session is dropped — verify no packet leaks"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                s1u_ifindex = get_ifindex(self.config.rx_iface)
+                self._add_session(bpf, s1u_ifindex, active=False)
+
+                marker = b"INACTIVE_MARKER"
+                cap = PacketCapture(self.config.rx_iface)
+                cap.start()
+                time.sleep(0.1)
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.external_ip, dst=self.config.ue_ip) /
+                    UDP(sport=80, dport=12345) /
+                    Raw(load=marker + self._PAD)
+                )
+                self._send_on_egress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                inactive = read_stat(bpf, STATS_INACTIVE_SESSION)
+                print(f"\n  Stats: total={total}, inactive_session={inactive}")
+
+                self.assertGreater(total, 0,
+                                   "Handler never ran — packet didn't reach TC pipeline")
+                self.assertGreater(inactive, 0, "Inactive session counter not incremented")
+
+                leaked = [p for p in packets if marker in bytes(p)]
+                self.assertEqual(len(leaked), 0,
+                                 f"{len(leaked)} packets leaked — "
+                                 f"handler should drop inactive sessions")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def test_06_double_encap_avoided(self):
+        """Already-GTP packets are not double-encapsulated"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                s1u_ifindex = get_ifindex(self.config.rx_iface)
+                self._add_session(bpf, s1u_ifindex)
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.external_ip, dst=self.config.ue_ip) /
+                    UDP(sport=2152, dport=2152) /
+                    Raw(load=b"ALREADY_GTP" + self._PAD)
+                )
+                self._send_on_egress(pkt)
+                time.sleep(0.1)
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                avoided = read_stat(bpf, STATS_DOUBLE_ENCAP_AVOIDED)
+                print(f"\n  Stats: total={total}, double_encap_avoided={avoided}")
+
+                self.assertGreater(total, 0,
+                                   "Handler never ran — packet didn't reach TC pipeline")
+                self.assertGreater(avoided, 0, "Double encap avoidance not counted")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def test_07_multiple_ue_sessions(self):
+        """Packets for different UEs get correct TEIDs"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                s1u_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_SGI_IP, ip_to_host_order(self.config.sgw_ip))
+
+                sessions = [
+                    ("192.168.128.101", 0x00000101),
+                    ("192.168.128.102", 0x00000102),
+                    ("192.168.128.103", 0x00000103),
+                ]
+
+                for ue_ip, teid in sessions:
+                    self._add_session(bpf, s1u_ifindex, teid_dl=teid, ue_ip=ue_ip)
+
+                cap = PacketCapture(self.config.rx_iface, filter="udp port 2152")
+                cap.start()
+                time.sleep(0.1)
+
+                for ue_ip, _ in sessions:
+                    pkt = (
+                        Ether(dst="ff:ff:ff:ff:ff:ff") /
+                        IP(src=self.config.external_ip, dst=ue_ip) /
+                        UDP(sport=80, dport=12345) /
+                        Raw(load=f"to_{ue_ip}".encode() + self._PAD)
+                    )
+                    self._send_on_egress(pkt)
+                    time.sleep(0.05)
+
+                time.sleep(0.1)
+                packets = cap.stop()
+
+                found_teids = set()
+                for pkt in packets:
+                    if GTP_U_Header in pkt:
+                        found_teids.add(pkt[GTP_U_Header].teid)
+
+                expected_teids = {teid for _, teid in sessions}
+                print(f"\n  Expected TEIDs: {[hex(t) for t in expected_teids]}")
+                print(f"  Found TEIDs: {[hex(t) for t in found_teids]}")
+
+                self.assertEqual(found_teids, expected_teids,
+                                 f"TEID mismatch: expected {expected_teids}, got {found_teids}")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def test_08_encap_double_encap_with_ipv4_options(self):
+        """Double-encap detection fails when outer IPv4 has options.
+
+        Finding 4: The encap handler checks UDP ports at hardcoded offsets
+        34-37 (ebpf_gtp_encap.c:197) assuming a 20-byte IPv4 header.
+        Protocol and dst IP are at fixed positions in IPv4 and read correctly,
+        but UDP ports are AFTER the IP header, so options shift them.
+        With IHL=6 (24 bytes), the handler reads option bytes instead of
+        UDP ports, misses port 2152, and re-encapsulates an already-GTP packet.
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                s1u_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_SGI_IP, ip_to_host_order(self.config.sgw_ip))
+                self._add_session(bpf, s1u_ifindex)
+
+                time.sleep(0.1)
+                initial_avoided = read_stat(bpf, STATS_DOUBLE_ENCAP_AVOIDED)
+
+                # Already-GTP packet with IPv4 options
+                # Without options, this triggers STATS_DOUBLE_ENCAP_AVOIDED.
+                # With options, the handler reads wrong port bytes and
+                # misses the double-encap check.
+                from scapy.all import IPOption
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.external_ip, dst=self.config.ue_ip,
+                       options=[IPOption(b'\x01')] * 4) /
+                    UDP(sport=2152, dport=2152) /
+                    Raw(load=b"ALREADY_GTP_WITH_OPTIONS" + self._PAD)
+                )
+                self._send_on_egress(pkt)
+                time.sleep(0.1)
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                avoided = read_stat(bpf, STATS_DOUBLE_ENCAP_AVOIDED)
+                encap_ok = read_stat(bpf, STATS_GTP_ENCAP_SUCCESS)
+                print(f"\n  Stats: total={total}, "
+                      f"double_encap_avoided={avoided}, "
+                      f"encap_ok={encap_ok}")
+
+                self.assertGreater(total, 0,
+                                   "Handler did not process packet")
+                self.assertGreater(
+                    avoided, initial_avoided,
+                    "FINDING 4: Double-encap detection broken with IPv4 "
+                    "options. Handler reads UDP ports at hardcoded offsets "
+                    "(bytes 34-37) which point into IP options instead of "
+                    "actual UDP header. Already-GTP packet was NOT detected "
+                    f"as double-encap (encap_ok={encap_ok}).")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def test_09_encap_missing_sgi_ip(self):
+        """Missing CONFIG_SGI_IP must fail closed — no packet emitted.
+
+        Finding 5: The handler should reject the packet when CONFIG_SGI_IP
+        is not configured, since the outer source IP is unknown. Expected:
+        encap_ok == 0, an error/drop counter incremented, no GTP packet
+        emitted. The current implementation silently uses 0.0.0.0.
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                s1u_ifindex = get_ifindex(self.config.rx_iface)
+                # Intentionally do NOT set CONFIG_SGI_IP
+                self._add_session(bpf, s1u_ifindex)
+
+                cap = PacketCapture(self.config.rx_iface, filter="udp port 2152")
+                cap.start()
+                time.sleep(0.1)
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.external_ip, dst=self.config.ue_ip) /
+                    UDP(sport=80, dport=12345) /
+                    Raw(load=b"MISSING_SGI_IP_TEST" + self._PAD)
+                )
+                self._send_on_egress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                encap_ok = read_stat(bpf, STATS_GTP_ENCAP_SUCCESS)
+                dropped = read_stat(bpf, STATS_PKT_DROPPED)
+                dl_errors = read_stat(bpf, STATS_DL_ERRORS)
+                print(f"\n  Stats: total={total}, encap_ok={encap_ok}, "
+                      f"dropped={dropped}, dl_errors={dl_errors}")
+
+                self.assertGreater(total, 0,
+                                   "Handler did not process the packet")
+
+                # Missing CONFIG_SGI_IP should prevent encapsulation
+                self.assertEqual(
+                    encap_ok, 0,
+                    "FINDING 5: Missing CONFIG_SGI_IP should fail closed. "
+                    "Handler must not encapsulate without a valid source IP.")
+
+                # No GTP packet should be emitted
+                marker = b"MISSING_SGI_IP_TEST"
+                leaked = [p for p in packets if marker in bytes(p)]
+                self.assertEqual(
+                    len(leaked), 0,
+                    "FINDING 5: Packet emitted despite missing CONFIG_SGI_IP. "
+                    "Handler silently used 0.0.0.0 as outer source IP.")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def test_10_encap_qfi_values(self):
+        """QFI boundary values: default (0→9), normal (1), maximum (63)"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            s1u_ifindex = get_ifindex(self.config.rx_iface)
+
+            cases = [
+                # (qfi_in, expected_qfi_out, ue_ip_suffix, description)
+                (0, 9, 200, "default: qfi=0 should output 9"),
+                (1, 1, 201, "normal: qfi=1"),
+                (63, 63, 202, "maximum: qfi=63 (6-bit max)"),
+            ]
+
+            for qfi_in, expected_qfi, ip_suffix, desc in cases:
+                with self.subTest(desc):
+                    bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+                    attach_tc(bpf, self.config.tx_iface,
+                              "gtp_encap_handler", "egress")
+                    try:
+                        set_config(bpf, CONFIG_SGI_IP,
+                                   ip_to_host_order(self.config.sgw_ip))
+                        ue_ip = f"192.168.128.{ip_suffix}"
+                        populate_session(
+                            bpf,
+                            ue_ip_str=ue_ip,
+                            enb_ip_str=self.config.enb_ip,
+                            teid_ul_in=self.config.teid_ul,
+                            teid_dl_out=self.config.teid_dl,
+                            s1u_ifindex=s1u_ifindex,
+                            mac_src=get_mac_address(self.config.rx_iface),
+                            mac_dst=get_mac_address(self.config.rx_iface),
+                            qfi=qfi_in,
+                            active=True,
+                        )
+
+                        cap = PacketCapture(self.config.rx_iface,
+                                            filter="udp port 2152")
+                        cap.start()
+                        time.sleep(0.1)
+
+                        pkt = (
+                            Ether(dst="ff:ff:ff:ff:ff:ff") /
+                            IP(src=self.config.external_ip, dst=ue_ip) /
+                            UDP(sport=80, dport=12345) /
+                            Raw(load=f"QFI_{qfi_in}_TEST".encode() +
+                                self._PAD)
+                        )
+                        self._send_on_egress(pkt)
+                        time.sleep(0.1)
+
+                        packets = cap.stop()
+                        self.assertGreater(len(packets), 0,
+                                           f"No encap output for {desc}")
+
+                        pkt_bytes = bytes(packets[0])
+                        # PDU Session Container QFI is at byte 56:
+                        # headers[54]=ext_len, [55]=PDU_type(0x10),
+                        # [56]=QFI, [57]=next_ext(0)
+                        qfi_offset = 56
+                        qfi_byte = pkt_bytes[qfi_offset] & 0x3F
+                        print(f"\n  {desc}: input={qfi_in}, "
+                              f"output={qfi_byte}")
+                        self.assertEqual(
+                            qfi_byte, expected_qfi,
+                            f"QFI mismatch for {desc}: "
+                            f"got {qfi_byte}, expected {expected_qfi}")
+                    finally:
+                        detach_tc(self.config.tx_iface, "egress")
+
+    def test_11_encap_non_ipv4_passthrough(self):
+        """Non-IPv4 packets (ARP) pass through without encapsulation.
+
+        The handler returns TC_ACT_OK for non-IPv4 (ebpf_gtp_encap.c:185-187).
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                s1u_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_SGI_IP, ip_to_host_order(self.config.sgw_ip))
+                self._add_session(bpf, s1u_ifindex)
+
+                time.sleep(0.1)
+                initial_total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                initial_encap = read_stat(bpf, STATS_GTP_ENCAP_SUCCESS)
+                initial_dropped = read_stat(bpf, STATS_PKT_DROPPED)
+
+                # ARP packet — non-IPv4, should pass through
+                arp_pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    ARP(pdst=self.config.ue_ip) /
+                    Raw(load=b'\x00' * 50)
+                )
+                self._send_on_egress(arp_pkt)
+                time.sleep(0.1)
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                encap_ok = read_stat(bpf, STATS_GTP_ENCAP_SUCCESS)
+                dropped = read_stat(bpf, STATS_PKT_DROPPED)
+                print(f"\n  Stats: total={total}, encap_ok={encap_ok}, "
+                      f"dropped={dropped}")
+
+                self.assertGreater(total, initial_total,
+                                   "Handler did not process ARP packet")
+                self.assertEqual(encap_ok, initial_encap,
+                                 "ARP should not be encapsulated")
+                self.assertEqual(dropped, initial_dropped,
+                                 "ARP should not increment drop counter")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+    def test_12_encap_teid_zero(self):
+        """Session with teid_dl_out=0 is treated as inactive — packet dropped"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_encap()
+
+            try:
+                s1u_ifindex = get_ifindex(self.config.rx_iface)
+                set_config(bpf, CONFIG_SGI_IP, ip_to_host_order(self.config.sgw_ip))
+                self._add_session(bpf, s1u_ifindex, teid_dl=0)
+
+                cap = PacketCapture(self.config.rx_iface, filter="udp port 2152")
+                cap.start()
+                time.sleep(0.1)
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.external_ip, dst=self.config.ue_ip) /
+                    UDP(sport=80, dport=12345) /
+                    Raw(load=b"TEID_ZERO_TEST" + self._PAD)
+                )
+                self._send_on_egress(pkt)
+                time.sleep(0.1)
+
+                packets = cap.stop()
+
+                total = read_stat(bpf, STATS_TOTAL_PROCESSED)
+                inactive = read_stat(bpf, STATS_INACTIVE_SESSION)
+                encap_ok = read_stat(bpf, STATS_GTP_ENCAP_SUCCESS)
+                print(f"\n  Stats: total={total}, inactive={inactive}, "
+                      f"encap_ok={encap_ok}")
+
+                self.assertGreater(total, 0,
+                                   "Handler did not process packet")
+                self.assertGreater(inactive, 0,
+                                   "teid_dl_out=0 should be treated as inactive")
+                self.assertEqual(encap_ok, 0,
+                                 "Packet with teid_dl_out=0 should not be encapsulated")
+
+                leaked = [p for p in packets
+                          if b"TEID_ZERO_TEST" in bytes(p)]
+                self.assertEqual(len(leaked), 0,
+                                 "Packet leaked through despite teid_dl_out=0")
+
+            finally:
+                detach_tc(self.config.tx_iface, "egress")
+
+
+if __name__ == '__main__':
+    if os.geteuid() != 0:
+        print("ERROR: Must run as root (sudo)")
+        sys.exit(1)
+    unittest.main(verbosity=2)

--- a/lte/gateway/python/magma/pipelined/ebpf/tests/test_production_mark.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/tests/test_production_mark.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""
+Production eBPF GTP Mark Restoration Tests
+
+Tests the ACTUAL ebpf_gtp_veth0_mark.c program -- compiles it with BCC,
+loads it, attaches to a veth pair, sends decapped inner IP packets, and
+verifies mark restoration via session map and stats counters.
+
+Topology:
+    [send inner IP] --> peer_veth --arrival--> mark_veth --[gtp_veth0_mark_handler ingress]--> kernel
+
+The mark handler looks up the UE session by source IP, computes
+compute_ue_mark(ue_ip), and writes it to session_info->metadata_mark
+and skb->mark. Returns TC_ACT_OK (passthrough) for all packets.
+
+Requirements:
+- Root access (sudo)
+- BCC library (python3-bpfcc)
+- Scapy
+- Linux kernel >= 4.18
+- Production ebpf_gtp_veth0_mark.c in parent directory
+
+Run: sudo python3 -m pytest test_production_mark.py -v -s
+"""
+
+import os
+import sys
+import time
+import unittest
+
+if os.geteuid() != 0:
+    raise unittest.SkipTest("Root access required")
+
+try:
+    from bcc import BPF
+    BCC_AVAILABLE = True
+except ImportError:
+    BCC_AVAILABLE = False
+
+try:
+    from scapy.all import Ether, IP, UDP, ARP, Raw, sendp, conf
+    conf.verb = 0
+    SCAPY_AVAILABLE = True
+except ImportError:
+    SCAPY_AVAILABLE = False
+
+try:
+    from lib.config import (
+        GTPUTestConfig, MARK_SOURCE, PRODUCTION_CFLAGS,
+        load_production_source, populate_session, read_stat,
+        ip_to_host_order, compute_ue_mark, attach_tc, detach_tc, has_map,
+        STATS_VETH0_PACKETS_PROCESSED, STATS_VETH0_MARK_RESTORED,
+        STATS_VETH0_SESSION_MISS,
+    )
+    from lib.network import veth_pair, setup_tc_qdisc
+    LIB_AVAILABLE = True
+except ImportError as e:
+    LIB_AVAILABLE = False
+    IMPORT_ERROR = str(e)
+
+
+@unittest.skipUnless(LIB_AVAILABLE, "Test library not available")
+@unittest.skipUnless(BCC_AVAILABLE, "BCC not available")
+class TestMarkCompilation(unittest.TestCase):
+    """Test that the production mark program compiles and has expected maps"""
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(MARK_SOURCE):
+            raise unittest.SkipTest(f"Production source not found: {MARK_SOURCE}")
+        cls.source = load_production_source(MARK_SOURCE)
+
+    def test_01_compiles(self):
+        """ebpf_gtp_veth0_mark.c compiles with production cflags"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        self.assertIsNotNone(bpf)
+
+    def test_02_has_mark_handler(self):
+        """gtp_veth0_mark_handler function is loadable"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        fn = bpf.load_func("gtp_veth0_mark_handler", BPF.SCHED_CLS)
+        self.assertIsNotNone(fn)
+
+    def test_03_has_session_map(self):
+        """ue_session_map exists"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        bpf.load_func("gtp_veth0_mark_handler", BPF.SCHED_CLS)
+        self.assertTrue(has_map(bpf, "ue_session_map"))
+
+    def test_04_has_stats_map(self):
+        """stats_map exists"""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        bpf.load_func("gtp_veth0_mark_handler", BPF.SCHED_CLS)
+        self.assertTrue(has_map(bpf, "stats_map"))
+
+
+@unittest.skipUnless(LIB_AVAILABLE, "Test library not available")
+@unittest.skipUnless(BCC_AVAILABLE, "BCC not available")
+@unittest.skipUnless(SCAPY_AVAILABLE, "Scapy not available")
+class TestMarkEndToEnd(unittest.TestCase):
+    """
+    End-to-end tests of the production GTP mark restoration program.
+
+    Each test:
+    1. Creates veth pair (mark_veth <-> peer_veth)
+    2. Compiles and attaches gtp_veth0_mark_handler on mark_veth ingress
+    3. Populates session map
+    4. Sends inner IP packets from peer_veth (arrives on mark_veth ingress)
+    5. Verifies mark restoration via session map and stats counters
+    """
+
+    _test_counter = 0
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(MARK_SOURCE):
+            raise unittest.SkipTest(f"Production source not found: {MARK_SOURCE}")
+        cls.source = load_production_source(MARK_SOURCE)
+
+    def setUp(self):
+        TestMarkEndToEnd._test_counter += 1
+        n = TestMarkEndToEnd._test_counter
+        self.config = GTPUTestConfig(
+            tx_iface=f"mrk_v0_{n}",
+            rx_iface=f"mrk_pr_{n}",
+        )
+
+    # Verifier BPF: reads skb->mark after the mark handler and stores
+    # it in a map keyed by source IP, proving the actual packet mark.
+    VERIFIER_SOURCE = """
+    #include <linux/bpf.h>
+    #include <linux/pkt_cls.h>
+    #include <linux/if_ether.h>
+    #include <linux/ip.h>
+
+    BPF_HASH(observed_marks, __u32, __u32, 64);
+
+    int mark_verifier(struct __sk_buff *skb) {
+        __u8 hdr[34];
+        if (bpf_skb_load_bytes(skb, 0, hdr, sizeof(hdr)) < 0)
+            return TC_ACT_OK;
+        __u16 eth_type = (__u16)hdr[12] << 8 | (__u16)hdr[13];
+        if (eth_type != 0x0800)
+            return TC_ACT_OK;
+        __u32 src_ip = (__u32)hdr[26] << 24 | (__u32)hdr[27] << 16 |
+                       (__u32)hdr[28] << 8 | (__u32)hdr[29];
+        __u32 mark = skb->mark;
+        observed_marks.update(&src_ip, &mark);
+        return TC_ACT_OK;
+    }
+    """
+
+    def _setup_mark(self):
+        """Compile, load, attach mark program on tx_iface ingress."""
+        bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        attach_tc(bpf, self.config.tx_iface,
+                  "gtp_veth0_mark_handler", "ingress")
+        return bpf
+
+    def _setup_mark_with_verifier(self):
+        """Attach mark handler (direct_action=False) + verifier probe.
+
+        Production uses direct_action=False so packets continue after
+        TC_ACT_OK. The verifier runs as a second filter on the same
+        ingress hook and records skb->mark in observed_marks map.
+        """
+        from pyroute2 import IPRoute
+
+        mark_bpf = BPF(text=self.source, cflags=PRODUCTION_CFLAGS)
+        verifier_bpf = BPF(text=self.VERIFIER_SOURCE)
+
+        ipr = IPRoute()
+        try:
+            ifindex = ipr.link_lookup(ifname=self.config.tx_iface)[0]
+            parent = "ffff:fff2"  # ingress
+
+            # Filter 1 (prio 1): mark handler, direct_action=False
+            fn_mark = mark_bpf.load_func(
+                "gtp_veth0_mark_handler", BPF.SCHED_CLS)
+            ipr.tc("add-filter", "bpf", ifindex, ":1",
+                   fd=fn_mark.fd, name=fn_mark.name, parent=parent,
+                   classid=1, direct_action=False, prio=1)
+
+            # Filter 2 (prio 2): verifier, direct_action=True
+            fn_verify = verifier_bpf.load_func(
+                "mark_verifier", BPF.SCHED_CLS)
+            ipr.tc("add-filter", "bpf", ifindex, ":1",
+                   fd=fn_verify.fd, name=fn_verify.name, parent=parent,
+                   classid=1, direct_action=True, prio=2)
+        finally:
+            ipr.close()
+
+        return mark_bpf, verifier_bpf
+
+    def _read_observed_mark(self, verifier_bpf, ue_ip):
+        """Read observed skb->mark from verifier map."""
+        import ctypes
+        marks = verifier_bpf.get_table("observed_marks")
+        key = ctypes.c_uint32(ip_to_host_order(ue_ip))
+        try:
+            val = marks[key]
+            return val.value
+        except KeyError:
+            return None
+
+    def _add_session(self, bpf, active=True, ue_ip=None):
+        """Add a UE session for mark restoration."""
+        populate_session(
+            bpf,
+            ue_ip_str=ue_ip or self.config.ue_ip,
+            enb_ip_str=self.config.enb_ip,
+            teid_ul_in=self.config.teid_ul,
+            teid_dl_out=self.config.teid_dl,
+            active=active,
+        )
+
+    def _send_to_ingress(self, pkt):
+        """Send packet so it arrives on tx_iface ingress.
+
+        Send from rx_iface (peer) so packet arrives at tx_iface ingress.
+        """
+        sendp(pkt, iface=self.config.rx_iface, verbose=False)
+
+    def _read_session_mark(self, bpf, ue_ip=None):
+        """Read metadata_mark from session map for a UE."""
+        session_map = bpf.get_table("ue_session_map")
+        key = session_map.Key()
+        key.ue_ip = ip_to_host_order(ue_ip or self.config.ue_ip)
+        try:
+            val = session_map[key]
+            return val.metadata_mark
+        except KeyError:
+            return None
+
+    def test_01_attach_to_tc(self):
+        """Production mark handler attaches to TC ingress"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_mark()
+            try:
+                import subprocess
+                result = subprocess.run(
+                    ['tc', 'filter', 'show', 'dev',
+                     self.config.tx_iface, 'ingress'],
+                    capture_output=True, text=True
+                )
+                self.assertIn('bpf', result.stdout.lower())
+                print(f"\n  Attached gtp_veth0_mark_handler to "
+                      f"{self.config.tx_iface} ingress")
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_02_mark_restoration(self):
+        """Active session gets correct metadata_mark from compute_ue_mark"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_mark()
+
+            try:
+                self._add_session(bpf)
+
+                # Verify mark starts at 0
+                initial_mark = self._read_session_mark(bpf)
+                self.assertEqual(initial_mark, 0,
+                                 "metadata_mark should start at 0")
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.ue_ip,
+                       dst=self.config.external_ip) /
+                    UDP(sport=12345, dport=80) /
+                    Raw(load=b"MARK_RESTORE_TEST")
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                processed = read_stat(bpf, STATS_VETH0_PACKETS_PROCESSED)
+                restored = read_stat(bpf, STATS_VETH0_MARK_RESTORED)
+                print(f"\n  Stats: processed={processed}, "
+                      f"restored={restored}")
+
+                self.assertGreater(processed, 0,
+                                   "Handler did not process packet")
+                self.assertGreater(restored, 0,
+                                   "Mark not restored")
+
+                # Verify mark matches compute_ue_mark
+                ue_ip_int = ip_to_host_order(self.config.ue_ip)
+                expected_mark = compute_ue_mark(ue_ip_int)
+                actual_mark = self._read_session_mark(bpf)
+                print(f"  Expected mark: 0x{expected_mark:08x}")
+                print(f"  Actual mark:   0x{actual_mark:08x}")
+
+                self.assertEqual(
+                    actual_mark, expected_mark,
+                    f"metadata_mark 0x{actual_mark:08x} != "
+                    f"compute_ue_mark 0x{expected_mark:08x}")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_03_mark_session_miss(self):
+        """Unknown UE triggers session miss, packet passes through"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_mark()
+
+            try:
+                # No session added — source IP won't match
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src="10.99.99.99", dst="8.8.8.8") /
+                    UDP(sport=12345, dport=80) /
+                    Raw(load=b"UNKNOWN_UE_MARK_TEST")
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                processed = read_stat(bpf, STATS_VETH0_PACKETS_PROCESSED)
+                miss = read_stat(bpf, STATS_VETH0_SESSION_MISS)
+                restored = read_stat(bpf, STATS_VETH0_MARK_RESTORED)
+                print(f"\n  Stats: processed={processed}, "
+                      f"miss={miss}, restored={restored}")
+
+                self.assertGreater(processed, 0,
+                                   "Handler did not process packet")
+                self.assertGreater(miss, 0,
+                                   "Session miss not counted")
+                self.assertEqual(restored, 0,
+                                 "Mark should not be restored for "
+                                 "unknown UE")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_04_mark_inactive_session(self):
+        """Inactive session does not get mark restored"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_mark()
+
+            try:
+                self._add_session(bpf, active=False)
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.ue_ip,
+                       dst=self.config.external_ip) /
+                    UDP(sport=12345, dport=80) /
+                    Raw(load=b"INACTIVE_MARK_TEST_PAD")
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                processed = read_stat(bpf, STATS_VETH0_PACKETS_PROCESSED)
+                restored = read_stat(bpf, STATS_VETH0_MARK_RESTORED)
+                mark = self._read_session_mark(bpf)
+                print(f"\n  Stats: processed={processed}, "
+                      f"restored={restored}, mark=0x{mark:08x}")
+
+                self.assertGreater(processed, 0,
+                                   "Handler did not process packet")
+                self.assertEqual(restored, 0,
+                                 "Mark should not be restored for "
+                                 "inactive session")
+                self.assertEqual(mark, 0,
+                                 "metadata_mark should remain 0 for "
+                                 "inactive session")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_05_mark_non_ipv4_passthrough(self):
+        """Non-IPv4 packets pass through without mark processing"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_mark()
+
+            try:
+                self._add_session(bpf)
+
+                time.sleep(0.1)
+                initial_processed = read_stat(
+                    bpf, STATS_VETH0_PACKETS_PROCESSED)
+                initial_restored = read_stat(
+                    bpf, STATS_VETH0_MARK_RESTORED)
+                initial_miss = read_stat(
+                    bpf, STATS_VETH0_SESSION_MISS)
+
+                # ARP packet — non-IPv4
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    ARP(pdst=self.config.ue_ip)
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                processed = read_stat(bpf, STATS_VETH0_PACKETS_PROCESSED)
+                restored = read_stat(bpf, STATS_VETH0_MARK_RESTORED)
+                miss = read_stat(bpf, STATS_VETH0_SESSION_MISS)
+                print(f"\n  Stats: processed={processed}, "
+                      f"restored={restored}, miss={miss}")
+
+                # Handler processes the packet (increments counter)
+                self.assertGreater(processed, initial_processed,
+                                   "Handler did not process ARP packet")
+                # But does not attempt mark restore or session lookup
+                self.assertEqual(restored, initial_restored,
+                                 "ARP should not trigger mark restore")
+                self.assertEqual(miss, initial_miss,
+                                 "ARP should not trigger session miss")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_06_mark_multiple_ues(self):
+        """Different UEs get correct distinct marks"""
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_mark()
+
+            try:
+                ues = [
+                    "192.168.128.101",
+                    "192.168.128.102",
+                    "192.168.128.103",
+                ]
+                for ue_ip in ues:
+                    self._add_session(bpf, ue_ip=ue_ip)
+
+                for ue_ip in ues:
+                    pkt = (
+                        Ether(dst="ff:ff:ff:ff:ff:ff") /
+                        IP(src=ue_ip, dst="8.8.8.8") /
+                        UDP(sport=12345, dport=80) /
+                        Raw(load=f"MULTI_UE_{ue_ip}".encode())
+                    )
+                    self._send_to_ingress(pkt)
+                    time.sleep(0.05)
+
+                time.sleep(0.1)
+
+                restored = read_stat(bpf, STATS_VETH0_MARK_RESTORED)
+                self.assertGreaterEqual(restored, len(ues),
+                                        f"Expected >= {len(ues)} marks "
+                                        f"restored, got {restored}")
+
+                for ue_ip in ues:
+                    ue_ip_int = ip_to_host_order(ue_ip)
+                    expected = compute_ue_mark(ue_ip_int)
+                    actual = self._read_session_mark(bpf, ue_ip=ue_ip)
+                    print(f"  UE {ue_ip}: expected=0x{expected:08x} "
+                          f"actual=0x{actual:08x}")
+                    self.assertEqual(
+                        actual, expected,
+                        f"UE {ue_ip}: mark 0x{actual:08x} != "
+                        f"expected 0x{expected:08x}")
+
+                # Verify marks are distinct
+                marks = set()
+                for ue_ip in ues:
+                    marks.add(self._read_session_mark(bpf, ue_ip=ue_ip))
+                self.assertEqual(len(marks), len(ues),
+                                 "Marks should be distinct per UE")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_07_mark_computation_correctness(self):
+        """Mark values for boundary IPs match compute_ue_mark() exactly.
+
+        Note: Python compute_ue_mark() is a port of the C function, not
+        an independent specification. This test catches byte-order, wiring,
+        and transcription bugs, but not a shared algorithmic error.
+        The mark formula is defined solely in the eBPF C code.
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            bpf = self._setup_mark()
+
+            try:
+                # Test IPs that exercise compute_ue_mark edge cases
+                test_ips = [
+                    "192.168.128.1",   # Normal range
+                    "10.0.0.1",        # Low range
+                    "172.16.0.1",      # Mid range
+                    "1.0.0.1",         # mark < 0x10000000 (OR 0x12000000)
+                    "0.0.0.1",         # Near-zero (mask → 0, fallback)
+                ]
+
+                for ue_ip in test_ips:
+                    self._add_session(bpf, ue_ip=ue_ip)
+
+                for ue_ip in test_ips:
+                    pkt = (
+                        Ether(dst="ff:ff:ff:ff:ff:ff") /
+                        IP(src=ue_ip, dst="8.8.8.8") /
+                        UDP(sport=12345, dport=80) /
+                        Raw(load=f"BOUNDARY_{ue_ip}".encode())
+                    )
+                    self._send_to_ingress(pkt)
+                    time.sleep(0.05)
+
+                time.sleep(0.1)
+
+                for ue_ip in test_ips:
+                    ue_ip_int = ip_to_host_order(ue_ip)
+                    expected = compute_ue_mark(ue_ip_int)
+                    actual = self._read_session_mark(bpf, ue_ip=ue_ip)
+                    print(f"  {ue_ip} (0x{ue_ip_int:08x}): "
+                          f"eBPF=0x{actual:08x} "
+                          f"Python=0x{expected:08x}")
+                    self.assertEqual(
+                        actual, expected,
+                        f"{ue_ip}: eBPF mark 0x{actual:08x} != "
+                        f"Python compute_ue_mark 0x{expected:08x}")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+    def test_08_skb_mark_verified(self):
+        """Verify skb->mark is actually set on the packet, not just the map.
+
+        Chains two TC ingress filters:
+        1. gtp_veth0_mark_handler (direct_action=False, prio 1)
+        2. mark_verifier probe (direct_action=True, prio 2)
+
+        The verifier reads skb->mark and writes it to observed_marks map
+        keyed by source IP. This proves the packet itself carries the
+        correct mark, not just session_info->metadata_mark.
+        """
+        with veth_pair(self.config.tx_iface, self.config.rx_iface):
+            setup_tc_qdisc(self.config.tx_iface)
+            mark_bpf, verifier_bpf = self._setup_mark_with_verifier()
+
+            try:
+                self._add_session(mark_bpf)
+
+                pkt = (
+                    Ether(dst="ff:ff:ff:ff:ff:ff") /
+                    IP(src=self.config.ue_ip,
+                       dst=self.config.external_ip) /
+                    UDP(sport=12345, dport=80) /
+                    Raw(load=b"SKB_MARK_VERIFY_TEST")
+                )
+                self._send_to_ingress(pkt)
+                time.sleep(0.1)
+
+                restored = read_stat(mark_bpf,
+                                     STATS_VETH0_MARK_RESTORED)
+                expected_mark = compute_ue_mark(
+                    ip_to_host_order(self.config.ue_ip))
+                observed = self._read_observed_mark(
+                    verifier_bpf, self.config.ue_ip)
+
+                print(f"\n  Stats: restored={restored}")
+                print(f"  Expected mark: 0x{expected_mark:08x}")
+                print(f"  Observed skb->mark: "
+                      f"{'0x{:08x}'.format(observed) if observed is not None else 'None'}")
+
+                self.assertGreater(restored, 0,
+                                   "Mark handler did not restore mark")
+                self.assertIsNotNone(
+                    observed,
+                    "Verifier did not capture skb->mark — packet "
+                    "may not have reached second filter")
+                self.assertEqual(
+                    observed, expected_mark,
+                    f"skb->mark 0x{observed:08x} != expected "
+                    f"0x{expected_mark:08x}. Handler may update "
+                    f"metadata_mark but fail to set skb->mark.")
+
+            finally:
+                detach_tc(self.config.tx_iface, "ingress")
+
+
+if __name__ == '__main__':
+    if os.geteuid() != 0:
+        print("ERROR: Must run as root (sudo)")
+        sys.exit(1)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

End-to-end test suite for the eBPF GTP-U handlers (`ebpf_gtp_decap.c`, `ebpf_gtp_encap.c`, `ebpf_gtp_veth0_mark.c`). Tests compile and load the **actual production C source** via BCC, attach to real TC hooks on veth pairs, send real packets, and validate output byte-for-byte against independent Scapy-based golden model functions.

**85 passed, 8 failed** — all 8 failures are production code defects documented as findings below.

## Findings

The test suite discovered 6 issues in the production eBPF handlers:

| # | Severity | Finding |
|---|----------|---------|
| 1 | High | `bpf_skb_set_tunnel_key()` requires undocumented `ip_tunnel`/`vxlan` kernel modules — all uplink silently dropped without them |
| 2 | High | Both handlers drop packets < 64 bytes via `bpf_skb_load_bytes(64)` — affects TCP ACKs, ICMP, small DNS |
| 3 | Low | `STATS_PKT_DROPPED` incremented for non-IPv4 `TC_ACT_OK` passthrough traffic (misleading counter) |
| 4 | Medium | Double-encap detection broken with IPv4 options — hardcoded UDP port offsets read option bytes |
| 5 | Medium | Missing `CONFIG_SGI_IP` silently uses 0.0.0.0 as outer source IP (fails open, no error counter) |
| 6 | High | Mark handler uses network byte order for session lookup — `bpf_ntohl()` missing, so `skb->mark` is never restored on little-endian (all AGW deployments) |

## Test coverage

**Decap** (15 E2E + 5 compilation): golden model byte-exact match, negative paths with leak assertions, multi-packet classification, non-GTP passthrough, malformed GTP rejection, GTP S flag, PDU Session Container extension, chained extensions, outer IPv4 options, inner TCP/ICMP preservation.

**Encap** (12 E2E + 5 compilation + 3 subtests): golden model byte-exact match (all 58 header bytes + IP checksum), negative paths with leak assertions, double-encap avoidance, multi-session TEIDs, IPv4 options double-encap regression, missing CONFIG_SGI_IP fail-closed, QFI boundaries, ARP passthrough, teid_dl_out=0.

**Mark** (8 E2E + 4 compilation): mark restoration via session map + skb->mark verifier probe, session miss, inactive session, non-IPv4 passthrough, multiple UEs with distinct marks, boundary IP computation, chained TC filter proving actual skb->mark value.

**Prerequisites** (28 tests): kernel, tunnel modules (ip_tunnel, vxlan, CONFIG_LWTUNNEL, CONFIG_NET_IP_TUNNEL), BCC, Scapy, network tools, root capabilities.

**GTP-U protocol** (20 unit tests): header building/parsing, 3GPP TS 29.281 compliance.

## How to run

```bash
cd lte/gateway/python/magma/pipelined/ebpf/tests
sudo modprobe ip_tunnel vxlan
python3 -m venv venv --system-site-packages
source venv/bin/activate
pip install -r requirements.txt
sudo venv/bin/python -m pytest . -v -s
```

## Expected failures

```
FAILED test_production_decap.py::test_08_decap_small_packet                     # Finding 2
FAILED test_production_encap.py::test_03_encap_small_packet                     # Finding 2
FAILED test_production_encap.py::test_08_encap_double_encap_with_ipv4_options   # Finding 4
FAILED test_production_encap.py::test_09_encap_missing_sgi_ip                   # Finding 5
FAILED test_production_mark.py::test_02_mark_restoration                        # Finding 6
FAILED test_production_mark.py::test_06_mark_multiple_ues                       # Finding 6
FAILED test_production_mark.py::test_07_mark_computation_correctness            # Finding 6
FAILED test_production_mark.py::test_08_skb_mark_verified                       # Finding 6
```

These tests assert correct behavior. They will pass once the corresponding production code fixes land.