### PR TITLE
fix(agw): Fix is_default boolean parsing in subscriber_cli

### DIFF
--- a/lte/gateway/python/scripts/subscriber_cli.py
+++ b/lte/gateway/python/scripts/subscriber_cli.py
@@ -249,7 +249,7 @@ def update_subscriber(client, args):
             apn_config.ambr.max_bandwidth_dl = int(apn_dict[dl])
             apn_config.pdn = int(apn_dict[pdn_type])
             apn_config.assigned_static_ip = apn_dict[static_ip]
-            apn_config.is_default = apn_dict[is_default]
+            apn_config.is_default = str(apn_dict[is_default]).strip().lower() == "true"
 
             if apn_dict[vlan_id]:
                 apn_config.resource.vlan_id = int(apn_dict[vlan_id])


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fix boolean parsing for the `is_default` APN configuration field in `subscriber_cli.py`

Previously, the CLI passed `is_default` as a string (`"true"`/`"false"`), which caused a protobuf type mismatch when assigning directly to `apn_config.is_default`.

This change converts the CLI argument into a proper boolean before assignment.

## Test Plan

Reproduced the issue using:

```bash
docker exec magmad subscriber_cli.py update IMSI001011000000006 --apn-config internet,9,15,0,0,1300000000,1300000000,0,,,,,true 
```

Before fix:

Command failed with:

`TypeError: 'true' has type str, but expected one of: int, bool`

After fix:

Command completes successfully
is_default is correctly stored as boolean true

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

closes  #15751
