### PR TITLE
chore: [6.5 License Header Consistency] Batch 1 - Add headers to 4 files

### DIFF
--- a/lte/gateway/c/core/oai/common/common_utility_funs.cpp
+++ b/lte/gateway/c/core/oai/common/common_utility_funs.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <stdint.h>
 #include <iostream>

--- a/lte/gateway/c/core/oai/common/common_utility_funs.hpp
+++ b/lte/gateway/c/core/oai/common/common_utility_funs.hpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #define pragma once
 
 #include "lte/gateway/c/core/oai/include/mme_config.hpp"

--- a/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/nas5g_message.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <arpa/inet.h>
 #include "lte/gateway/c/core/common/common_defs.h"

--- a/lte/gateway/c/session_manager/AmfServiceClient.cpp
+++ b/lte/gateway/c/session_manager/AmfServiceClient.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "lte/gateway/c/session_manager/AmfServiceClient.hpp"
 
 #include <glog/logging.h>


### PR DESCRIPTION
This is Batch 1 of the license header standardization for `lte/gateway/c/`. It adds the standard Magma BSD-3-Clause license header to 4 source files identified as having no existing license information.

Files updated:
- core/oai/common/common_utility_funs.hpp
- core/oai/tasks/amf/nas5g_message.cpp
- core/oai/tasks/nas5g/include/M5GCommonDefs.h
- session_manager/AmfServiceClient.cpp

**Note:** This is a subset of the larger modular rollout for Phase 6 license consistency.

Refs: #15838