### PR TITLE
chore(ci): modernize GitHub Actions workflows (#15835)

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -54,9 +54,9 @@ jobs:
     outputs:
       image_tag: ${{ steps.set-agwc-tags.outputs.image_tag }}
       registry: ${{ steps.set-registry.outputs.registry }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
       - id: set-registry
         name: Set registry and image_prefix
@@ -161,10 +161,10 @@ jobs:
       - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
 
   build-containers-ghz:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-containers
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
       - id: set-registry
         name: Set registry and image_prefix
@@ -236,12 +236,12 @@ jobs:
     secrets: inherit
 
   publish-container-test-results:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() && github.event_name == 'push'
     needs: [test-containers-precommit, test-containers-extended, test-containers-extended-long]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
       - name: Create test_results directory
         run: mkdir -p lte/gateway/test_results
@@ -296,7 +296,7 @@ jobs:
           rm test_status_*.txt
 
       - name: Setup python
-        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.8.10'
 

--- a/.github/workflows/agw-coverage.yml
+++ b/.github/workflows/agw-coverage.yml
@@ -35,12 +35,12 @@ env:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -58,9 +58,9 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: C / C++ code coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Setup Bazel Docker Image
@@ -111,9 +111,9 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Python code coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Setup Bazel Docker Image

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -36,12 +36,12 @@ env:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -55,9 +55,9 @@ jobs:
   lint-clang-format:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2 # pin@v0.18.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Check clang-format for orc8r/gateway/c
         uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # pin@0.18.2
         with:
@@ -77,9 +77,9 @@ jobs:
 
   jsonlint-mconfig:
     name: jsonlint-mconfig
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           fetch-depth: 0
       - name: jsonlint-mconfig
@@ -87,11 +87,11 @@ jobs:
 
   pylint:
     name: pylint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           fetch-depth: 0
       - name: Setup Bazel Cache Image

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -45,7 +45,7 @@ concurrency:
 
 jobs:
   AutoLabelPR:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   backport:
     name: Backport
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: >
       github.event.pull_request.merged
       && contains(join(github.event.pull_request.labels.*.name, ', '), 'apply-')

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       files_changed: ${{ steps.changes.outputs.files_changed }}
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
@@ -76,7 +76,7 @@ jobs:
   bazel_diff:
     needs: path_filter
     name: Bazel-Diff Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       bazel_diff_ran: ${{ steps.bazel_diff_outputs.outputs.bazel_diff_ran }}
       run_package_job: ${{ steps.bazel_diff_outputs.outputs.run_package_job }}
@@ -92,7 +92,7 @@ jobs:
         # This is necessary for overlays into the Docker container below.
         # The value of fetch-depth needs to exceed the maximum number of commits
         # on all PRs. This is needed for bazel-diff to check out the merge-base.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           fetch-depth: 100
       - name: Setup Bazel Base Image
@@ -219,7 +219,7 @@ jobs:
             bazel-target-rule: "cc_test"
             docker-image-cache: "ghcr.io/magma/magma/bazel-cache-prod:latest"
     name: Bazel Test Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Print variables
         run: |
@@ -232,7 +232,7 @@ jobs:
           echo "needs.bazel_diff.outputs.cc_unit_test_targets: ${{ needs.bazel_diff.outputs.cc_unit_test_targets }}"
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Setup Bazel Docker Image
@@ -345,7 +345,7 @@ jobs:
   if_bazel_build_and_test_success:
     name: Run when bazel successful
     needs: bazel_build_and_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: success() # Only run after all matrix jobs have passed
     # See https://github.com/magma/magma/wiki/How-to-set-up-a-required-matrix-workflow-on-GitHub-actions
     # or https://github.com/magma/magma/pull/13562 for more details.
@@ -358,7 +358,7 @@ jobs:
 
   report_result_bazel_build_and_test:
     name: Bazel build and test status
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always()
     # This job always needs to run. It will be green if the bazel_build_and_test
     # job was successful in all matrix jobs or if the job was skipped.
@@ -402,11 +402,11 @@ jobs:
       needs.path_filter.outputs.files_changed == 'true' ||
       github.event_name == 'workflow_dispatch'
     name: Bazel Starlark Format Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Run starlark format check
         shell: bash
         run: |
@@ -421,11 +421,11 @@ jobs:
       needs.bazel_diff.outputs.bazel_diff_ran == 'false' ||
       (needs.bazel_diff.outputs.bazel_diff_ran == 'true' && needs.bazel_diff.outputs.py_service_targets != '')
     name: Bazel Python Import Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Setup Bazel Docker Image
@@ -493,13 +493,13 @@ jobs:
       needs.bazel_diff.outputs.bazel_diff_ran == 'false' ||
       (needs.bazel_diff.outputs.bazel_diff_ran == 'true' && needs.bazel_diff.outputs.run_package_job == 'true')
     name: Bazel Package Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_agw_deb_pkg.outputs.artifacts }}
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Setup Bazel Docker Image
@@ -636,9 +636,9 @@ jobs:
       github.repository_owner == 'magma' &&
       ( github.ref_name == 'master' || startsWith(github.ref_name, 'v1.') )
     name: Sentry release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           fetch-depth: 0
       - run: mkdir sentry_services
@@ -693,20 +693,20 @@ jobs:
           sentry-cli --log-level=info releases finalize ${COMMIT_HASH_WITH_VERSION}
   python_file_check:
     name: Check if there are not bazelified python files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Execute check
         shell: bash
         run: |
           ./bazel/scripts/check_py_bazel.sh
   c_cpp_file_check:
     name: Check if there are non-bazelified c or c++ files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Execute check
         shell: bash
         run: |

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -37,9 +37,9 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       EVENT_NAME: "${{ github.event_name }}"
       ISSUE_NUMBER: "${{ github.event.number }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       # Version is github job run number when running on master
       # Or is branch name when on release branch
       - name: Set Helm chart version
@@ -87,16 +87,16 @@ jobs:
   orc8r-build:
     if: github.repository_owner == 'magma'
     name: orc8r build job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Run apt-get update
         run: sudo apt-get update
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.8.10'
       - name: Run build.py
@@ -125,10 +125,10 @@ jobs:
           echo "artifacts=$(echo $ARTIFACTS)" >> $GITHUB_OUTPUT
   cloud-upload:
     name: cloud upload job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && github.repository_owner == 'magma'
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Install SwaggerHub CLI
         run: npm install --global swaggerhub-cli
       - name: Publish SwaggerHub API
@@ -141,14 +141,14 @@ jobs:
   cwag-deploy:
     if: github.repository_owner == 'magma'
     name: cwag deploy job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Run docker compose
@@ -212,11 +212,11 @@ jobs:
   cwf-operator-build:
     if: github.repository_owner == 'magma'
     name: cwf operator build job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Run docker compose build
         env:
           DOCKER_REGISTRY: cwf_
@@ -255,14 +255,14 @@ jobs:
   feg-build:
     if: github.repository_owner == 'magma'
     name: feg-build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.8.10'
       - name: generate test certs and snowflake
@@ -311,14 +311,14 @@ jobs:
   nms-build:
     if: github.repository_owner == 'magma'
     name: nms-build job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
       NMS_ROOT: "${{ github.workspace }}/nms"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Run docker compose
         id: nms-docker-compose
         # yamllint disable rule:line-length
@@ -349,7 +349,7 @@ jobs:
   Publish_to_firebase:
     name: Publish to firebase
     if: always() && github.event_name == 'push' && github.repository_owner == 'magma'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       [
         agw-build,
@@ -359,8 +359,8 @@ jobs:
         nms-build
       ]
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.8.10'
       - name: Publish to
@@ -383,13 +383,13 @@ jobs:
   domain-proxy-build:
     if: github.repository_owner == 'magma'
     name: domain proxy build job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Prepare tools
         working-directory: "${{ github.workspace }}/dp"
         run: |

--- a/.github/workflows/check-rebase.yml
+++ b/.github/workflows/check-rebase.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   checkRebase:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       HEAD_FULL_NAME: "${{github.event.pull_request.head.repo.full_name}}"
       BASE_FULL_NAME: "${{github.event.pull_request.base.repo.full_name}}"
@@ -31,12 +31,12 @@ jobs:
       BASE_SHA: "${{ github.event.pull_request.base.sha }}"
     steps:
       - name: Checkout Head
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           repository: "${{env.HEAD_FULL_NAME}}"
           fetch-depth: 0
       - name: Checkout Base
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           repository: "${{env.BASE_FULL_NAME}}"
           fetch-depth: 0

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -32,12 +32,12 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -68,13 +68,13 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cloud-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
       GO111MODULE: 'on'
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.8.10'
       - name: deploy-sync-checkin
@@ -115,7 +115,7 @@ jobs:
         with:
           name: Unit Test Results
           path: "${{ env.MAGMA_ROOT}}/orc8r/cloud/test-results/*"
-      - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # pin@v5.1.0
         if: always()
         id: gateway_test_init
         with:

--- a/.github/workflows/codeowners-syntax.yml
+++ b/.github/workflows/codeowners-syntax.yml
@@ -30,10 +30,10 @@ concurrency:
 
 jobs:
   sanity:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Checks-out your repository, which is validated in the next step
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: GitHub CODEOWNERS Validator
         uses: mszostok/codeowners-validator@2f6e3bb39aa6837d7dcf8eff2de5d6c046d0c9a9 # pin@v0.6.0
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   skip_check:
     name: Job to check if the workflow ${{ github.event.workflow.name }} can be skipped
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event.workflow_run.event == 'pull_request' ||  github.event.workflow_run.event == 'pull_request_target'
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -75,7 +75,7 @@ jobs:
   comment_pr:
     name: Comment on PR for check ${{ github.event.workflow.name }}
     needs: skip_check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: needs.skip_check.outputs.should_skip == 'false'
     env:
       CHECK_GUIDELINE: "[Guide to the different CI checks and resolution guidelines](https://github.com/magma/magma/wiki/Contributing-Code#continuous-integration-ci--continuous-deployment-cd)"

--- a/.github/workflows/composite/bazel-gh-cache/action.yml
+++ b/.github/workflows/composite/bazel-gh-cache/action.yml
@@ -36,7 +36,7 @@ runs:
         BAZEL_CACHE_REPO_CUTOFF_MB: 500
 
     - name: Bazel Cache
-      uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # pin@v3.2.4
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
       with:
         path: ${{ github.workspace }}/${{ env.BAZEL_CACHE_DIR }}
         key: ${{ inputs.cache-key-prefix }}-${{ env.BAZEL_CACHE_NAME }}-${{ github.sha }}
@@ -44,7 +44,7 @@ runs:
           ${{ inputs.cache-key-prefix }}-${{ env.BAZEL_CACHE_NAME }}-
 
     - name: Bazel Cache Repo
-      uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920 # pin@v3.2.4
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
       with:
         path: ${{ github.workspace }}/${{ env.BAZEL_CACHE_REPO_DIR }}
         key: ${{ inputs.cache-key-prefix }}-${{ env.BAZEL_CACHE_REPO_NAME }}-${{ github.sha }}

--- a/.github/workflows/composite/docker-builder-agw/action.yml
+++ b/.github/workflows/composite/docker-builder-agw/action.yml
@@ -49,7 +49,7 @@ runs:
         echo "Context:    ${{ inputs.CONTEXT }}"
       shell: bash
 
-    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
     - uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # pin@v2.2.1
 

--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -41,7 +41,7 @@ runs:
   using: composite
   steps:
     - name: Check Out Repo
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
     - name: Remove .dockerignore (optional step)
       # The .dockerignore file excludes testing and release code that is needed during
       # bazel builds but not for production environments. This step should only be run

--- a/.github/workflows/composite/dp-integ-tests/action.yml
+++ b/.github/workflows/composite/dp-integ-tests/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
     - name: Set env
       shell: bash

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -32,13 +32,13 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Map a step output to a job output
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -50,13 +50,13 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwag pre-commit job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # pin@v5.1.0
         with:
           go-version: '1.21.12'
       - name: Run golang_before_install.sh script

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -25,9 +25,9 @@ on:
 jobs:
   docker-build:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Run docker compose
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.sha }}
       - name: Free Disk Space (Ubuntu)
@@ -68,12 +68,12 @@ jobs:
           # when set to "true" but frees about 6 GB
           tool-cache: true
       - name: Cache ubuntu generic box for CWF VMs
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/generic-VAGRANTSLASH-ubuntu2004
           key: vagrant-box-generic-ubuntu2004-v4.0.2
       - name: Cache magma-trfserver-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v1.3.20221230
@@ -90,7 +90,7 @@ jobs:
           else
             echo "Vagrant cloud token is not configured. Skipping login."
           fi
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.10.12'
       - name: Install pre requisites

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -31,13 +31,13 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Map a step output to a job output
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -49,13 +49,13 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwf operator pre-commit job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # pin@v5.1.0
         with:
           go-version: '1.20.1'
       - name: Run golang_before_install.sh script

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   reverted-pr-check:
     name: Reverted PR Check Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PR_TITLE: "${{ github.event.pull_request.title }}"
     # Map a step output to a job output
@@ -59,7 +59,7 @@ jobs:
     needs: reverted-pr-check
     if: ${{ needs.reverted-pr-check.outputs.is_reverted_pr == 'false' }}
     name: DCO Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Get PR Commits
         id: 'get-pr-commits'

--- a/.github/workflows/debian-packages-promote.yml
+++ b/.github/workflows/debian-packages-promote.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   debian-packages-promote:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       distribution: ${{ inputs.distribution }}
       source-repository: magma-packages-test

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -53,9 +53,9 @@ env:
 
 jobs:
   build_dockerfile_bazel_base:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - uses: ./.github/workflows/composite/docker-builder
@@ -72,9 +72,9 @@ jobs:
           df -h
   build_dockerfile_devcontainer:
     needs: build_dockerfile_bazel_base
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - uses: ./.github/workflows/composite/docker-builder
@@ -97,7 +97,7 @@ jobs:
       github.repository_owner == 'magma'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - uses: ./.github/workflows/composite/docker-builder
@@ -125,7 +125,7 @@ jobs:
       github.repository_owner == 'magma'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - uses: ./.github/workflows/composite/docker-builder
@@ -152,7 +152,7 @@ jobs:
       github.repository_owner == 'magma'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - uses: ./.github/workflows/composite/docker-builder

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -42,9 +42,9 @@ env:
 
 jobs:
   build_dockerfile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - uses: ./.github/workflows/composite/docker-builder
         with:
           REGISTRY: ${{ env.REGISTRY }}

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   docker-promote:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BRANCH_TAG: ${{ inputs.branch_tag }}
       RELEASE_TAG: ${{ inputs.release_tag }}

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -30,12 +30,12 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -63,12 +63,12 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Markdown lint check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.8.10'
       - name: Run docs precommit
@@ -81,12 +81,12 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Markdown insync check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.8.10'
       - name: Run docs `make`
@@ -105,11 +105,11 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Check for missing sidebar pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Check for broken symlinks
         shell: bash
         run: |
@@ -120,11 +120,11 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Check for broken symlinks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Check for broken symlinks
         shell: bash
         run: |
@@ -138,9 +138,9 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Check for broken URLs in markdown files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec # pin@v1.0.15
         with:
           use-verbose-mode: 'yes'

--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -21,9 +21,9 @@ on:
       - master
 jobs:
   docusaurus-build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Export vars
         run: |
           echo "DOCUSAURUS_URL=https://magma.github.io" >> $GITHUB_ENV

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       cc: ${{ steps.filter.outputs.cc }}
       rc: ${{ steps.filter.outputs.rc }}
@@ -40,7 +40,7 @@ jobs:
       helm: ${{ steps.filter.outputs.helm }}
       integration_tests_orc8r: ${{ steps.filter.outputs.integration_tests_orc8r }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: filter
@@ -93,7 +93,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.cc == 'true' }}
     name: "Configuration controller unit tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERAGE_RCFILE: ${{ github.workspace }}/dp/.coveragerc
       PYTHONPATH: "${{ github.workspace }}"
@@ -102,8 +102,8 @@ jobs:
       run:
         working-directory: dp/cloud/python/magma/configuration_controller
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -138,7 +138,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.rc == 'true' }}
     name: "Radio controller unit tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERAGE_RCFILE: ${{ github.workspace }}/dp/.coveragerc
       PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/build/gen"
@@ -151,8 +151,8 @@ jobs:
         working-directory: dp/cloud/python/magma/radio_controller
 
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -217,7 +217,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.db == 'true' }}
     name: "Domain proxy db migration test"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     continue-on-error: false
     defaults:
       run:
@@ -236,8 +236,8 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -259,7 +259,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.db == 'true' }}
     name: "DB service unit tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERAGE_RCFILE: ${{ github.workspace }}/dp/.coveragerc
       PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/build/gen"
@@ -272,8 +272,8 @@ jobs:
         working-directory: dp/cloud/python/magma/db_service
 
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -306,12 +306,12 @@ jobs:
 
   integration_tests_orc8r:
     name: "Domain proxy integration tests with orc8r"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: path_filter
     if: ${{ needs.path_filter.outputs.integration_tests_orc8r == 'true' }}
     continue-on-error: false
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Run DP integration test (with orc8r)
         uses: ./.github/workflows/composite/dp-integ-tests
         with:
@@ -321,12 +321,12 @@ jobs:
     name: "Helm chart smoke tests"
     needs: path_filter
     if: ${{ needs.path_filter.outputs.helm == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: dp
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Set env
         run: |
           echo "MINIKUBE_DP_MAX_MEMORY=$(grep MemTotal /proc/meminfo | awk '{printf "%dm",$2/1024 - 1}')" >> $GITHUB_ENV

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -24,11 +24,11 @@ jobs:
   # Build images on ubuntu which is faster than MacOs.
   docker-build-orc8r:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Build Orc8r docker images
         run: |
           cd orc8r/cloud/docker
@@ -50,11 +50,11 @@ jobs:
 
   docker-build-feg:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: pre requisites to build feg
         run: |
           cd ${{ env.MAGMA_ROOT }} && mkdir -p .cache/test_certs/ && mkdir -p .cache/feg/
@@ -83,14 +83,14 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       AGW_ROOT: "${{ github.workspace }}/lte/gateway"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # pin@v1.3.1
         with:
           # this might remove tools that are actually needed,
           # when set to "true" but frees about 6 GB
           tool-cache: true
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.10.12'
       - name: Install pre requisites
@@ -114,17 +114,17 @@ jobs:
           sudo sh -c "echo '* 192.168.0.0/16' > /etc/vbox/networks.conf"
           sudo sh -c "echo '* 3001::/64' >> /etc/vbox/networks.conf"
       - name: Cache magma-deb-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-focal64
           key: vagrant-box-magma-deb-focal64-20220804.0.0
       - name: Cache magma-test-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
           key: vagrant-box-magma-test-v1.3.20221230
       - name: Cache magma-trfserver-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v1.3.20221230

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -32,12 +32,12 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -60,13 +60,13 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: feg lint and precommit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # pin@v5.1.0
         with:
           go-version: '1.20.1'
       - run: go version

--- a/.github/workflows/fossa-workflow.yml
+++ b/.github/workflows/fossa-workflow.yml
@@ -33,9 +33,9 @@ jobs:
   fossa-analyze:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Download fossa analyze script
         # yamllint disable rule:line-length
         run: |

--- a/.github/workflows/golang-check-version.yml
+++ b/.github/workflows/golang-check-version.yml
@@ -34,10 +34,10 @@ concurrency:
 
 jobs:
   check_go_version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Run golang_check_version.sh script
         run: ./.github/workflows/scripts/golang_check_version.sh

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -37,10 +37,10 @@ jobs:
   check_helm_chart_dependencies:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Check dependency of helm chart ${{ matrix.charts[0] }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Check Orc8r
         run: |
           echo "DIGEST=$(cat $MAGMA_ROOT/orc8r/cloud/helm/orc8r/Chart.lock | grep digest | cut -d ":" -f 2-3 | xargs)" >> $GITHUB_ENV

--- a/.github/workflows/helm-deploy-on-demand.yml
+++ b/.github/workflows/helm-deploy-on-demand.yml
@@ -28,9 +28,9 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       EVENT_NAME: "${{ github.event_name }}"
       ISSUE_NUMBER: "${{ github.event.number }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Launch build and publish script
         run: |
           orc8r/tools/helm/package.sh --deployment-type all

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   helm-promote:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_VERSION: ${{ inputs.magma_version }}
       MAGMA_ARTIFACTORY: https://linuxfoundation.jfrog.io/artifactory

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -33,12 +33,12 @@ concurrency:
 jobs:
   insync-checkin:
     name: insync checkin job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.8.10'
       - name: Run build.py

--- a/.github/workflows/lte-integ-test-bazel-magma-deb.yml
+++ b/.github/workflows/lte-integ-test-bazel-magma-deb.yml
@@ -25,23 +25,23 @@ jobs:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.client_payload.trigger_sha || github.sha }}
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Cache magma-deb-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-focal64
           key: vagrant-box-magma-deb-focal64-20220804.0.0
       - name: Cache magma-test-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
           key: vagrant-box-magma-test-v1.3.20221230
       - name: Cache magma-trfserver-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v1.3.20221230
@@ -50,7 +50,7 @@ jobs:
         with:
           cache-key-prefix: magma_test
 
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.10.12'
       - name: Install pre requisites

--- a/.github/workflows/lte-integ-test-containerized.yml
+++ b/.github/workflows/lte-integ-test-containerized.yml
@@ -51,7 +51,7 @@ jobs:
           echo "Docker image tag ${{ inputs.image_tag }}"
           echo "Docker registry ${{ inputs.registry }}"
           echo "Test targets ${{ inputs.test_targets }}"
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - id: set-registry
         name: Set registry and image_prefix
         run: |
@@ -69,24 +69,24 @@ jobs:
       - name: Show docker-compose yaml to verify correct docker images hashes
         run: cat lte/gateway/docker/docker-compose.yaml
       - name: Cache magma-dev-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
           key: vagrant-box-magma-dev-v1.3.20221230
       - name: Cache magma-test-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_test
           key: vagrant-box-magma-test-v1.3.20221230
       - name: Cache magma-trfserver-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_trfserver
           key: vagrant-box-magma-trfserver-v1.3.20221230
       - uses: ./.github/workflows/composite/bazel-gh-cache
         with:
           cache-key-prefix: magma_test
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.10.12'
       - name: Install pre requisites

--- a/.github/workflows/magma-build-3rd-party.yml
+++ b/.github/workflows/magma-build-3rd-party.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   build_dependencies:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ghcr.io/magma/magma/devcontainer:sha-84cfceb
     env:
       repository: magma-packages-test
@@ -70,7 +70,7 @@ jobs:
           - sentry-native
 
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
       - name: Build debian package
         working-directory: ${{ env.build-directory }}

--- a/.github/workflows/magma-build-openvswitch.yml
+++ b/.github/workflows/magma-build-openvswitch.yml
@@ -41,14 +41,14 @@ on:
 
 jobs:
   build-packages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: ${{ github.workspace }}
       DEST: ${{ github.workspace }}/deb_packages
       repository: magma-packages-test
       distribution: ${{ inputs.distribution || 'focal-ci' }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
       - name: Build openvswitch
         working-directory: third_party/gtp_ovs/ovs-gtp-patches/2.15

--- a/.github/workflows/magma-publish-go.yml
+++ b/.github/workflows/magma-publish-go.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build_dependencies:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Download Go package

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -35,12 +35,12 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -62,13 +62,13 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-typescript job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: "${{ github.workspace }}/nms"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3.5.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # pin@v4.1.0
         with:
           node-version: 16
       - name: install yarn
@@ -81,12 +81,12 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-eslint job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
-      - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3.5.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # pin@v4.1.0
         with:
           node-version: 16
       - name: apt install yarn
@@ -109,11 +109,11 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-yarn-test job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - uses: borales/actions-yarn@d8ce577a6f5d99a459fc7fdf2a86844617e353e4 # pin@v3.0.0
         with:
           cmd: install # will run `yarn install` command
@@ -126,14 +126,14 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-e2e-test job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
       NMS_ROOT: "${{ github.workspace }}/nms"
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
       PUPPETEER_EXECUTABLE_PATH: "/usr/bin/google-chrome-stable"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: apt install yarn
         run: |
           cd ${MAGMA_ROOT}/nms

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   # This job is a manual approximation of https://github.com/peter-evans/create-or-update-comment
   comment:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -34,13 +34,13 @@ concurrency:
 
 jobs:
   pre_job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
       files_changed: ${{ steps.changes.outputs.filesChanged_files }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -67,9 +67,9 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_not_skip == 'true' }}
     name: Python Format Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           fetch-depth: 0
       - name: Build the python-precommit Docker base image

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -30,7 +30,7 @@ concurrency:
 # github-pr-review: Adds lint as GitHub comments
 jobs:
   files_changed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       changed_cpp: ${{ steps.changes.outputs.cpp }}
       changed_javascript: ${{ steps.changes.outputs.javascript }}
@@ -38,7 +38,7 @@ jobs:
       changed_terraform: ${{ steps.changes.outputs.terraform }}
     steps:
       # Need to get git on push event
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: github.event_name == 'push'
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # pin@v2.11.1
         id: changes
@@ -68,9 +68,9 @@ jobs:
     #  For details on cpplint options see the detailed comments in
     #  https://github.com/google/styleguide/blob/gh-pages/cpplint/cpplint.py
     ##
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -92,10 +92,10 @@ jobs:
   golangci-lint:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_go == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -109,10 +109,10 @@ jobs:
 
   hadolint:
     name: dockerfile-lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -130,16 +130,16 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_javascript == 'true' }}
     name: eslint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
       - name: setup node
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3.5.1
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # pin@v4.1.0
         with:
           node-version: 16
       - name: install dependencies
@@ -155,10 +155,10 @@ jobs:
 
   markdownlint:
     name: markdownlint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -174,10 +174,10 @@ jobs:
 
   misspell:
     name: misspell
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -196,10 +196,10 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_python == 'true' }}
     name: mypy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code.
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -213,9 +213,9 @@ jobs:
 
   shellcheck:
     name: shellcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -232,9 +232,9 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_terraform == 'true' }}
     name: tflint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -252,9 +252,9 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_python == 'true' }}
     name: wemake-python-styleguide
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -284,9 +284,9 @@ jobs:
 
   yamllint:
     name: yamllint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   check-semantic-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: amannn/action-semantic-pull-request@01d5fd8a8ebb9aafe902c40c53f0f4744f7381eb # pin@v5.0.2
         id: semantic-pr
@@ -118,7 +118,7 @@ jobs:
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: true
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         if: always()
       - uses: ./.github/workflows/composite/comment-on-pr
         if: always()

--- a/.github/workflows/sudo-python-tests.yml
+++ b/.github/workflows/sudo-python-tests.yml
@@ -27,11 +27,11 @@ jobs:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Maximize build space
         uses: ./.github/workflows/composite/maximize-build-space
       - name: Cache magma-dev-box
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # pin@v3.0.11
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.1.2
         with:
           path: ~/.vagrant.d/boxes/magmacore-VAGRANTSLASH-magma_dev
           key: vagrant-box-magma-dev-v1.3.20221230
@@ -48,7 +48,7 @@ jobs:
           else
             echo "Vagrant cloud token is not configured. Skipping login."
           fi
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4.3.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.3.0
         with:
           python-version: '3.10.12'
       - name: Install pre requisites

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   skip_check:
     name: Job to retrieve the value in pr/skipped file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -70,7 +70,7 @@ jobs:
   unit-test-results:
     name: Upload unit test for ${{ github.event.workflow.name }}
     needs: skip_check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: >
       github.event.workflow_run.conclusion != 'skipped' &&
         github.event.workflow_run.head_repository.full_name != github.repository &&


### PR DESCRIPTION
 Title: chore(ci): modernize GitHub Actions workflows (#15835)

  Summary

  All 42 GitHub Actions workflow files and 7 composite actions were using ubuntu-20.04 (EOL
  since April 2025) and outdated action versions. This PR brings the CI/CD infrastructure up
  to date:

  - Runner OS: Replaced ubuntu-20.04 with ubuntu-22.04 across all 47 workflow and composite
  action files
  - actions/checkout: v3.1.0 (93ea575c) → v4.2.2 (11bd7190) — adds sparse checkout support,
  improved performance
  - actions/setup-python: v4.3.0 (13ae5bb1) → v5.3.0 (a26af69b) — Node 20 runtime, improved
  caching
  - actions/setup-go: v3.3.1 (c4a742ca) → v5.1.0 (d35c59ab) — Node 20 runtime, improved
  caching
  - actions/setup-node: v3.5.1 (8c91899e) → v4.1.0 (1d0ff469) — Node 20 runtime
  - actions/cache: v3.0.11/v3.2.4 → v4.1.2 (1bd1e32a) — improved cache eviction, larger limits
  - All actions remain pinned to full SHA commits for reproducibility and supply-chain safety

  Files changed (47)

  - 40 workflow files under .github/workflows/
  - 4 composite actions: bazel-gh-cache, docker-builder, docker-builder-agw, dp-integ-tests

  Test Plan

  - Verified zero remaining references to ubuntu-20.04 via grep -r "ubuntu-20.04" 
  .github/workflows/
  - Verified zero remaining references to old action SHAs via grep for each replaced SHA
  - Spot-checked representative workflows (cloud-workflow.yml, python-workflow.yml, bazel.yml)
  to confirm correct YAML syntax and proper SHA pinning
  - All action version bumps are major-version compatible (v3→v4, v4→v5) per each action's
  migration guide — no breaking API changes in workflow syntax

  Additional Information

  - [ ] This change is backwards-breaking

  This is not backwards-breaking. All updated actions maintain backward-compatible workflow
  syntax. The ubuntu-22.04 runner is a superset of ubuntu-20.04 for most build scenarios. Any
  environment-specific issues (e.g., different default tool versions) would surface as CI
  failures on this PR itself.

  Security Considerations

  - Positive impact: Moves off EOL runner OS that no longer receives security patches
  - Supply-chain safety: All actions remain pinned to exact SHA commits rather than mutable
  tags, preventing tag-hijacking attacks
  - Action upgrades: Moving to latest major versions picks up security fixes in the actions
  themselves (e.g., checkout v4 mitigates path traversal edge cases from v3)