### PR TITLE
fix(nms): fix relative asset paths in NMS alert documentation

### DIFF
--- a/docs/readmes/nms/alert.md
+++ b/docs/readmes/nms/alert.md
@@ -20,13 +20,13 @@ In this guide we will discuss
 ### Top Level Network Dashboard
 
 Alert dashboard displays the current firing alerts in a table tabbed by severity. In each of the columns we additionally display the labels passed along with the alert.
-![viewing_alerts_1](assets/nms/userguide/alerts/viewing_alerts1.png)
+![viewing_alerts_1](../assets/nms/userguide/alerts/viewing_alerts1.png)
 
 ### Alarm component’s Alert Tab
 
 Alerts can also be viewed from the alert tab in the Alarm table.
-![viewing_alerts_2](assets/nms/userguide/alerts/viewing_alerts2.png)
-![viewing_alerts_3](assets/nms/userguide/alerts/viewing_alerts3.png)
+![viewing_alerts_2](../assets/nms/userguide/alerts/viewing_alerts2.png)
+![viewing_alerts_3](../assets/nms/userguide/alerts/viewing_alerts3.png)
 
 ## Alert Receivers
 
@@ -39,29 +39,29 @@ An alert Receiver is created to push the alert notification in real time so that
 - Create an App: Go to <https://api.slack.com/apps?new_app=1> and click on “Create New App”. Enter the App Name and the Slack Workspace.
 - Click on “Incoming Webhooks” and change “Active Incoming Webhooks” to On
 
-    ![alert_recv1](assets/nms/userguide/alerts/alert_recv1.png)
+    ![alert_recv1](../assets/nms/userguide/alerts/alert_recv1.png)
 
 - Scroll down and create a new Webhook by clicking on “Add New Webhook to Workspace”. Select the Slack Channel name.
 
-    ![alert_recv2](assets/nms/userguide/alerts/alert_recv2.png)
+    ![alert_recv2](../assets/nms/userguide/alerts/alert_recv2.png)
 
 - Copy the “Webhook URL” once it is generated.
 
-    ![alert_recv3](assets/nms/userguide/alerts/alert_recv3.png)
+    ![alert_recv3](../assets/nms/userguide/alerts/alert_recv3.png)
 
 #### Create a new Alert Receiver in NMS
 
-![alert_recv4](assets/nms/userguide/alerts/alert_recv4.png)
+![alert_recv4](../assets/nms/userguide/alerts/alert_recv4.png)
 
 #### Testing the newly added alert receiver
 
 Add a dummy alert to verify if the alert receiver is indeed working. A dummy alert expression can be constructed
 with a PromQL advanced expresssion of `vector(1)` as shown below.
 
-![alert_recv5](assets/nms/userguide/alerts/alert_recv5.png)
+![alert_recv5](../assets/nms/userguide/alerts/alert_recv5.png)
 
 Look for the notification on the slack channel
-![alert_recv6](assets/nms/userguide/alerts/alert_recv6.png)
+![alert_recv6](../assets/nms/userguide/alerts/alert_recv6.png)
 
 ## Configuring Alert rules
 
@@ -70,8 +70,8 @@ Alert rule configuration lets us define rules for triggering alerts.
 ### Predefined Alerts
 
 Magma NMS comes loaded with some default set of alert rules. These default rules aren’t configured automatically. If an operator chooses to use these default rules, they can do it by clicking “Sync Predefined Alerts” button in Alert rule configuration tab. As shown below
-![alerts1](assets/nms/userguide/alerts/alerts1.png)
-![alerts2](assets/nms/userguide/alerts/alerts2.png)
+![alerts1](../assets/nms/userguide/alerts/alerts1.png)
+![alerts2](../assets/nms/userguide/alerts/alerts2.png)
 
 Currently predefined alerts configure following alerts
 
@@ -85,7 +85,7 @@ Currently predefined alerts configure following alerts
 
 > Note Operator will have to go and additionally specify the receiver in each of these alerts when they want to be notified of the alerts as follows
 
-![alerts3](assets/nms/userguide/alerts/alerts3.png)
+![alerts3](../assets/nms/userguide/alerts/alerts3.png)
 
 ### Custom Alert Rules
 
@@ -107,18 +107,18 @@ An alert configuration consists of
 - Additional labels which can be added to provide more information about the alert. (optional)
 
 Alert definition consists of a metric expression (a [Prometheus PromQL expression](https://prometheus.io/docs/prometheus/latest/querying/basics/)) and a duration attribute which specifies the time for the expression to be true, following which the alert is fired.
-![alerts5](assets/nms/userguide/alerts/alerts5.png)
-![alerts6](assets/nms/userguide/alerts/alerts6.png)
+![alerts5](../assets/nms/userguide/alerts/alerts5.png)
+![alerts6](../assets/nms/userguide/alerts/alerts6.png)
 
 We can create a custom alert either from a simple expression or an advanced expression.
 In case of a simple expression, we can choose a metric from the dropdown and construct an expression based on that
 as shown below
 For e.g.
-![simple_alert](assets/nms/userguide/alerts/simple_alert.png)
+![simple_alert](../assets/nms/userguide/alerts/simple_alert.png)
 
 In case of an advanced expression([PromQL cheatsheet](https://promlabs.com/promql-cheat-sheet/)) which might involve applying different functions on metric, we can
 type the advanced promQL expression directly in the textbox
-![advanced_alert](assets/nms/userguide/alerts/advanced_alert.png)
+![advanced_alert](../assets/nms/userguide/alerts/advanced_alert.png)
 
 The following examples show how we can create custom alerts on the above mentioned metrics.
 
@@ -220,7 +220,7 @@ Duration:
 
 ## REST API for alerts
 
-![api](assets/nms/userguide/alerts/alerts_api.png)
+![api](../assets/nms/userguide/alerts/alerts_api.png)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
Fixes broken relative asset links in `docs/readmes/nms/alert.md` by updating `assets/nms/*` paths to `../assets/nms/*` so they resolve correctly in the root assets directory.

## Test Plan
- Executed `npx markdown-link-check docs/readmes/nms/alert.md` locally.
- Verified 0 dead link errors.

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

None. Documentation fix.
