### PR TITLE
docs(orc8r): clarify tenant control_proxy prerequisite

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.8.0/orc8r/dev_gateway_registration.md
+++ b/docs/docusaurus/versioned_docs/version-1.8.0/orc8r/dev_gateway_registration.md
@@ -18,7 +18,20 @@ In efforts to simplify gateway registration, the new registration process only r
 The overview of gateway registration is as follows:
 ![gateway_registration_overview](assets/orc8r/gateway_registration_overview.png)
 
-Note: The operator should set per-tenant default `control_proxy.yml` through the API endpoint `\tenants\{tenant_id}\control_proxy` as a prerequisite.
+Note: The operator should set per-tenant default `control_proxy.yml` through the API endpoint `/tenants/{tenant_id}/control_proxy` as a prerequisite. The `tenant_id` is the numeric tenant ID, not the network ID. The tenant must include the network that contains the gateway being registered, because Orc8r resolves the control proxy from the gateway network ID during registration.
+
+For example, if the gateway belongs to network `my-network`, create or update a tenant with that network attached:
+
+```json
+{
+   "id": 1,
+   "name": "local-tenant",
+   "networks": ["my-network"]
+}
+```
+
+Then set the tenant control proxy at `/tenants/1/control_proxy`. If the gateway network is not attached to a tenant, registration can fail with an error similar to `could not get control-proxy from tenant with network ID <network_id>`.
+
 The control proxy must have `\n` characters as line breaks. Here is a sample request body:
 
 ```json

--- a/docs/readmes/orc8r/dev_gateway_registration.md
+++ b/docs/readmes/orc8r/dev_gateway_registration.md
@@ -17,7 +17,20 @@ In efforts to simplify gateway registration, the new registration process only r
 The overview of gateway registration is as follows:
 ![gateway_registration_overview](assets/orc8r/gateway_registration_overview.png)
 
-Note: The operator should set per-tenant default `control_proxy.yml` through the API endpoint `\tenants\{tenant_id}\control_proxy` as a prerequisite.
+Note: The operator should set per-tenant default `control_proxy.yml` through the API endpoint `/tenants/{tenant_id}/control_proxy` as a prerequisite. The `tenant_id` is the numeric tenant ID, not the network ID. The tenant must include the network that contains the gateway being registered, because Orc8r resolves the control proxy from the gateway network ID during registration.
+
+For example, if the gateway belongs to network `my-network`, create or update a tenant with that network attached:
+
+```json
+{
+   "id": 1,
+   "name": "local-tenant",
+   "networks": ["my-network"]
+}
+```
+
+Then set the tenant control proxy at `/tenants/1/control_proxy`. If the gateway network is not attached to a tenant, registration can fail with an error similar to `could not get control-proxy from tenant with network ID <network_id>`.
+
 The control proxy must have `\n` characters as line breaks. Here is a sample request body:
 
 ```json


### PR DESCRIPTION
  ## Summary

  Clarifies the gateway registration prerequisite for tenant-level `control_proxy.yml`.

  The existing gateway registration guide mentions the per-tenant control proxy endpoint, but it did not explicitly state that:

  - `tenant_id` is the numeric tenant ID, not the network ID
  - the tenant must include the network that contains the gateway being registered
  - Orc8r resolves the control proxy from the gateway network ID during registration

  This also updates the endpoint example from backslash form to `/tenants/{tenant_id}/control_proxy`.

  ## Test Plan

  Docs-only change.

  Verified against the gateway registration flow and tenant service behavior:
  - registration retrieves the gateway network ID
  - Orc8r looks up the tenant control proxy from that network ID
  - registration can fail if the network is not attached to a tenant with a configured control proxy

  ## Additional Information

  - [ ] This change is backwards-breaking

  ## Security Considerations

  Docs-only change. No security impact expected.

