### PR TITLE
fix(lte): replace bare except clauses in state_cli with specific exception types

### DIFF
--- a/lte/gateway/python/scripts/state_cli.py
+++ b/lte/gateway/python/scripts/state_cli.py
@@ -69,10 +69,10 @@ def _deserialize_generic_json(
         # try to deserialize as json string
         try:
             element = ast.literal_eval(element)
-        except:
+        except (ValueError, SyntaxError):
             try:
                 element = jsonpickle.decode(element)
-            except:
+            except Exception:
                 return element
 
     if isinstance(element, dict):


### PR DESCRIPTION
## Summary

- Replace two bare `except:` blocks in `_deserialize_generic_json()` with specific exception types
- `ast.literal_eval()` raises `ValueError` or `SyntaxError` on malformed input — catch those specifically instead of all exceptions
- `jsonpickle.decode()` can raise various errors — use `except Exception:` as a minimum to avoid swallowing `KeyboardInterrupt` and `SystemExit`

## Motivation

Bare `except:` is a well-known Python anti-pattern. It silently catches system-level signals (`KeyboardInterrupt`, `SystemExit`, `GeneratorExit`) that should propagate, making the process impossible to interrupt cleanly and masking unexpected errors from callers.

## Changes

**File:** `lte/gateway/python/scripts/state_cli.py`

```python
# Before
except:

# After (first block)
except (ValueError, SyntaxError):

# After (second block)
except Exception:
```

## Test plan

- [ ] Verify `state_cli.py` still deserializes valid JSON strings correctly
- [ ] Verify it returns raw string when both decoders fail
- [ ] `python3 -c "from magma.scripts import state_cli"` imports without error

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)