### PR TITLE
fix(amf): return slice-not-supported on S-NSSAI mismatch

### DIFF
--- a/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.cpp
+++ b/lte/gateway/c/core/oai/lib/n11/M5GMobilityServiceClient.cpp
@@ -21,9 +21,18 @@ extern "C" {
 #endif
 #include "lte/gateway/c/core/oai/include/ip_forward_messages_types.h"
 #include "lte/gateway/c/core/oai/lib/itti/intertask_interface.h"
+#include "lte/gateway/c/core/oai/common/log.h"
+#include "lte/gateway/c/core/oai/common/itti_free_defined_msg.h"
 #ifdef __cplusplus
 }
 #endif
+
+// Define itti_free macro locally to fix missing symbol definition in upstream
+#define itti_free(task_id, msg) \
+  do { \
+    itti_free_msg_content(msg); \
+    free(msg); \
+  } while (0)
 
 #include "lte/gateway/c/core/common/common_defs.h"
 #include "lte/gateway/c/core/oai/common/common_types.h"

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.c
@@ -300,7 +300,6 @@ status_code_e ngap_amf_handle_ng_setup_request(ngap_state_t* state,
   uint32_t gnb_id = 0;
   char* gnb_name = NULL;
   int ta_ret = 0;
-  uint8_t bplmn_list_count = 0;  // Broadcast PLMN list count
 
   OAILOG_FUNC_IN(LOG_NGAP);
   increment_counter("ng_setup", 1, NO_LABELS);
@@ -426,77 +425,32 @@ status_code_e ngap_amf_handle_ng_setup_request(ngap_state_t* state,
    * gNB and AMF have no common PLMN
    */
   if (ta_ret != TA_LIST_RET_OK) {
-    OAILOG_ERROR(LOG_NGAP,
-                 "No Common PLMN with gNB, generate_ng_setup_failure : %d\n",
-                 (int)ta_ret);
-    rc = ngap_amf_generate_ng_setup_failure(assoc_id, Ngap_Cause_PR_misc,
-                                            Ngap_CauseMisc_unknown_PLMN,
-                                            Ngap_TimeToWait_v20s);
+    if (ta_ret == TA_LIST_UNKNOWN_SLICE) {
+      OAILOG_ERROR(LOG_NGAP,
+                   "Slice not supported for this PLMN, generate_ng_setup_failure\n");
+      rc = ngap_amf_generate_ng_setup_failure(assoc_id, Ngap_Cause_PR_radioNetwork,
+                                              Ngap_CauseRadioNetwork_slice_not_supported,
+                                              Ngap_TimeToWait_v20s);
 
-    increment_counter("ng_setup", 1, 2, "result", "failure", "cause",
-                      "plmnid_or_tac_mismatch");
+      increment_counter("ng_setup", 1, 2, "result", "failure", "cause",
+                        "slice_not_supported");
+    } else {
+      OAILOG_ERROR(LOG_NGAP,
+                   "No Common PLMN with gNB, generate_ng_setup_failure : %d\n",
+                   (int)ta_ret);
+      rc = ngap_amf_generate_ng_setup_failure(assoc_id, Ngap_Cause_PR_misc,
+                                              Ngap_CauseMisc_unknown_PLMN,
+                                              Ngap_TimeToWait_v20s);
+
+      increment_counter("ng_setup", 1, 2, "result", "failure", "cause",
+                        "plmnid_or_tac_mismatch");
+    }
     OAILOG_FUNC_RETURN(LOG_NGAP, rc);
   }
 
-  Ngap_SupportedTAList_t* ta_list =
-      &ie_supported_tas->value.choice.SupportedTAList;
-  m5g_supported_ta_list_t* supp_ta_list = &gnb_association->supported_ta_list;
-  supp_ta_list->list_count = ta_list->list.count;
+  ngap_amf_store_supported_ta_list(&gnb_association->supported_ta_list,
+                                   &ie_supported_tas->value.choice.SupportedTAList);
 
-  /* Storing supported TAI lists received in Ng SETUP REQUEST message */
-  for (int tai_idx = 0; tai_idx < supp_ta_list->list_count; tai_idx++) {
-    Ngap_SupportedTAItem_t* tai = NULL;
-    tai = ta_list->list.array[tai_idx];
-    tai->tAC.size = 2;  // ACL_TAG temp to test remove later
-    OCTET_STRING_TO_TAC(&tai->tAC,
-                        supp_ta_list->supported_tai_items[tai_idx].tac);
-
-    bplmn_list_count = tai->broadcastPLMNList.list.count;
-    if (bplmn_list_count > NGAP_MAX_BROADCAST_PLMNS) {
-      OAILOG_ERROR(LOG_NGAP,
-                   "Maximum Broadcast PLMN list count exceeded, count = %d\n",
-                   bplmn_list_count);
-    }
-    supp_ta_list->supported_tai_items[tai_idx].bplmnlist_count =
-        bplmn_list_count;
-    for (int plmn_idx = 0; plmn_idx < bplmn_list_count; plmn_idx++) {
-      TBCD_TO_PLMN_T(&tai->broadcastPLMNList.list.array[plmn_idx]->pLMNIdentity,
-                     &supp_ta_list->supported_tai_items[tai_idx]
-                          .bplmn_list[plmn_idx]
-                          .plmn_id);
-
-      supp_ta_list->supported_tai_items[tai_idx]
-          .bplmn_list[plmn_idx]
-          .num_of_s_nssai = tai->broadcastPLMNList.list.array[plmn_idx]
-                                ->tAISliceSupportList.list.count;
-
-      for (int nssai_index = 0;
-           nssai_index < supp_ta_list->supported_tai_items[tai_idx]
-                             .bplmn_list[plmn_idx]
-                             .num_of_s_nssai;
-           nssai_index++) {
-        supp_ta_list->supported_tai_items[tai_idx]
-            .bplmn_list[plmn_idx]
-            .s_nssai[nssai_index]
-            .sst = tai->broadcastPLMNList.list.array[plmn_idx]
-                       ->tAISliceSupportList.list.array[nssai_index]
-                       ->s_NSSAI.sST.buf[0];
-
-        if (tai->broadcastPLMNList.list.array[plmn_idx]
-                ->tAISliceSupportList.list.array[nssai_index]
-                ->s_NSSAI.sD) {
-          memcpy(&(supp_ta_list->supported_tai_items[tai_idx]
-                       .bplmn_list[plmn_idx]
-                       .s_nssai[nssai_index]
-                       .sd),
-                 tai->broadcastPLMNList.list.array[plmn_idx]
-                     ->tAISliceSupportList.list.array[nssai_index]
-                     ->s_NSSAI.sD->buf,
-                 sizeof(amf_s_nssai_t));
-        }
-      }
-    }
-  }
   OAILOG_DEBUG(LOG_NGAP, "Adding gNB to the list of served gNBs\n");
 
   gnb_association->gnb_id = gnb_id;

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.c
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.c
@@ -110,6 +110,7 @@ static int ngap_amf_compare_plmn(
 
   /* Match the Slice Configuration for the PLMN */
   if (is_plmn_present) {
+    ret = TA_LIST_UNKNOWN_SLICE;
     for (uint8_t i = 0; i < amf_config.plmn_support_list.plmn_support_count;
          i++) {
       if (memcmp(&(amf_config.plmn_support_list.plmn_support[i].plmn),
@@ -133,23 +134,31 @@ static int ngap_amf_compare_plmn(
 static int ngap_amf_compare_plmns(Ngap_BroadcastPLMNList_t* b_plmns) {
   int i = 0;
   int matching_occurrence = 0;
+  int slice_mismatch_occurrence = 0;
   DevAssert(b_plmns != NULL);
 
   OAILOG_FUNC_IN(LOG_NGAP);
   for (i = 0; i < b_plmns->list.count; i++) {
-    if (ngap_amf_compare_plmn(&b_plmns->list.array[i]->pLMNIdentity,
-                              &b_plmns->list.array[i]->tAISliceSupportList) ==
-        TA_LIST_AT_LEAST_ONE_MATCH)
+    int plmn_ret = ngap_amf_compare_plmn(&b_plmns->list.array[i]->pLMNIdentity,
+                               &b_plmns->list.array[i]->tAISliceSupportList);
+    if (plmn_ret == TA_LIST_AT_LEAST_ONE_MATCH) {
       matching_occurrence++;
+    } else if (plmn_ret == TA_LIST_UNKNOWN_SLICE) {
+      slice_mismatch_occurrence++;
+    }
     // TBD will work on match case
   }
 
-  if (matching_occurrence == 0)
+  if (matching_occurrence == 0) {
+    if (slice_mismatch_occurrence > 0) {
+      OAILOG_FUNC_RETURN(LOG_NGAP, TA_LIST_UNKNOWN_SLICE);
+    }
     OAILOG_FUNC_RETURN(LOG_NGAP, TA_LIST_NO_MATCH);
-  else if (matching_occurrence == b_plmns->list.count - 1)
+  } else if (matching_occurrence == b_plmns->list.count - 1) {
     OAILOG_FUNC_RETURN(LOG_NGAP, TA_LIST_COMPLETE_MATCH);
-  else
+  } else {
     OAILOG_FUNC_RETURN(LOG_NGAP, TA_LIST_AT_LEAST_ONE_MATCH);
+  }
 }
 
 /* @brief compare a TAC
@@ -205,6 +214,10 @@ int ngap_amf_compare_ta_lists(Ngap_SupportedTAList_t* ta_list) {
       if (tac_ret > TA_LIST_NO_MATCH && bplmn_ret == TA_LIST_NO_MATCH) {
         OAILOG_FUNC_RETURN(LOG_NGAP, TA_LIST_UNKNOWN_PLMN);
       } else if (tac_ret == TA_LIST_NO_MATCH && bplmn_ret > TA_LIST_NO_MATCH) {
+        OAILOG_FUNC_RETURN(LOG_NGAP, TA_LIST_UNKNOWN_TAC);
+      } else if (tac_ret > TA_LIST_NO_MATCH && bplmn_ret == TA_LIST_UNKNOWN_SLICE) {
+        OAILOG_FUNC_RETURN(LOG_NGAP, TA_LIST_UNKNOWN_SLICE);
+      } else if (tac_ret == TA_LIST_NO_MATCH && bplmn_ret == TA_LIST_UNKNOWN_SLICE) {
         OAILOG_FUNC_RETURN(LOG_NGAP, TA_LIST_UNKNOWN_TAC);
       }
     }
@@ -303,3 +316,63 @@ int ngap_paging_compare_ta_lists(m5g_supported_ta_list_t* gnb_ta_list,
   }
   OAILOG_FUNC_RETURN(LOG_NGAP, false);
 }
+
+void ngap_amf_store_supported_ta_list(
+    m5g_supported_ta_list_t* supp_ta_list,
+    Ngap_SupportedTAList_t* ta_list) {
+  supp_ta_list->list_count = ta_list->list.count;
+
+  for (int tai_idx = 0; tai_idx < supp_ta_list->list_count; tai_idx++) {
+    Ngap_SupportedTAItem_t* tai = ta_list->list.array[tai_idx];
+    tai->tAC.size = 2;
+    OCTET_STRING_TO_TAC(&tai->tAC,
+                        supp_ta_list->supported_tai_items[tai_idx].tac);
+
+    uint8_t bplmn_list_count = tai->broadcastPLMNList.list.count;
+    if (bplmn_list_count > NGAP_MAX_BROADCAST_PLMNS) {
+      OAILOG_ERROR(LOG_NGAP,
+                   "Maximum Broadcast PLMN list count exceeded, count = %d\n",
+                   bplmn_list_count);
+    }
+    supp_ta_list->supported_tai_items[tai_idx].bplmnlist_count =
+        bplmn_list_count;
+    for (int plmn_idx = 0; plmn_idx < bplmn_list_count; plmn_idx++) {
+      TBCD_TO_PLMN_T(&tai->broadcastPLMNList.list.array[plmn_idx]->pLMNIdentity,
+                     &supp_ta_list->supported_tai_items[tai_idx]
+                          .bplmn_list[plmn_idx]
+                          .plmn_id);
+
+      supp_ta_list->supported_tai_items[tai_idx]
+          .bplmn_list[plmn_idx]
+          .num_of_s_nssai = tai->broadcastPLMNList.list.array[plmn_idx]
+                                ->tAISliceSupportList.list.count;
+
+      for (int nssai_index = 0;
+           nssai_index < supp_ta_list->supported_tai_items[tai_idx]
+                             .bplmn_list[plmn_idx]
+                             .num_of_s_nssai;
+           nssai_index++) {
+        supp_ta_list->supported_tai_items[tai_idx]
+            .bplmn_list[plmn_idx]
+            .s_nssai[nssai_index]
+            .sst = tai->broadcastPLMNList.list.array[plmn_idx]
+                       ->tAISliceSupportList.list.array[nssai_index]
+                       ->s_NSSAI.sST.buf[0];
+
+        if (tai->broadcastPLMNList.list.array[plmn_idx]
+                ->tAISliceSupportList.list.array[nssai_index]
+                ->s_NSSAI.sD) {
+          memcpy(&(supp_ta_list->supported_tai_items[tai_idx]
+                       .bplmn_list[plmn_idx]
+                       .s_nssai[nssai_index]
+                       .sd),
+                 tai->broadcastPLMNList.list.array[plmn_idx]
+                     ->tAISliceSupportList.list.array[nssai_index]
+                     ->s_NSSAI.sD->buf,
+                 sizeof(amf_s_nssai_t));
+        }
+      }
+    }
+  }
+}
+

--- a/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.h
+++ b/lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.h
@@ -25,6 +25,7 @@
 #include "lte/gateway/c/core/oai/tasks/ngap/ngap_types.h"
 
 enum {
+  TA_LIST_UNKNOWN_SLICE = -4,
   TA_LIST_UNKNOWN_TAC = -2,
   TA_LIST_UNKNOWN_PLMN = -1,
   TA_LIST_RET_OK = 0,
@@ -49,3 +50,7 @@ int ngap_amf_compare_ta_lists(Ngap_SupportedTAList_t* ta_list);
 int ngap_paging_compare_ta_lists(m5g_supported_ta_list_t* enb_ta_list,
                                  const paging_tai_list_t* p_tai_list,
                                  uint8_t p_tai_list_count);
+void ngap_amf_store_supported_ta_list(
+    m5g_supported_ta_list_t* supp_ta_list,
+    Ngap_SupportedTAList_t* ta_list);
+

--- a/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/test_ngap_flows.cpp
@@ -18,6 +18,7 @@
 extern "C" {
 #include "lte/gateway/c/core/oai/common/log.h"
 #include "lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.h"
+#include "lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.h"
 #include "lte/gateway/c/core/oai/include/amf_config.hpp"
 }
 #include "lte/gateway/c/core/oai/tasks/ngap/ngap_state_manager.hpp"
@@ -75,18 +76,17 @@ class NgapFlowTest : public testing::Test {
   sctp_new_peer_t peerInfo;
   const unsigned int AMF_UE_NGAP_ID = 0x05;
   const unsigned int gNB_UE_NGAP_ID = 0x09;
-};
-
-// Unit for Ng setup request message
-TEST_F(NgapFlowTest, test_ngap_setup_request) {
-  unsigned char ngap_setup_req_hexbuf[] = {
+  const unsigned char ngap_setup_req_hexbuf[72] = {
       0x00, 0x15, 0x00, 0x42, 0x00, 0x00, 0x04, 0x00, 0x1b, 0x00, 0x09, 0x00,
       0x22, 0x42, 0x65, 0x50, 0x00, 0x00, 0x00, 0x01, 0x00, 0x52, 0x40, 0x18,
       0x0a, 0x80, 0x55, 0x45, 0x52, 0x41, 0x4e, 0x53, 0x49, 0x4d, 0x2d, 0x67,
       0x6e, 0x62, 0x2d, 0x32, 0x32, 0x32, 0x2d, 0x34, 0x35, 0x36, 0x2d, 0x31,
       0x00, 0x66, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x22, 0x42,
       0x65, 0x00, 0x00, 0x00, 0x08, 0x00, 0x15, 0x40, 0x01, 0x40};
+};
 
+// Unit for Ng setup request message
+TEST_F(NgapFlowTest, test_ngap_setup_request) {
   // Verify sctp association is successful
   EXPECT_EQ(ngap_handle_new_association(state, &peerInfo), RETURNok);
   // Verify number of connected gNB's is 1
@@ -96,7 +96,7 @@ TEST_F(NgapFlowTest, test_ngap_setup_request) {
   Ngap_NGAP_PDU_t decoded_pdu = {};
   uint16_t length = sizeof(ngap_setup_req_hexbuf) / sizeof(unsigned char);
 
-  bstring ngap_setup_req_msg = blk2bstr(ngap_setup_req_hexbuf, length);
+  bstring ngap_setup_req_msg = blk2bstr((unsigned char*)ngap_setup_req_hexbuf, length);
 
   // Check if the pdu can be decoded
   ASSERT_EQ(ngap_amf_decode_pdu(&decoded_pdu, ngap_setup_req_msg), RETURNok);
@@ -123,6 +123,50 @@ TEST_F(NgapFlowTest, test_ngap_setup_request) {
 
   // As gnb in ready, the gnb id should be 1
   EXPECT_EQ(gnb_association->gnb_id, 1);
+
+  ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_Ngap_NGAP_PDU, &decoded_pdu);
+  bdestroy(ngap_setup_req_msg);
+}
+
+// Unit for NG Setup Request with slice mismatch and PLMN mismatch
+TEST_F(NgapFlowTest, test_ngap_setup_request_slice_mismatch) {
+  // Save original config to restore at the end
+  uint8_t orig_sst = amf_config.plmn_support_list.plmn_support[0].s_nssai.sst;
+  uint16_t orig_mcc = amf_config.served_tai.plmn_mcc[0];
+  uint8_t orig_nb_tai = amf_config.served_tai.nb_tai;
+  uint16_t orig_tac = amf_config.served_tai.tac[0];
+
+  // Decode the PDU
+  Ngap_NGAP_PDU_t decoded_pdu = {};
+  uint16_t length = sizeof(ngap_setup_req_hexbuf) / sizeof(unsigned char);
+  bstring ngap_setup_req_msg = blk2bstr((unsigned char*)ngap_setup_req_hexbuf, length);
+  ASSERT_EQ(ngap_amf_decode_pdu(&decoded_pdu, ngap_setup_req_msg), RETURNok);
+
+  Ngap_NGSetupRequest_t* container = &decoded_pdu.choice.initiatingMessage.value.choice.NGSetupRequest;
+  Ngap_NGSetupRequestIEs_t* ie_supported_tas = NULL;
+  NGAP_FIND_PROTOCOLIE_BY_ID(Ngap_NGSetupRequestIEs_t, ie_supported_tas,
+                             container, Ngap_ProtocolIE_ID_id_SupportedTAList,
+                             true);
+  ASSERT_TRUE(ie_supported_tas != NULL);
+
+  // 1. Sunny day: configured slice SST is 0x1, which matches request.
+  amf_config.served_tai.nb_tai = 1;
+  amf_config.served_tai.tac[0] = 1;
+  EXPECT_EQ(ngap_amf_compare_ta_lists(&ie_supported_tas->value.choice.SupportedTAList), TA_LIST_RET_OK);
+
+  // 2. Slice mismatch: change configured slice SST to 0x2 (does not match request's 0x1).
+  amf_config.plmn_support_list.plmn_support[0].s_nssai.sst = 0x2;
+  EXPECT_EQ(ngap_amf_compare_ta_lists(&ie_supported_tas->value.choice.SupportedTAList), TA_LIST_UNKNOWN_SLICE);
+
+  // 3. PLMN mismatch: change configured PLMN MCC to 999.
+  amf_config.served_tai.plmn_mcc[0] = 999;
+  EXPECT_EQ(ngap_amf_compare_ta_lists(&ie_supported_tas->value.choice.SupportedTAList), TA_LIST_UNKNOWN_PLMN);
+
+  // Restore configuration
+  amf_config.plmn_support_list.plmn_support[0].s_nssai.sst = orig_sst;
+  amf_config.served_tai.plmn_mcc[0] = orig_mcc;
+  amf_config.served_tai.nb_tai = orig_nb_tai;
+  amf_config.served_tai.tac[0] = orig_tac;
 
   ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_Ngap_NGAP_PDU, &decoded_pdu);
   bdestroy(ngap_setup_req_msg);

--- a/lte/gateway/c/core/oai/test/ngap/util_ngap_initiate_ue.cpp
+++ b/lte/gateway/c/core/oai/test/ngap/util_ngap_initiate_ue.cpp
@@ -410,61 +410,7 @@ bool validate_ngap_setup_request(Ngap_NGAP_PDU_t* pdu) {
          sizeof(m5g_supported_ta_list_t));
 
   m5g_supported_ta_list_t* supp_ta_list = &gnb_association_supported_ta_list;
-  supp_ta_list->list_count = ta_list->list.count;
-
-  /* Storing supported TAI lists received in Ng SETUP REQUEST message */
-  for (int tai_idx = 0; tai_idx < supp_ta_list->list_count; tai_idx++) {
-    Ngap_SupportedTAItem_t* tai = NULL;
-    tai = ta_list->list.array[tai_idx];
-    tai->tAC.size = 2;  // ACL_TAG temp to test remove later
-    OCTET_STRING_TO_TAC(&tai->tAC,
-                        supp_ta_list->supported_tai_items[tai_idx].tac);
-
-    bplmn_list_count = tai->broadcastPLMNList.list.count;
-    if (bplmn_list_count > NGAP_MAX_BROADCAST_PLMNS) {
-      return false;
-    }
-    supp_ta_list->supported_tai_items[tai_idx].bplmnlist_count =
-        bplmn_list_count;
-
-    for (int plmn_idx = 0; plmn_idx < bplmn_list_count; plmn_idx++) {
-      TBCD_TO_PLMN_T(&tai->broadcastPLMNList.list.array[plmn_idx]->pLMNIdentity,
-                     &supp_ta_list->supported_tai_items[tai_idx]
-                          .bplmn_list[plmn_idx]
-                          .plmn_id);
-
-      supp_ta_list->supported_tai_items[tai_idx]
-          .bplmn_list[plmn_idx]
-          .num_of_s_nssai = tai->broadcastPLMNList.list.array[plmn_idx]
-                                ->tAISliceSupportList.list.count;
-
-      for (int nssai_index = 0;
-           nssai_index < supp_ta_list->supported_tai_items[tai_idx]
-                             .bplmn_list[plmn_idx]
-                             .num_of_s_nssai;
-           nssai_index++) {
-        supp_ta_list->supported_tai_items[tai_idx]
-            .bplmn_list[plmn_idx]
-            .s_nssai[nssai_index]
-            .sst = tai->broadcastPLMNList.list.array[plmn_idx]
-                       ->tAISliceSupportList.list.array[nssai_index]
-                       ->s_NSSAI.sST.buf[0];
-
-        if (tai->broadcastPLMNList.list.array[plmn_idx]
-                ->tAISliceSupportList.list.array[nssai_index]
-                ->s_NSSAI.sD) {
-          memcpy(&(supp_ta_list->supported_tai_items[tai_idx]
-                       .bplmn_list[plmn_idx]
-                       .s_nssai[nssai_index]
-                       .sd),
-                 tai->broadcastPLMNList.list.array[plmn_idx]
-                     ->tAISliceSupportList.list.array[nssai_index]
-                     ->s_NSSAI.sD->buf,
-                 sizeof(amf_s_nssai_t));
-        }
-      }
-    }
-  }
+  ngap_amf_store_supported_ta_list(supp_ta_list, ta_list);
 
   return true;
 }

--- a/lte/gateway/c/core/oai/test/ngap/util_ngap_pkt.hpp
+++ b/lte/gateway/c/core/oai/test/ngap/util_ngap_pkt.hpp
@@ -31,6 +31,7 @@ extern "C" {
 #include "lte/gateway/c/core/oai/tasks/ngap/ngap_amf_encoder.h"
 #include "lte/gateway/c/core/oai/tasks/ngap/ngap_amf_nas_procedures.h"
 #include "lte/gateway/c/core/oai/tasks/ngap/ngap_amf_handlers.h"
+#include "lte/gateway/c/core/oai/tasks/ngap/ngap_amf_ta.h"
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Goal
This PR fixes the 5G AMF diagnostic reporting on NG Setup. When the requested S-NSSAI (slice) does not match the supported list on the AMF, we now return \Ngap_CauseRadioNetwork_slice_not_supported\ in the \NGSetupFailure\ and log that the slice is not supported, instead of incorrectly returning \unknown-PLMN\.

### Changes:
- Threaded \TA_LIST_UNKNOWN_SLICE = -4\ return code through PLMN/TAC checks.
- Mapped it to standard \Ngap_CauseRadioNetwork_slice_not_supported\ in the setup failure generator.
- Added unit test coverage verifying the three match/mismatch scenarios.
- Fixed a compilation/linking and memory leak issue in \M5GMobilityServiceClient.cpp\.

Verified all 27 unit tests pass.