### PR TITLE
chore(ci): bump wemake-python-styleguide to 0.19.2

### DIFF
--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -270,7 +270,7 @@ jobs:
             ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
             | grep .py$ | xargs)" >> $GITHUB_OUTPUT
       - name: wemake-python-styleguide
-        uses: wemake-services/wemake-python-styleguide@657508a0b169e15faeda641c4d9c7bc2afda484b # pin@0.17.0
+        uses: wemake-services/wemake-python-styleguide@18276e6a10f1645ef69ae82fcf0b88bc5cb1452d # pin@0.19.2
         with:
           reporter: github-pr-review
           path: ${{ steps.py-changes.outputs.py_files_list }}

--- a/lte/gateway/docker/python-precommit/Dockerfile
+++ b/lte/gateway/docker/python-precommit/Dockerfile
@@ -9,14 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.9.10-alpine
+FROM python:3.11.5-alpine
 
 RUN addgroup -S linter && adduser -S -G linter linter
 
-# Installing wemake-python-styleguide==0.17.0 is not
+# Installing wemake-python-styleguide==0.19.1 is not
 # working with a requirements.in file.
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir wemake-python-styleguide==0.17.0 \
+RUN pip install --no-cache-dir wemake-python-styleguide==0.19.1 \
                 add-trailing-comma \
                 isort \
                 autopep8


### PR DESCRIPTION
Fixes #15473

This updates the wemake-python-styleguide action and local dockerfile from the obsolete 0.17.0 to 0.19.2 to resolve the CI pipeline crashes caused by a broken reviewdog installation script in the old image.