### PR TITLE
ci: pin BuildKit image to v0.12.5 for kernel 5.4 runner compatibility

### DIFF
--- a/.github/workflows/composite/docker-builder/action.yml
+++ b/.github/workflows/composite/docker-builder/action.yml
@@ -61,6 +61,8 @@ runs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # pin@v2.2.1
+      with:
+        driver-opts: image=moby/buildkit:v0.12.5
     - name: Login to GHCR
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin v2.1.0
       with:


### PR DESCRIPTION
The default buildx image (buildx-stable-1, currently v0.31.2) bundles runc 1.2.x, whose /proc masking is rejected by self-hosted runners on kernel 5.4 (5.4.0-1048-aws), failing all docker-container builds at the first RUN step. Pinning BuildKit to v0.12.5 (runc 1.1.x) avoids the incompatible masking path.

Summary

docker/setup-buildx-action in the docker-builder composite sets no driver-opts: image=, so it defaults to buildx-stable-1 — currently BuildKit v0.31.2, which bundles runc 1.2.x. On self-hosted runners on kernel 5.4 (5.4.0-1048-aws), runc 1.2.x's /proc masking is rejected by the kernel and every docker-container build fails at the first RUN:

runc run failed: ... can't mask dir "/proc/acpi": ... invalid argument

This has been failing the python-precommit build across multiple PRs. This change pins BuildKit to v0.12.5 (runc 1.1.x), which uses the older masking path the 5.4 kernel accepts.

Note: docker-builder-agw uses the same setup-buildx-action and is very likely affected by the same root cause. This PR is scoped to the build I could verify directly; flagging AGW for maintainers to confirm/patch.

Test Plan

Reproduced on an affected 5.4 runner. With the default BuildKit, the build fails at [2/4] RUN addgroup with the /proc/acpi error. Pinned to v0.12.5, the same build (same runner, same kernel, same Dockerfile, same docker-container driver) completes all four stages. The only changed variable is the BuildKit image, isolating it as the cause.

Additional Information
 This change is backwards-breaking
Security Considerations

Pinning to an older BuildKit (v0.12.5, ~2 years old) means older-image CVE exposure, and applies the pin globally — including on runners that may be on newer kernels that don't need it. The durable alternative is upgrading the affected runner off kernel 5.4, which removes the incompatibility without pinning; that needs validation against AGW datapath (OVS + GTP kernel module) requirements and is out of scope here.