### PR TITLE
fix(orc8r): pin ruby gems for fluentd to support ruby 2.7.5

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -11,7 +11,9 @@
 
 FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
-RUN gem install \
+RUN gem install multi_json -v 1.15.0 --no-document && \
+    gem install excon -v 1.2.5 --no-document && \
+    gem install \
     elasticsearch:7.13.0 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \


### PR DESCRIPTION
This PR fixes a build failure in the fluentd container caused by incompatible transitive dependencies (multi_json and excon) which now require Ruby >= 3.1.0, while the base fluentd image uses Ruby 2.7.5.