### PR TITLE
chore: [6.5] Phase 3 - Add missing magma headers - Batch 7

### DIFF
--- a/lte/gateway/c/core/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/core/oai/oai_mme/oai_mme.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/oai_mme/oai_mme.h
+++ b/lte/gateway/c/core/oai/oai_mme/oai_mme.h
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/lte/gateway/c/core/oai/oai_mme/oai_mme_log.c
+++ b/lte/gateway/c/core/oai/oai_mme/oai_mme_log.c
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Prepend the standard Magma BSD-3-Clause license header to source files containing legacy copyright information.

Files updated:
- `./core/oai/oai_mme/oai_mme.c`
- `./core/oai/oai_mme/oai_mme.h`
- `./core/oai/oai_mme/oai_mme_log.c`

Refs: #15838