### PR TITLE
chore: [6.5] Phase 3 - Add missing magma headers - Batch 2

### DIFF
--- a/lte/gateway/c/core/oai/common/TLVDecoder.c
+++ b/lte/gateway/c/core/oai/common/TLVDecoder.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/common/TLVDecoder.h
+++ b/lte/gateway/c/core/oai/common/TLVDecoder.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/common/TLVEncoder.c
+++ b/lte/gateway/c/core/oai/common/TLVEncoder.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/common/TLVEncoder.h
+++ b/lte/gateway/c/core/oai/common/TLVEncoder.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/common/asn1_conversions.h
+++ b/lte/gateway/c/core/oai/common/asn1_conversions.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/async_system.c
+++ b/lte/gateway/c/core/oai/common/async_system.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/async_system.h
+++ b/lte/gateway/c/core/oai/common/async_system.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/common_ies.h
+++ b/lte/gateway/c/core/oai/common/common_ies.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/common_types.h
+++ b/lte/gateway/c/core/oai/common/common_types.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/conversions.c
+++ b/lte/gateway/c/core/oai/common/conversions.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/conversions.h
+++ b/lte/gateway/c/core/oai/common/conversions.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.
@@ -388,7 +401,7 @@
     (bITsTRING)->buf = (uint8_t*)calloc(3, sizeof(uint8_t)); \
     (bITsTRING)->buf[0] = ((mACRO) >> 12);                   \
     (bITsTRING)->buf[1] = (mACRO) >> 4;                      \
-    (bITsTRING)->buf[2] = ((mACRO) & 0x0f) << 4;             \
+    (bITsTRING)->buf[2] = ((mACRO)&0x0f) << 4;               \
     (bITsTRING)->size = 3;                                   \
     (bITsTRING)->bits_unused = 4;                            \
   } while (0)
@@ -399,15 +412,15 @@
  * Identity correspond to the eNB
  * ID (defined in subclause 9.2.1.37).
  */
-#define MACRO_ENB_ID_TO_CELL_IDENTITY(mACRO, cELL_iD, bITsTRING)      \
-  do {                                                                \
-    (bITsTRING)->buf = (uint8_t*)calloc(4, sizeof(uint8_t));          \
-    (bITsTRING)->buf[0] = ((mACRO) >> 12);                            \
-    (bITsTRING)->buf[1] = (mACRO) >> 4;                               \
-    (bITsTRING)->buf[2] = (((mACRO) & 0x0f) << 4) | ((cELL_iD) >> 4); \
-    (bITsTRING)->buf[3] = ((cELL_iD) & 0x0f) << 4;                    \
-    (bITsTRING)->size = 4;                                            \
-    (bITsTRING)->bits_unused = 4;                                     \
+#define MACRO_ENB_ID_TO_CELL_IDENTITY(mACRO, cELL_iD, bITsTRING)    \
+  do {                                                              \
+    (bITsTRING)->buf = (uint8_t*)calloc(4, sizeof(uint8_t));        \
+    (bITsTRING)->buf[0] = ((mACRO) >> 12);                          \
+    (bITsTRING)->buf[1] = (mACRO) >> 4;                             \
+    (bITsTRING)->buf[2] = (((mACRO)&0x0f) << 4) | ((cELL_iD) >> 4); \
+    (bITsTRING)->buf[3] = ((cELL_iD)&0x0f) << 4;                    \
+    (bITsTRING)->size = 4;                                          \
+    (bITsTRING)->bits_unused = 4;                                   \
   } while (0)
 
 /* Used to format an uint32_t containing an ipv4 address */
@@ -727,11 +740,11 @@ void hexa_to_ascii(uint8_t* from, char* to, size_t length);
 
 int ascii_to_hex(uint8_t* dst, const char* h);
 #define UINT8_TO_BINARY_FMT "%c%c%c%c%c%c%c%c"
-#define UINT8_TO_BINARY_ARG(bYtE)                               \
-  ((bYtE) & 0x80 ? '1' : '0'), ((bYtE) & 0x40 ? '1' : '0'),     \
-      ((bYtE) & 0x20 ? '1' : '0'), ((bYtE) & 0x10 ? '1' : '0'), \
-      ((bYtE) & 0x08 ? '1' : '0'), ((bYtE) & 0x04 ? '1' : '0'), \
-      ((bYtE) & 0x02 ? '1' : '0'), ((bYtE) & 0x01 ? '1' : '0')
+#define UINT8_TO_BINARY_ARG(bYtE)                           \
+  ((bYtE)&0x80 ? '1' : '0'), ((bYtE)&0x40 ? '1' : '0'),     \
+      ((bYtE)&0x20 ? '1' : '0'), ((bYtE)&0x10 ? '1' : '0'), \
+      ((bYtE)&0x08 ? '1' : '0'), ((bYtE)&0x04 ? '1' : '0'), \
+      ((bYtE)&0x02 ? '1' : '0'), ((bYtE)&0x01 ? '1' : '0')
 
 int get_time_zone(void);
 #define GUTI_STRING_LEN 21

--- a/lte/gateway/c/core/oai/common/digest.c
+++ b/lte/gateway/c/core/oai/common/digest.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/digest.h
+++ b/lte/gateway/c/core/oai/common/digest.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/enum_string.c
+++ b/lte/gateway/c/core/oai/common/enum_string.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/enum_string.h
+++ b/lte/gateway/c/core/oai/common/enum_string.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/gcc_diag.h
+++ b/lte/gateway/c/core/oai/common/gcc_diag.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/glogwrapper/glog_logging.cpp
+++ b/lte/gateway/c/core/oai/common/glogwrapper/glog_logging.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/glogwrapper/glog_logging.hpp
+++ b/lte/gateway/c/core/oai/common/glogwrapper/glog_logging.hpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/intertask_interface_conf.h
+++ b/lte/gateway/c/core/oai/common/intertask_interface_conf.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/core/oai/common/itti_free_defined_msg.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/common/itti_free_defined_msg.h
+++ b/lte/gateway/c/core/oai/common/itti_free_defined_msg.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/log.c
+++ b/lte/gateway/c/core/oai/common/log.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/log.h
+++ b/lte/gateway/c/core/oai/common/log.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.
@@ -596,4 +609,4 @@ const char* get_short_file_name(const char* const source_file_nameP);
     log_message_prefix_id(OAILOG_LEVEL_INFO, pRoTo, __FILE__, __LINE__, ue_id, \
                           ##__VA_ARGS__);                                      \
   } while (0) /*!< \brief informational */
-#endif /* FILE_LOG_SEEN */
+#endif        /* FILE_LOG_SEEN */

--- a/lte/gateway/c/core/oai/common/mme_default_values.h
+++ b/lte/gateway/c/core/oai/common/mme_default_values.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/pid_file.c
+++ b/lte/gateway/c/core/oai/common/pid_file.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/pid_file.h
+++ b/lte/gateway/c/core/oai/common/pid_file.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/queue.h
+++ b/lte/gateway/c/core/oai/common/queue.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 1991, 1993
  *  The Regents of the University of California.  All rights reserved.
@@ -104,7 +117,8 @@
     struct type* lh_first; /* first element */ \
   }
 
-#define LIST_HEAD_INITIALIZER(head) {NULL}
+#define LIST_HEAD_INITIALIZER(head) \
+  { NULL }
 
 #define LIST_ENTRY(type)                                          \
   struct {                                                        \
@@ -169,7 +183,8 @@
     struct type* slh_first; /* first element */ \
   }
 
-#define SLIST_HEAD_INITIALIZER(head) {NULL}
+#define SLIST_HEAD_INITIALIZER(head) \
+  { NULL }
 
 #define SLIST_ENTRY(type)                     \
   struct {                                    \
@@ -231,7 +246,8 @@
     struct type** stqh_last; /* addr of last next element */ \
   }
 
-#define STAILQ_HEAD_INITIALIZER(head) {NULL, &(head).stqh_first}
+#define STAILQ_HEAD_INITIALIZER(head) \
+  { NULL, &(head).stqh_first }
 
 #define STAILQ_ENTRY(type)                     \
   struct {                                     \
@@ -316,7 +332,8 @@
     struct type** sqh_last; /* addr of last next element */ \
   }
 
-#define SIMPLEQ_HEAD_INITIALIZER(head) {NULL, &(head).sqh_first}
+#define SIMPLEQ_HEAD_INITIALIZER(head) \
+  { NULL, &(head).sqh_first }
 
 #define SIMPLEQ_ENTRY(type)                   \
   struct {                                    \
@@ -392,7 +409,8 @@
   }
 #define TAILQ_HEAD(name, type) _TAILQ_HEAD(name, struct type, )
 
-#define TAILQ_HEAD_INITIALIZER(head) {NULL, &(head).tqh_first}
+#define TAILQ_HEAD_INITIALIZER(head) \
+  { NULL, &(head).tqh_first }
 
 #define _TAILQ_ENTRY(type, qual)                                      \
   struct {                                                            \
@@ -493,7 +511,8 @@
     struct type* cqh_last;  /* last element */  \
   }
 
-#define CIRCLEQ_HEAD_INITIALIZER(head) {(void*)&head, (void*)&head}
+#define CIRCLEQ_HEAD_INITIALIZER(head) \
+  { (void*)&head, (void*)&head }
 
 #define CIRCLEQ_ENTRY(type)                       \
   struct {                                        \

--- a/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
+++ b/lte/gateway/c/core/oai/common/redis_utils/redis_client.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/common/redis_utils/redis_client.hpp
+++ b/lte/gateway/c/core/oai/common/redis_utils/redis_client.hpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/common/rfc_1332.h
+++ b/lte/gateway/c/core/oai/common/rfc_1332.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/rfc_1877.h
+++ b/lte/gateway/c/core/oai/common/rfc_1877.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/security_types.h
+++ b/lte/gateway/c/core/oai/common/security_types.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/shared_ts_log.c
+++ b/lte/gateway/c/core/oai/common/shared_ts_log.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/shared_ts_log.h
+++ b/lte/gateway/c/core/oai/common/shared_ts_log.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright (c) 2015, EURECOM (www.eurecom.fr)
  * All rights reserved.

--- a/lte/gateway/c/core/oai/common/state_converter.cpp
+++ b/lte/gateway/c/core/oai/common/state_converter.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/common/tree.h
+++ b/lte/gateway/c/core/oai/common/tree.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Copyright 2002 Niels Provos <provos@citi.umich.edu>
  * All rights reserved.
@@ -58,7 +71,8 @@
     struct type* sph_root; /* root of the tree */ \
   }
 
-#define SPLAY_INITIALIZER(root) {NULL}
+#define SPLAY_INITIALIZER(root) \
+  { NULL }
 
 #define SPLAY_INIT(root)     \
   do {                       \
@@ -275,7 +289,8 @@
     struct type* rbh_root; /* root of the tree */ \
   }
 
-#define RB_INITIALIZER(root) {NULL}
+#define RB_INITIALIZER(root) \
+  { NULL }
 
 #define RB_INIT(root)        \
   do {                       \


### PR DESCRIPTION
Prepend the standard Magma BSD-3-Clause license header to source files containing legacy copyright information.

Files updated:
- `./core/oai/common/glogwrapper/glog_logging.hpp`
- `./core/oai/common/glogwrapper/glog_logging.cpp`
- `./core/oai/common/common_types.h`
- `./core/oai/common/async_system.h`
- `./core/oai/common/queue.h`
- `./core/oai/common/TLVEncoder.h`
- `./core/oai/common/TLVDecoder.h`
- `./core/oai/common/digest.c`
- `./core/oai/common/conversions.h`
- `./core/oai/common/async_system.c`
- `./core/oai/common/enum_string.h`
- `./core/oai/common/itti_free_defined_msg.c`
- `./core/oai/common/shared_ts_log.h`
- `./core/oai/common/rfc_1332.h`
- `./core/oai/common/log.h`
- `./core/oai/common/shared_ts_log.c`
- `./core/oai/common/itti_free_defined_msg.h`
- `./core/oai/common/gcc_diag.h`
- `./core/oai/common/redis_utils/redis_client.hpp`
- `./core/oai/common/redis_utils/redis_client.cpp`
- `./core/oai/common/conversions.c`
- `./core/oai/common/pid_file.c`
- `./core/oai/common/common_ies.h`
- `./core/oai/common/enum_string.c`
- `./core/oai/common/TLVEncoder.c`
- `./core/oai/common/digest.h`
- `./core/oai/common/asn1_conversions.h`
- `./core/oai/common/rfc_1877.h`
- `./core/oai/common/log.c`
- `./core/oai/common/tree.h`
- `./core/oai/common/intertask_interface_conf.h`
- `./core/oai/common/pid_file.h`
- `./core/oai/common/state_converter.cpp`
- `./core/oai/common/mme_default_values.h`
- `./core/oai/common/security_types.h`
- `./core/oai/common/TLVDecoder.c`

Refs: #15838