### PR TITLE
fix(dp): fix broken relative links and image paths in DP architecture overview

### DIFF
--- a/docs/readmes/dp/architecture_overview.md
+++ b/docs/readmes/dp/architecture_overview.md
@@ -39,11 +39,11 @@ NMS UI page for Domain Proxy management is currently under development.
 
 The picture below gives a very general look at the Domain Proxy as a proxy service between radios and SAS
 
-![dp](assets/dp/dp_high_level_overview.png)
+![dp](../assets/dp/dp_high_level_overview.png)
 
 ### Domain Proxy in Magma's Context
 
-![dp](assets/dp/dp_in_context.png)
+![dp](../assets/dp/dp_in_context.png)
 
 If we take a closer look, Domain Proxy as part of Magma is situated next to Orc8r,
 (typically on the same Kubernetes cluster) and uses the same database as the Orc8r.
@@ -75,7 +75,7 @@ radio. This is achieved mainly by
 
 In the picture we see three components that comprise Domain Proxy
 
-![dp](assets/dp/dp_architecture.png)
+![dp](../assets/dp/dp_architecture.png)
 
 #### Radio Controller
 
@@ -118,7 +118,7 @@ messages sent using a specific protocol. Currently, the only eNBs connected to D
 Englewood and Baicells 430 Nova).
 
 Instead, the component treated by Domain Proxy as the only `Protocol Controller` is currently
-AGW's [Enodebd](lte/architecture_overview.md#enodebd)
+AGW's [Enodebd](../lte/architecture_overview.md#enodebd)
 being the configuration component for `TR069` based radios.
 
 `Enodebd` communicates with Domain Proxy's `Radio Controller` as if it were just another DP component, over gRPC, using


### PR DESCRIPTION
## Summary
Fixes 4 broken relative links in `docs/readmes/dp/architecture_overview.md`:
1. Updated `lte/architecture_overview.md#enodebd` to `../lte/architecture_overview.md#enodebd` to properly reference the LTE architecture doc.
2. Updated `assets/dp/*` image paths to `../assets/dp/*` to correctly point to the root assets folder.

## Test Plan
- Executed `npx markdown-link-check docs/readmes/dp/architecture_overview.md` locally.
- Verified all 7 links pass with 0 errors.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

None. Documentation fix.
