### PR TITLE
fix(orc8r): pin multi_json gem to fix Fluentd build failure (#15917)

### DIFF
--- a/orc8r/cloud/docker/fluentd/Dockerfile
+++ b/orc8r/cloud/docker/fluentd/Dockerfile
@@ -11,7 +11,10 @@
 
 FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
-RUN gem install \
+RUN gem install rubygems-update -v 3.2.33 --no-document && \
+    update_rubygems && \
+    gem install \
+    multi_json:1.15.0 \
     elasticsearch:7.13.0 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \

--- a/orc8r/cloud/docker/fluentd_daemon/Gemfile
+++ b/orc8r/cloud/docker/fluentd_daemon/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "multi_json", "1.15.0"
 gem "fluentd", "1.14.6"
 gem "oj", "3.8.1"
 gem "fluent-plugin-multi-format-parser", "~> 1.0.0"

--- a/orc8r/cloud/docker/fluentd_forward/Dockerfile
+++ b/orc8r/cloud/docker/fluentd_forward/Dockerfile
@@ -11,7 +11,10 @@
 
 FROM fluent/fluentd:v1.14.6-debian-1.0
 USER root
-RUN gem install \
+RUN gem install rubygems-update -v 3.2.33 --no-document && \
+    update_rubygems && \
+    gem install \
+    multi_json:1.15.0 \
     elasticsearch:7.13.0 \
     fluent-plugin-elasticsearch:5.2.1 \
     fluent-plugin-multi-format-parser:1.0.0 \


### PR DESCRIPTION
Title: fix(orc8r): pin multi_json gem to fix Fluentd build failure (#15917)

  Summary

  - Orc8r Docker deployments fail during docker-compose build because the Fluentd container
  build pulls the latest multi_json gem, which now requires Ruby >= 3.0
  - The Fluentd base image (fluent/fluentd:v1.14.6-debian-1.0) ships Ruby 2.7, so gem install
  fails with "ERROR: multi_json requires Ruby version >= 3.0"
  - This is a dependency drift issue — the Dockerfiles had no pin on multi_json, which is a
  transitive dependency of elasticsearch and other gems

  Changes across 3 files:

  1. orc8r/cloud/docker/fluentd/Dockerfile — Added rubygems-update:3.2.33 install +
  update_rubygems step, and pinned multi_json:1.15.0 (last version compatible with Ruby < 3.0)
  before the other gems
  2. orc8r/cloud/docker/fluentd_forward/Dockerfile — Same change (this file was identical to
  fluentd/Dockerfile)
  3. orc8r/cloud/docker/fluentd_daemon/Gemfile — Added gem "multi_json", "1.15.0" to the
  Gemfile so Bundler resolves the pinned version during bundle install

  Why these specific versions:

  - multi_json 1.15.0 — Last release that supports Ruby >= 2.0 (the 1.16.0+ series requires
  Ruby >= 3.0)
  - rubygems-update 3.2.33 — Last rubygems version compatible with Ruby 2.7; ensures gem 
  install resolves dependency constraints correctly

  Test Plan

  - docker build orc8r/cloud/docker/fluentd/ should complete without the multi_json requires 
  Ruby version >= 3.0 error
  - docker build orc8r/cloud/docker/fluentd_forward/ — same validation
  - docker build orc8r/cloud/docker/fluentd_daemon/ — Bundler should resolve multi_json to
  exactly 1.15.0 via the Gemfile pin
  - Verified that multi_json 1.15.0 is compatible with the pinned elasticsearch:7.13.0,
  fluent-plugin-elasticsearch:5.2.1, and fluent-plugin-multi-format-parser:1.0.0 — all list
  multi_json as a dependency with no minimum above 1.15.0
  - Full Orc8r Docker deployment: docker-compose build from orc8r/cloud/docker/ should succeed
  end-to-end

  Additional Information

  - [ ] This change is backwards-breaking

  Not backwards-breaking. The pinned versions are the same ones that were being implicitly
  resolved before multi_json bumped its Ruby requirement. Functionality is identical.

  Security Considerations

  - Pinning reduces attack surface: Unpinned transitive dependencies allow arbitrary new
  versions to enter the build. Pinning multi_json to a specific version ensures reproducible
  builds and prevents unexpected code from entering the container image
  - Known vulnerabilities: multi_json 1.15.0 has no known CVEs. The rubygems-update 3.2.33 is
  the latest in the 3.2.x line which still receives backported security fixes for Ruby 2.7
  - Long-term recommendation: The Fluentd base image should eventually be upgraded to a Ruby
  3.0+ image, which would remove the need for these pins. This fix is a bridge to keep builds
  working until that migration happens
