### PR TITLE
fix(nms): fix relative asset paths in NMS admin user guide

### DIFF
--- a/docs/readmes/nms/admin.md
+++ b/docs/readmes/nms/admin.md
@@ -14,8 +14,8 @@ NMS provides an admin page to manage the NMS itself. Admin page currently has th
 ## Users
 
 New users to NMS can be added or edited through the admin page.
-![admin](assets/nms/userguide/admin/admin.png)
-![users](assets/nms/userguide/admin/users.png)
+![admin](../assets/nms/userguide/admin/admin.png)
+![users](../assets/nms/userguide/admin/users.png)
 
 Users can be configured as either a superuser/user/readonly user.
 Super User will have capability to view all the metrics in the organization through Grafana.
@@ -25,11 +25,11 @@ Read Only user can only view the various components in NMS. They cannot make any
 ## Audit Logs
 
 All configuration change made through NMS can be viewed through the audit log component. Audit log component comes with a convenient interface to search, sort and view the entire JSON payload of the configuration change.
-![audit_log](assets/nms/userguide/admin/audit_log1.png)
-![audit_log](assets/nms/userguide/admin/audit_log2.png)
-![audit_log](assets/nms/userguide/admin/audit_log3.png)
+![audit_log](../assets/nms/userguide/admin/audit_log1.png)
+![audit_log](../assets/nms/userguide/admin/audit_log2.png)
+![audit_log](../assets/nms/userguide/admin/audit_log3.png)
 
 ## Networks
 
 Admin page also contains a network page to add any network to the given organization.
-![network](assets/nms/userguide/admin/network.png)
+![network](../assets/nms/userguide/admin/network.png)


### PR DESCRIPTION
## Summary
Fixes 6 broken relative asset links in `docs/readmes/nms/admin.md`. 
Updating `assets/nms/*` to `../assets/nms/*` resolves the images in the root assets directory during markdown CI checks.

## Test Plan
- Executed `npx markdown-link-check docs/readmes/nms/admin.md` locally.
- Verified all 6 links passed with 0 errors.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

None. Documentation fix.