### PR TITLE
fix(pipelined): graceful bcc import to prevent startup crash (#15812)

### DIFF
--- a/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
+++ b/lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py
@@ -20,8 +20,12 @@ import struct
 import subprocess
 
 import netifaces
-from bcc import BPF
 from lte.protos.mobilityd_pb2 import IPAddress
+
+try:
+    from bcc import BPF
+except ImportError:
+    BPF = None
 from magma.pipelined.gw_mac_address import get_mac_by_ip4, get_mac_by_ip6
 from magma.pipelined.ifaces import get_mac_address_from_iface
 from magma.pipelined.mobilityd_client import get_mobilityd_gw_info
@@ -46,6 +50,10 @@ DL_CFG_ARRAY_NAME = "cfg_array"
 def get_ebpf_manager(config):
     if 'ebpf' not in config or not config['ebpf']['enabled']:
         LOG.info("eBPF manager: Not initilized")
+        return None
+
+    if BPF is None:
+        LOG.warning("eBPF manager: bcc module not available, skipping eBPF initialization")
         return None
 
     gw_info = get_mobilityd_gw_info()


### PR DESCRIPTION
Title: fix(pipelined): graceful bcc import to prevent startup crash (#15812)

  Summary

  - The pipelined service crashes on startup on fresh Ubuntu 20.04 AGW deployments because
  from bcc import BPF at module level in ebpf_manager.py raises ModuleNotFoundError when the
  BPF Compiler Collection (bcc) Python bindings are not installed
  - This crash happens unconditionally — even when eBPF is disabled in the pipelined config —
  because the import is at the top of the file, which gets executed when service_manager.py:77
  imports get_ebpf_manager
  - The bcc package is also not listed in any requirements.txt or setup.py, so there's no
  install-time guarantee it will be present

  Changes in lte/gateway/python/magma/pipelined/ebpf/ebpf_manager.py:

  1. Wrapped from bcc import BPF in try/except — on ImportError, sets BPF = None instead of
  crashing the entire module load
  2. Added a guard in get_ebpf_manager() — if eBPF is enabled in config but BPF is None, logs
  a warning ("bcc module not available, skipping eBPF initialization") and returns None
  instead of proceeding to construct an EbpfManager that would fail
  3. service_manager.py already handles get_ebpf_manager() returning None (line 534), so no
  changes needed downstream

  Test Plan

  - Without bcc installed: python -c "from magma.pipelined.ebpf.ebpf_manager import 
  get_ebpf_manager" should succeed without error (previously raised ModuleNotFoundError)
  - eBPF disabled in config: get_ebpf_manager({'ebpf': {'enabled': False}}) returns None —
  same behavior as before
  - eBPF enabled but bcc missing: get_ebpf_manager({'ebpf': {'enabled': True}}) logs a warning
  and returns None instead of crashing
  - eBPF enabled and bcc installed: No change in behavior — BPF is imported normally and
  EbpfManager is constructed as before
  - Note: lte/gateway/python/magma/kernsnoopd/snooper.py:17 already has # 
  pylint:disable=import-error on its own from bcc import BPF, confirming the team was aware
  bcc may be absent — this fix applies the same principle with proper runtime handling

  Additional Information

  - [ ] This change is backwards-breaking

  Not backwards-breaking. When bcc is installed, behavior is identical. When bcc is not
  installed, the service now starts successfully (with eBPF disabled) instead of
  crash-looping.

  Security Considerations

  - No privilege escalation: eBPF programs require CAP_BPF/CAP_SYS_ADMIN — this change doesn't
  alter any privilege handling. If bcc is absent, eBPF simply doesn't initialize
  - Fail-open vs fail-closed: This change makes pipelined fail-open (starts without eBPF)
  rather than fail-closed (crash). This is appropriate because eBPF is an optional performance
  optimization for the datapath, not a security control. The OVS-based pipeline continues to
  handle traffic safely without it
  - Logging: The warning log ensures operators are aware that eBPF is configured but not
  functional, preventing silent misconfiguration