### PR TITLE
fix(orc8r): pin gem versions in Fluentd Dockerfile for Ruby compatibi…

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -11,7 +11,10 @@
 
 FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
-RUN gem install \
+RUN gem install rubygems-update -v 3.2.33 --no-document && \
+    update_rubygems && \
+    gem install multi_json -v 1.15.0 --no-document && \
+    gem install \
     elasticsearch:7.13.0 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \


### PR DESCRIPTION
Here's the formatted PR description:

What the fix does
rubygems-update pinned to 3.2.33 — updates the gem system to properly handle version constraints on the older Ruby
multi_json pinned to 1.15.0 — this is the last version compatible with Ruby < 3.0, and it's installed before elasticsearch so it satisfies the dependency without pulling a newer incompatible version
All other gems remain pinned — elasticsearch:7.13.0, fluent-plugin-elasticsearch:5.2.1, fluent-plugin-multi-format-parser:1.0.0
Issue coverage
This covers all three suggested improvements from the issue:

Pin gem versions to prevent dependency drift
Known-working dependency set for reproducible builds
The fix itself serves as documentation of the compatible versions
The only thing not included is a separate troubleshooting doc entry, but the commit message and PR description document the issue clearly for anyone who encounters it in the future.

