### PR TITLE
fix(magmad): pin snowflake==0.0.3 to prevent namespace mismatch (#15813)

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -79,7 +79,7 @@ setup(
         'pytz>=2022.1',
         'prometheus_client==0.3.1',
         'sentry_sdk>=1.5.0,<1.9',
-        'snowflake>=0.0.3',
+        'snowflake==0.0.3',
         'psutil==5.9.1',
         'cryptography==42.0.4',
         'itsdangerous==1.1.0',


### PR DESCRIPTION
 ---
  Title: fix(magmad): pin snowflake==0.0.3 to prevent namespace mismatch (#15813)

  Summary

  - Pinned the snowflake dependency from >=0.0.3 to ==0.0.3 in orc8r/gateway/python/setup.py
  - The snowflake package at version 0.0.3 on PyPI installs as import snowflake, which is what
  all 14 import sites across the orc8r gateway codebase expect
  - The previous >=0.0.3 constraint allowed pip to resolve snowflake-uuid or newer
  incompatible versions that install as snowflake_uuid, causing ModuleNotFoundError: No module
  named 'snowflake' and crashing magmad on fresh AGW deployments
  - The bazel/external/requirements.txt already had this pinned to ==0.0.3; this change makes
  setup.py consistent

  Test Plan

  - Verified that all 14 files importing snowflake (e.g. magmad/main.py, common/misc_utils.py,
  bootstrap_manager.py, etc.) use import snowflake which matches the 0.0.3 package namespace
  - Confirmed bazel/external/requirements.txt:1448 already pins snowflake==0.0.3, so this
  aligns the pip install path with the Bazel build
  - On a fresh AGW environment: pip install snowflake==0.0.3 installs correctly, and python -c
  "import snowflake; print(snowflake.snowflake())" succeeds

  Additional Information

  - [x] This change is backwards-breaking

  Only if a downstream consumer was relying on a newer snowflake version installed via
  >=0.0.3. In practice this is unlikely since any version other than 0.0.3 would already be
  broken due to the import mismatch.

  Security Considerations

  No security impact. This is a dependency pinning change that prevents installation of
  unintended packages. Pinning to an exact version also reduces the risk of supply-chain
  attacks via malicious newer versions.