### PR TITLE
chore: [6.5] Phase 3 - Add missing magma headers - Batch 4

### DIFF
--- a/lte/gateway/c/core/oai/test/mme_app_task/test_ApnAggregateMaximumBitRate.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_ApnAggregateMaximumBitRate.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_EPSQualityOfService.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_EPSQualityOfService.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_ue_context.cpp
+++ b/lte/gateway/c/core/oai/test/mme_app_task/test_mme_app_ue_context.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/test/nas/test_nas_converter.cpp
+++ b/lte/gateway/c/core/oai/test/nas/test_nas_converter.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/test/ngap/util_ngap_pkt.hpp
+++ b/lte/gateway/c/core/oai/test/ngap/util_ngap_pkt.hpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/test/openflow/openflow_mocks.h
+++ b/lte/gateway/c/core/oai/test/openflow/openflow_mocks.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/test/openflow/test_gtp_app.cpp
+++ b/lte/gateway/c/core/oai/test/openflow/test_gtp_app.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/test/openflow/test_imsi_encoder.cpp
+++ b/lte/gateway/c/core/oai/test/openflow/test_imsi_encoder.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/test/openflow/test_openflow_controller.cpp
+++ b/lte/gateway/c/core/oai/test/openflow/test_openflow_controller.cpp
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Prepend the standard Magma BSD-3-Clause license header to source files containing legacy copyright information.

Files updated:
- `./core/oai/test/mme_app_task/test_mme_app_ue_context.cpp`
- `./core/oai/test/mme_app_task/test_EPSQualityOfService.cpp`
- `./core/oai/test/mme_app_task/test_ApnAggregateMaximumBitRate.cpp`
- `./core/oai/test/nas/test_nas_converter.cpp`
- `./core/oai/test/ngap/util_ngap_pkt.hpp`
- `./core/oai/test/openflow/openflow_mocks.h`
- `./core/oai/test/openflow/test_gtp_app.cpp`
- `./core/oai/test/openflow/test_openflow_controller.cpp`
- `./core/oai/test/openflow/test_imsi_encoder.cpp`

Refs: #15838
