### PR TITLE
chore: [6.5] Phase 2 - Fix inconsistent headers - Batch 1

### DIFF
--- a/lte/gateway/c/core/oai/common/common_utility_funs.cpp
+++ b/lte/gateway/c/core/oai/common/common_utility_funs.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <stdint.h>
 #include <iostream>


### PR DESCRIPTION
Change the standard Magma BSD-3-Clause license header from block-style to Doxygen-style

Files updated:
- `./core/oai/common/common_utility_funs.cpp`

Refs: magma#15838