### PR TITLE
docs: fix relative image path for docker-config in prerequisites

### DIFF
--- a/docs/readmes/basics/prerequisites.md
+++ b/docs/readmes/basics/prerequisites.md
@@ -53,7 +53,7 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    Advanced). If you are running into build/test failures with Go that report
    "signal killed", you likely need to increase Docker's allocated resources.
 
-   ![Increasing docker engine resources](assets/docker-config.png)
+   ![Increasing docker engine resources](../assets/docker-config.png)
 
 ### Ubuntu
 


### PR DESCRIPTION
## Summary
Fixes a broken relative path link to `docker-config.png` in `docs/readmes/basics/prerequisites.md`. 

The image reference was previously set to `assets/docker-config.png` instead of `../assets/docker-config.png`, which caused a 400 dead link error during markdown CI checks.

## Test Plan
- Executed local markdown link check:
  `npx markdown-link-check docs/readmes/basics/prerequisites.md`
- Verified all 17 links (including the image asset) passed with 0 errors.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

None. Documentation-only change.
