### PR TITLE
fix(orc8r): pin ruby gem versions for fluentd to support ruby 2.7

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -12,6 +12,8 @@
 FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
 RUN gem install \
+    multi_json -v 1.15.0 \
+    excon -v 1.2.5 \
     elasticsearch:7.13.0 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \


### PR DESCRIPTION
During the Orchestrator build process, the fluentd container fails because upstream dependencies (multi_json and excon) have updated to require Ruby >= 3.0. Since the base image uses Ruby 2.7, this patch pins those gems to the last compatible versions.

Fixes:

    Pins multi_json to 1.15.0

    Pins excon to 1.2.5

This allows the ./build.py --all command to complete successfully on Ubuntu 20.04 environments.