### PR TITLE
chore: [6.5] Phase 2 - Fix inconsistent headers - Batch 5

### DIFF
--- a/lte/gateway/c/session_manager/SessionStateEnforcer.hpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.hpp
@@ -1,13 +1,15 @@
-/*
-Copyright 2020 The Magma Authors.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /*****************************************************************************
   Source      	SessionStateEnforcer.h


### PR DESCRIPTION
Change the standard Magma BSD-3-Clause license header from block-style to Doxygen-style

Files updated:
- `./session_manager/SessionStateEnforcer.hpp`

Refs: #15838