### PR TITLE
chore: [6.5] Phase 2 - Fix inconsistent headers - Batch 2

### DIFF
--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.cpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.cpp
@@ -1,15 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 //--C includes -----------------------------------------------------------------
 extern "C" {
 #include "lte/gateway/c/core/oai/common/log.h"

--- a/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.hpp
+++ b/lte/gateway/c/core/oai/tasks/amf/amf_app_timer_management.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 //--C includes -----------------------------------------------------------------
@@ -62,7 +62,7 @@ class AmfUeContext {
  private:
   std::map<int, timer_arg_t> amf_app_timers;
   std::map<int, ue_pdu_id_t> amf_pdu_timers;
-  AmfUeContext() : amf_app_timers(), amf_pdu_timers() {};
+  AmfUeContext() : amf_app_timers(), amf_pdu_timers(){};
 
  public:
   static AmfUeContext& Instance() {

--- a/lte/gateway/c/core/oai/tasks/async_grpc_service/grpc_async_service_task.hpp
+++ b/lte/gateway/c/core/oai/tasks/async_grpc_service/grpc_async_service_task.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/grpc_service/HaServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/HaServiceImpl.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <string>
 

--- a/lte/gateway/c/core/oai/tasks/grpc_service/HaServiceImpl.hpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/HaServiceImpl.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/grpc_service/S8ServiceImpl.cpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/S8ServiceImpl.cpp
@@ -1,15 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 #include <string>
 
 extern "C" {

--- a/lte/gateway/c/core/oai/tasks/grpc_service/S8ServiceImpl.hpp
+++ b/lte/gateway/c/core/oai/tasks/grpc_service/S8ServiceImpl.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/ha/HaClient.cpp
+++ b/lte/gateway/c/core/oai/tasks/ha/HaClient.cpp
@@ -1,15 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 #include <grpcpp/impl/codegen/async_unary_call.h>
 #include <thread>  // std::thread
 #include <iostream>

--- a/lte/gateway/c/core/oai/tasks/ha/ha_defs.hpp
+++ b/lte/gateway/c/core/oai/tasks/ha/ha_defs.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/ha/ha_service_handler.cpp
+++ b/lte/gateway/c/core/oai/tasks/ha/ha_service_handler.cpp
@@ -1,15 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 #include <iostream>
 #include <string.h>
 #include <sys/types.h>

--- a/lte/gateway/c/core/oai/tasks/ha/ha_task.cpp
+++ b/lte/gateway/c/core/oai/tasks/ha/ha_task.cpp
@@ -1,15 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 #define HA
 #define HA_TASK_C
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.hpp"
 

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.hpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ip_imsi.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include <stdint.h>

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer.hpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer.hpp
@@ -1,15 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 #pragma once
 
 #include <czmq.h>

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.cpp
@@ -1,15 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 //--C includes -----------------------------------------------------------------
 extern "C" {
 #include "lte/gateway/c/core/oai/common/log.h"

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.hpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_timer_management.hpp
@@ -1,15 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 #pragma once
 // C includes --------------------------------------------------------------
 extern "C" {
@@ -33,7 +34,7 @@ typedef timer_arg_t TimerArgType;
 class MmeUeContext {
  private:
   std::map<int, TimerArgType> mme_app_timers;
-  MmeUeContext() : mme_app_timers() {};
+  MmeUeContext() : mme_app_timers(){};
 
  public:
   static MmeUeContext& Instance() {

--- a/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ueip_imsi_map.hpp
+++ b/lte/gateway/c/core/oai/tasks/mme_app/mme_app_ueip_imsi_map.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationFailure.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GAuthenticationFailure.hpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationComplete.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/M5GRegistrationComplete.hpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationFailureIE.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GAuthenticationFailureIE.hpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GExtendedProtocolDiscriminator.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GExtendedProtocolDiscriminator.hpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMMCause.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GMMCause.hpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNSSAI.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNSSAI.hpp
@@ -1,13 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <sstream>
 #include <cstdint>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSDeRegistrationType.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSDeRegistrationType.hpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.hpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationResult.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GSRegistrationResult.hpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GTAIList.hpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GTAIList.hpp
@@ -1,13 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <sstream>
 #include <cstdint>

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMaxNumOfSupportedPacketFilters.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GMaxNumOfSupportedPacketFilters.cpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <iostream>
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNSSAI.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GNSSAI.cpp
@@ -1,13 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <sstream>
 #include <cstdint>
 #include <string.h>
@@ -21,9 +24,9 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GNSSAI.hpp"
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h"
 namespace magma5g {
-NSSAIMsg::NSSAIMsg() {};
+NSSAIMsg::NSSAIMsg(){};
 
-NSSAIMsg::~NSSAIMsg() {};
+NSSAIMsg::~NSSAIMsg(){};
 
 int NSSAIMsg::EncodeNSSAIMsg(NSSAIMsg* NSSAI, uint8_t iei, uint8_t* buffer,
                              uint32_t len) {

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionReActivationResult.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionReActivationResult.cpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <iostream>
 #include <sstream>
@@ -17,8 +19,8 @@ limitations under the License.
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionReActivationResult.hpp"
 
 namespace magma5g {
-M5GPDUSessionReActivationResult::M5GPDUSessionReActivationResult() {};
-M5GPDUSessionReActivationResult::~M5GPDUSessionReActivationResult() {};
+M5GPDUSessionReActivationResult::M5GPDUSessionReActivationResult(){};
+M5GPDUSessionReActivationResult::~M5GPDUSessionReActivationResult(){};
 
 int M5GPDUSessionReActivationResult::EncodePDUSessionReActivationResult(
     M5GPDUSessionReActivationResult* pduSessionReActivationStatus, uint8_t iei,

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionStatus.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GPDUSessionStatus.cpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <iostream>
 #include <sstream>
@@ -17,8 +19,8 @@ limitations under the License.
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GPDUSessionStatus.hpp"
 
 namespace magma5g {
-M5GPDUSessionStatus::M5GPDUSessionStatus() {};
-M5GPDUSessionStatus::~M5GPDUSessionStatus() {};
+M5GPDUSessionStatus::M5GPDUSessionStatus(){};
+M5GPDUSessionStatus::~M5GPDUSessionStatus(){};
 
 int M5GPDUSessionStatus::EncodePDUSessionStatus(
     M5GPDUSessionStatus* pduSessionStatus, uint8_t iei, uint8_t* buffer,

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSDeRegistrationType.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSDeRegistrationType.cpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <iostream>
 #include <sstream>
@@ -16,8 +18,8 @@ limitations under the License.
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/M5GCommonDefs.h"
 
 namespace magma5g {
-M5GSDeRegistrationTypeMsg::M5GSDeRegistrationTypeMsg() {};
-M5GSDeRegistrationTypeMsg::~M5GSDeRegistrationTypeMsg() {};
+M5GSDeRegistrationTypeMsg::M5GSDeRegistrationTypeMsg(){};
+M5GSDeRegistrationTypeMsg::~M5GSDeRegistrationTypeMsg(){};
 
 int M5GSDeRegistrationTypeMsg::DecodeM5GSDeRegistrationTypeMsg(
     M5GSDeRegistrationTypeMsg* de_reg_type, uint8_t iei, uint8_t* buffer,

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMCause.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GSMCause.cpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <iostream>
 #include <sstream>

--- a/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUplinkDataStatus.cpp
+++ b/lte/gateway/c/core/oai/tasks/nas5g/src/ies/M5GUplinkDataStatus.cpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <iostream>
 #include <sstream>
@@ -17,8 +19,8 @@ limitations under the License.
 #include "lte/gateway/c/core/oai/tasks/nas5g/include/ies/M5GUplinkDataStatus.hpp"
 
 namespace magma5g {
-M5GUplinkDataStatus::M5GUplinkDataStatus() {};
-M5GUplinkDataStatus::~M5GUplinkDataStatus() {};
+M5GUplinkDataStatus::M5GUplinkDataStatus(){};
+M5GUplinkDataStatus::~M5GUplinkDataStatus(){};
 
 int M5GUplinkDataStatus::EncodeUplinkDataStatus(
     M5GUplinkDataStatus* uplinkDataStatus, uint8_t iei, uint8_t* buffer,

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_timer.hpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_timer.hpp
@@ -1,15 +1,16 @@
-/*
-Copyright 2020 The Magma Authors.
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 #pragma once
 
 #include <czmq.h>

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_timer_management.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_timer_management.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 // --C includes
 #include <stdexcept>

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_timer_management.hpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_timer_management.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_defs.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_defs.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <stdio.h>
 #include <stdint.h>
@@ -614,9 +614,9 @@ static void insert_sgw_cp_and_up_teid_to_directoryd(sgw_state_t* sgw_state,
                     ->s_gw_teid_S5_S8_up;
           }
         }  // end of bearer list
-      }  // check for sgw_session_ctxt_p
-    }  // switch based on teid type
-  }  // end of s11_teid_list
+      }    // check for sgw_session_ctxt_p
+    }      // switch based on teid type
+  }        // end of s11_teid_list
 
   char separator = ',';
   for (uint8_t idx = 0; idx < teid_list_idx; idx++) {

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_s11_handlers.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_s11_handlers.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "lte/gateway/c/core/oai/include/sgw_s8_state.hpp"
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_converter.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_converter.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_converter.hpp"
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_converter.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_converter.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.hpp"
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.hpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_task.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_task.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #define SGW_S8
 #define SGW_S8_TASK_C


### PR DESCRIPTION
Change the standard Magma BSD-3-Clause license header from block-style to Doxygen-style

Files updated:
- `./core/oai/tasks/grpc_service/HaServiceImpl.hpp`
- `./core/oai/tasks/grpc_service/HaServiceImpl.cpp`
- `./core/oai/tasks/grpc_service/S8ServiceImpl.cpp`
- `./core/oai/tasks/grpc_service/S8ServiceImpl.hpp`
- `./core/oai/tasks/async_grpc_service/grpc_async_service_task.hpp`
- `./core/oai/tasks/mme_app/mme_app_ip_imsi.hpp`
- `./core/oai/tasks/mme_app/mme_app_timer.hpp`
- `./core/oai/tasks/mme_app/mme_app_timer_management.hpp`
- `./core/oai/tasks/mme_app/mme_app_ip_imsi.cpp`
- `./core/oai/tasks/mme_app/mme_app_timer_management.cpp`
- `./core/oai/tasks/mme_app/mme_app_ueip_imsi_map.hpp`
- `./core/oai/tasks/amf/amf_app_timer_management.cpp`
- `./core/oai/tasks/amf/amf_app_timer_management.hpp`
- `./core/oai/tasks/nas5g/include/M5GRegistrationComplete.hpp`
- `./core/oai/tasks/nas5g/include/ies/M5GTAIList.hpp`
- `./core/oai/tasks/nas5g/include/ies/M5GExtendedProtocolDiscriminator.hpp`
- `./core/oai/tasks/nas5g/include/ies/M5GMMCause.hpp`
- `./core/oai/tasks/nas5g/include/ies/M5GNSSAI.hpp`
- `./core/oai/tasks/nas5g/include/ies/M5GSRegistrationResult.hpp`
- `./core/oai/tasks/nas5g/include/ies/M5GAuthenticationFailureIE.hpp`
- `./core/oai/tasks/nas5g/include/ies/M5GSMobileIdentity.hpp`
- `./core/oai/tasks/nas5g/include/ies/M5GSDeRegistrationType.hpp`
- `./core/oai/tasks/nas5g/include/M5GAuthenticationFailure.hpp`
- `./core/oai/tasks/nas5g/src/ies/M5GPDUSessionStatus.cpp`
- `./core/oai/tasks/nas5g/src/ies/M5GUplinkDataStatus.cpp`
- `./core/oai/tasks/nas5g/src/ies/M5GSDeRegistrationType.cpp`
- `./core/oai/tasks/nas5g/src/ies/M5GMaxNumOfSupportedPacketFilters.cpp`
- `./core/oai/tasks/nas5g/src/ies/M5GSMCause.cpp`
- `./core/oai/tasks/nas5g/src/ies/M5GNSSAI.cpp`
- `./core/oai/tasks/nas5g/src/ies/M5GPDUSessionReActivationResult.cpp`
- `./core/oai/tasks/ha/HaClient.cpp`
- `./core/oai/tasks/ha/ha_task.cpp`
- `./core/oai/tasks/ha/ha_defs.hpp`
- `./core/oai/tasks/ha/ha_service_handler.cpp`
- `./core/oai/tasks/s1ap/s1ap_timer.hpp`
- `./core/oai/tasks/s1ap/s1ap_timer_management.hpp`
- `./core/oai/tasks/s1ap/s1ap_timer_management.cpp`
- `./core/oai/tasks/sgw_s8/sgw_s8_s11_handlers.hpp`
- `./core/oai/tasks/sgw_s8/sgw_s8_state_manager.cpp`
- `./core/oai/tasks/sgw_s8/sgw_s8_state_converter.cpp`
- `./core/oai/tasks/sgw_s8/sgw_s8_state_manager.hpp`
- `./core/oai/tasks/sgw_s8/sgw_s8_state_converter.hpp`
- `./core/oai/tasks/sgw_s8/sgw_s8_task.cpp`
- `./core/oai/tasks/sgw_s8/sgw_s8_handlers.cpp`
- `./core/oai/tasks/sgw_s8/sgw_s8_state.cpp`
- `./core/oai/tasks/sgw_s8/sgw_s8_defs.hpp`

Refs: #15838