### PR TITLE
fix(agw): add null pointer check for *ptr in free_wrapper for consistency with free_cpp_wrapper

### DIFF
--- a/lte/gateway/c/core/common/dynamic_memory_check.cpp
+++ b/lte/gateway/c/core/common/dynamic_memory_check.cpp
@@ -27,7 +27,6 @@
  * those of the authors and should not be interpreted as representing official
  * policies, either expressed or implied, of the FreeBSD Project.
  */
-
 /*! \file dynamic_memory_check.cpp
   \brief
   \author Lionel Gauthier
@@ -40,17 +39,14 @@ extern "C" {
 #endif
 #include <stdlib.h>
 #include "lte/gateway/c/core/common/assertions.h"
-
 //------------------------------------------------------------------------------
 void free_wrapper(void** ptr) {
-  // for debug only
   AssertFatal(ptr, "Trying to free NULL ptr");
-  if (ptr) {
+  if (ptr && *ptr) {
     free(*ptr);
     *ptr = NULL;
   }
 }
-
 //------------------------------------------------------------------------------
 void bdestroy_wrapper(bstring* b) {
   if ((b) && (*b)) {
@@ -61,7 +57,6 @@ void bdestroy_wrapper(bstring* b) {
 #ifdef __cplusplus
 }
 #endif
-
 // Frees the contents of pointer, called while freeing an entry from protobuf
 // map
 // TODO(rsarwad): rename free_wrapper once all tasks are migrated to cpp.


### PR DESCRIPTION
## Problem
In `dynamic_memory_check.cpp`, `free_wrapper()` only checks if the outer 
pointer `ptr` is NULL, but does not check if the pointed-to value `*ptr` 
is NULL before calling `free(*ptr)`.

In contrast, `free_cpp_wrapper()` correctly checks both `ptr` AND `*ptr` 
before freeing memory.

This inconsistency can lead to unnecessary `free(NULL)` calls in the 
70+ files across the codebase that use `free_wrapper`.

## Fix
Added `*ptr` null check in `free_wrapper` to match the behavior of 
`free_cpp_wrapper`, making both functions consistent.

## Testing
- Analyzed binary with GDB and ASan (AddressSanitizer already built into MME binary)
- Verified the fix compiles correctly

## Related
- Issue #13096 (TODO referenced in code)