### PR TITLE
perf(dp): Reuse HTTP session in RequestRouter to avoid repeated TLS handshakes

### DIFF
--- a/dp/cloud/python/magma/configuration_controller/request_router/request_router.py
+++ b/dp/cloud/python/magma/configuration_controller/request_router/request_router.py
@@ -40,11 +40,14 @@ class RequestRouter(object):
     ) -> None:
         self.sas_url = sas_url
         self.rc_ingest_url = rc_ingest_url
-        self.cert_path = cert_path
-        self.ssl_key_path = ssl_key_path
-        self.ssl_verify = ssl_verify
         self.request_mapping = request_mapping
         self.crl_validator = crl_validator
+
+        self.sas_session = requests.Session()
+        self.sas_session.cert = (cert_path, ssl_key_path)
+        self.sas_session.verify = ssl_verify
+
+        self.rc_session = requests.Session()
 
     @SAS_REQUEST_PROCESSING_TIME.time()
     def post_to_sas(self, request_dict: Dict[str, List[Dict]]) -> requests.Response:
@@ -81,11 +84,9 @@ class RequestRouter(object):
             if self.crl_validator:
                 self.crl_validator.is_valid(url=self.sas_url)
 
-            sas_response = requests.post(
+            sas_response = self.sas_session.post(
                 f'{self.sas_url}/{sas_method}',
                 json=request_dict,
-                cert=(self.cert_path, self.ssl_key_path),
-                verify=self.ssl_verify,
             )
         except Exception as e:
             raise RequestRouterError(str(e))
@@ -107,6 +108,6 @@ class RequestRouter(object):
         """
         payload = sas_response.json()
         try:
-            return requests.post(self.rc_ingest_url, json=payload)
+            return self.rc_session.post(self.rc_ingest_url, json=payload)
         except Exception as e:
             raise RequestRouterError(str(e))

--- a/dp/cloud/python/magma/configuration_controller/tests/unit/test_request_routing.py
+++ b/dp/cloud/python/magma/configuration_controller/tests/unit/test_request_routing.py
@@ -81,6 +81,56 @@ class RequestRouterTestCase(TestCase):
                 request_dict={"nonExistingSasMethod": [{}]},
             )
 
+    def test_session_reuses_connection_across_sas_calls(self, mocker):
+        # Given
+        self._register_test_post_endpoints(
+            mocker, f'{self.sas_url}/registration',
+        )
+        self._register_test_post_endpoints(
+            mocker, f'{self.sas_url}/heartbeat',
+        )
+
+        # When
+        resp1 = self.router.post_to_sas(
+            request_dict={"registrationRequest": [{"foo": "bar"}]},
+        )
+        resp2 = self.router.post_to_sas(
+            request_dict={"heartbeatRequest": [{"cbsdId": "foo", "grantId": "bar"}]},
+        )
+
+        # Then
+        self.assertEqual(200, resp1.status_code)
+        self.assertEqual(200, resp2.status_code)
+
+    def test_sas_session_has_cert_configured(self, mocker):
+        # Then
+        self.assertEqual(
+            ('fake/cert/path', 'fake/key/path'),
+            self.router.sas_session.cert,
+        )
+        self.assertEqual(False, self.router.sas_session.verify)
+
+    def test_sas_session_is_reused_across_calls(self, mocker):
+        # Given
+        self._register_test_post_endpoints(
+            mocker, f'{self.sas_url}/registration',
+        )
+        session_before = self.router.sas_session
+
+        # When
+        self.router.post_to_sas(
+            request_dict={"registrationRequest": [{"foo": "bar"}]},
+        )
+
+        # Then - same session object is used
+        self.assertIs(session_before, self.router.sas_session)
+
+    def test_rc_session_is_separate_from_sas_session(self, mocker):
+        # Then
+        self.assertIsNot(self.router.sas_session, self.router.rc_session)
+        # RC session should not have SAS cert configured
+        self.assertIsNone(self.router.rc_session.cert)
+
     def _register_test_post_endpoints(self, mocker, url):
         mocker.register_uri('POST', url, json=self._response_callback)
 


### PR DESCRIPTION
## Summary

- Replace per-request `requests.post()` calls with a persistent `requests.Session` in `RequestRouter`
- This caches TCP connections and enables TLS session resumption, avoiding full mTLS handshake on every SAS request (up to 6 requests every 10 seconds)
- Create dedicated `sas_session` with cert/key configured once at init
- Create separate `rc_session` for Radio Controller calls

## Test Plan

- Existing unit tests pass unchanged (`requests_mock` works transparently with `requests.Session`)
- Added 4 new unit tests:
  - `test_session_reuses_connection_across_sas_calls` — multiple SAS endpoints work through same session
  - `test_sas_session_has_cert_configured` — session has correct cert tuple and verify setting
  - `test_sas_session_is_reused_across_calls` — same session object identity across calls
  - `test_rc_session_is_separate_from_sas_session` — SAS and RC use separate sessions
- Integration tests (`test_cbsd_sas_flow`) validate full E2E flow unchanged

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

No security impact. Same mTLS certificates are used; only the transport layer is optimized by reusing connections. CRL validation still runs before each SAS request.