### PR TITLE
docs(lte): fix typo in integrated_5g_sa.md

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5g_sa.md
+++ b/docs/docusaurus/versioned_docs/version-1.7.0/lte/integrated_5g_sa.md
@@ -90,7 +90,7 @@ sequenceDiagram
     SESSIOND->>MME(AMF): SetSmfSessionContext
     MME(AMF)->>RAN: Initial ContextSetup Request
     RAN->>UE/CPE: Service Request Accept
-    RAN->>MME(AMF): IntialContextSetup Response
+    RAN->>MME(AMF): InitialContextSetup Response
 ```
 
 Paging procedure call flow

--- a/docs/readmes/lte/integrated_5g_sa.md
+++ b/docs/readmes/lte/integrated_5g_sa.md
@@ -89,7 +89,7 @@ sequenceDiagram
     SESSIOND->>MME(AMF): SetSmfSessionContext
     MME(AMF)->>RAN: Initial ContextSetup Request
     RAN->>UE/CPE: Service Request Accept
-    RAN->>MME(AMF): IntialContextSetup Response
+    RAN->>MME(AMF): InitialContextSetup Response
 ```
 
 Paging procedure call flow


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(orc8r): Fix reindexer race condition" or "feat(agw) ..."
-->

## Summary

Fix a typo in `integrated_5g_sa.md` documentation.

## Test Plan

- Verified the typo correction renders properly in the markdown file
- Confirmed no other documentation content was affected

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

None. This change only updates documentation text.
