### PR TITLE
chore: [6.5] Phase 2 - Fix inconsistent headers - Batch 4

### DIFF
--- a/lte/gateway/c/core/oai/lib/s8_proxy/S8Client.cpp
+++ b/lte/gateway/c/core/oai/lib/s8_proxy/S8Client.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <grpcpp/impl/codegen/async_unary_call.h>
 #include <thread>  // std::thread

--- a/lte/gateway/c/core/oai/lib/s8_proxy/S8Client.hpp
+++ b/lte/gateway/c/core/oai/lib/s8_proxy/S8Client.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 

--- a/lte/gateway/c/core/oai/lib/s8_proxy/s8_client_api.cpp
+++ b/lte/gateway/c/core/oai/lib/s8_proxy/s8_client_api.cpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <grpcpp/impl/codegen/status.h>
 #include "feg/protos/s8_proxy.grpc.pb.h"

--- a/lte/gateway/c/core/oai/lib/s8_proxy/s8_client_api.hpp
+++ b/lte/gateway/c/core/oai/lib/s8_proxy/s8_client_api.hpp
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #ifdef __cplusplus

--- a/lte/gateway/c/core/oai/lib/s8_proxy/s8_itti_proto_conversion.h
+++ b/lte/gateway/c/core/oai/lib/s8_proxy/s8_itti_proto_conversion.h
@@ -1,15 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #pragma once
 #include "feg/protos/s8_proxy.grpc.pb.h"


### PR DESCRIPTION
Change the standard Magma BSD-3-Clause license header from block-style to Doxygen-style

Files updated:
- `./core/oai/lib/s8_proxy/s8_itti_proto_conversion.h`
- `./core/oai/lib/s8_proxy/S8Client.cpp`
- `./core/oai/lib/s8_proxy/S8Client.hpp`
- `./core/oai/lib/s8_proxy/s8_client_api.hpp`
- `./core/oai/lib/s8_proxy/s8_client_api.cpp`

Refs: #15838