### PR TITLE
chore: [6.5] Phase 3 - Add missing magma headers - Batch 1

### DIFF
--- a/lte/gateway/c/core/common/assertions.h
+++ b/lte/gateway/c/core/common/assertions.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/common/backtrace.c
+++ b/lte/gateway/c/core/common/backtrace.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/common/backtrace.h
+++ b/lte/gateway/c/core/common/backtrace.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/common/common_defs.h
+++ b/lte/gateway/c/core/common/common_defs.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/common/dynamic_memory_check.cpp
+++ b/lte/gateway/c/core/common/dynamic_memory_check.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/common/dynamic_memory_check.h
+++ b/lte/gateway/c/core/common/dynamic_memory_check.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.


### PR DESCRIPTION
Prepend the standard Magma BSD-3-Clause license header to source files containing legacy copyright information.

Files updated:
- `./core/common/dynamic_memory_check.cpp`
- `./core/common/assertions.h`
- `./core/common/common_defs.h`
- `./core/common/backtrace.h`
- `./core/common/backtrace.c`
- `./core/common/dynamic_memory_check.h`

Refs: #15838

