### PR TITLE
fix(bazel): add mirror URL for liblfds to fix SSL cert failure (#15797)

### DIFF
--- a/bazel/cpp_repositories.bzl
+++ b/bazel/cpp_repositories.bzl
@@ -106,7 +106,10 @@ def cpp_repositories():
 
     http_archive(
         name = "liblfds",
-        urls = ["https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip"],
+        urls = [
+            "https://web.archive.org/web/2024/https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip",
+            "https://liblfds.org/downloads/liblfds%20release%207.1.0%20source.zip",
+        ],
         sha256 = "1b1938db2c6928cd8668087effcf4a1211585d24310ab2a82fe446442473c1c4",
         build_file = "//bazel/external:liblfds.BUILD",
     )


### PR DESCRIPTION
Title: fix(bazel): add mirror URL for liblfds to fix SSL cert failure (#15797)

  Summary

  - The liblfds.org domain has an expired/invalid SSL certificate, causing http_archive in
  Bazel to fail when fetching the liblfds release 7.1.0 source.zip dependency
  - This blocks all AGW C/C++ builds (bazel build //lte/gateway/c/core:all) and the
  dev_tools/gen_compilation_database.py script, including inside the official devcontainer
  - Added a Wayback Machine mirror (web.archive.org) as the primary URL in
  bazel/cpp_repositories.bzl, keeping the original liblfds.org URL as a fallback
  - Bazel's http_archive tries URLs in order — if the first succeeds, it skips the rest, so
  builds proceed even while liblfds.org remains down
  - The sha256 checksum is unchanged (1b1938db...), so the archive is verified regardless of
  which URL serves it

  File changed

  - bazel/cpp_repositories.bzl (lines 107-112)

  Test Plan

  - Verified the sha256 hash remains identical — Bazel will reject any content mismatch
  regardless of source
  - Confirmed the Wayback Machine URL pattern
  (https://web.archive.org/web/2024/https://liblfds.org/downloads/...) follows the standard
  archive.org proxy format for cached resources
  - To validate end-to-end: bazel fetch @liblfds//... should now succeed in a clean build
  environment where liblfds.org SSL errors previously blocked the download

  Additional Information

  - [ ] This change is backwards-breaking

  Not backwards-breaking. The fallback URL list is additive — if liblfds.org fixes their
  certificate, it will still work as the secondary URL. No build configuration or downstream
  code changes required.

  Security Considerations

  - SHA256 integrity: The downloaded archive is verified against the pinned sha256 checksum
  regardless of which mirror serves it, so a compromised mirror cannot inject malicious
  content
  - Wayback Machine trust: web.archive.org serves cached copies of the original content over
  HTTPS with valid certificates. It is widely used as a dependency mirror in open-source
  projects
  - No certificate bypass: This fix does not disable SSL verification or add --insecure flags
  — it routes around the expired cert by using a mirror that has valid TLS