### PR TITLE
fix(lte): resolve requests dependency bug and add troubleshooting docs

### DIFF
--- a/docs/readmes/lte/readme_agw.md
+++ b/docs/readmes/lte/readme_agw.md
@@ -148,4 +148,26 @@ subcommands:
     config_enodeb       Configure eNodeB
     reboot_enodeb       Reboot eNodeB
     get_status          Get eNodeB status
+
+```
+
+## Troubleshooting
+
+### AGW Build Fails at `install_egg` (Python Dependency Conflicts)
+
+If your `make build` execution fails during the Python environment setup with errors related to `setuptools` (e.g., `AttributeError: type object 'Distribution' has no attribute '_finalize_feature_opts'`) or missing `requests` distributions, the build environment is trying to pull deprecated dependencies.
+
+You can dynamically patch the legacy version limits before compiling by running the following commands from your Vagrant instance:
+
+```bash
+# 1. Downgrade setuptools to a stable legacy version across all make files
+find ~/magma -type f -name "python.mk" -exec sed -i 's/setuptools==58.3.0/setuptools==49.6.0/g' {} +
+
+# 2. Relax the requests versioning constraint to allow flexible pip resolution
+find ~/magma -type f -name "setup.py" -exec sed -i 's/requests==2.32.4/requests>=2.20.0/g' {} +
+
+# 3. Clean the corrupted virtual environment and rebuild
+rm -rf /home/vagrant/build/python
+make build
+
 ```

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -116,7 +116,7 @@ setup(
         'docker==4.1.0',
         'urllib3==1.26.19',
         'websocket-client>=1.3.2',
-        'requests==2.33.0',
+        'requests>=2.20.0',
         'certifi>=2022.6.15',
         'idna==3.3',
         'python-dateutil>=2.8.2',


### PR DESCRIPTION
## Description
During the `make build` execution for the AGW, the build consistently crashes at the `install_egg` step due to a strict, unavailable version requirement (`requests==2.33.0`). 

This comprehensive PR does two things to resolve this roadblock for future developers:
1. **Codebase Bug Fix:** Relaxes the dependency constraint in `setup.py` to `requests>=2.20.0`, allowing the pip package manager to successfully resolve it.
2. **Documentation:** Adds a troubleshooting section to `docs/readmes/lte/readme_agw.md` to guide new contributors on how to dynamically patch these legacy dependencies.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update