### PR TITLE
fix(orc8r): update removed Kubernetes beta API versions in Helm charts

### DIFF
--- a/lte/cloud/helm/lte-orc8r/templates/ha.pdb.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/ha.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "ha.pdb") -}}
 {{- define "ha.pdb" -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-ha

--- a/lte/cloud/helm/lte-orc8r/templates/lte.pdb.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/lte.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "lte.pdb") -}}
 {{- define "lte.pdb" -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-lte

--- a/lte/cloud/helm/lte-orc8r/templates/nprobe.pdb.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/nprobe.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "nprobe.pdb") -}}
 {{- define "nprobe.pdb" -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-nprobe

--- a/lte/cloud/helm/lte-orc8r/templates/policydb.pdb.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/policydb.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "policydb.pdb") -}}
 {{- define "policydb.pdb" -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-policydb

--- a/lte/cloud/helm/lte-orc8r/templates/smsd.pdb.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/smsd.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "smsd.pdb") -}}
 {{- define "smsd.pdb" -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-smsd

--- a/lte/cloud/helm/lte-orc8r/templates/subscriberdb.pdb.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/subscriberdb.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "subscriberdb.pdb") -}}
 {{- define "subscriberdb.pdb" -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-subscriberdb

--- a/lte/cloud/helm/lte-orc8r/templates/subscriberdb_cache.pdb.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/subscriberdb_cache.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "subscriberdb_cache.pdb") -}}
 {{- define "subscriberdb_cache.pdb" -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-subscriberdb-cache

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/serviceaccount-rbac.yml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/serviceaccount-rbac.yml
@@ -93,7 +93,7 @@ rules:
       - create
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ $serviceAccountName }}

--- a/orc8r/cloud/helm/orc8r/templates/accessd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/accessd.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "accessd.pdb") -}}
 {{- define "accessd.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-accessd

--- a/orc8r/cloud/helm/orc8r/templates/analytics.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/analytics.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "analytics.pdb") -}}
 {{- define "analytics.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-analytics

--- a/orc8r/cloud/helm/orc8r/templates/bootstrapper.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/bootstrapper.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "bootstrapper.pdb") -}}
 {{- define "bootstrapper.pdb" -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-bootstrapper

--- a/orc8r/cloud/helm/orc8r/templates/certifier.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/certifier.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "certifier.pdb") -}}
 {{- define "certifier.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-certifier

--- a/orc8r/cloud/helm/orc8r/templates/configurator.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/configurator.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "configurator.pdb") -}}
 {{- define "configurator.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-configurator

--- a/orc8r/cloud/helm/orc8r/templates/ctraced.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ctraced.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "ctraced.pdb") -}}
 {{- define "ctraced.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-ctraced

--- a/orc8r/cloud/helm/orc8r/templates/device.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/device.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "device.pdb") -}}
 {{- define "device.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-device

--- a/orc8r/cloud/helm/orc8r/templates/directoryd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/directoryd.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "directoryd.pdb") -}}
 {{- define "directoryd.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-directoryd

--- a/orc8r/cloud/helm/orc8r/templates/dispatcher.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dispatcher.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "dispatcher.pdb") -}}
 {{- define "dispatcher.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-dispatcher

--- a/orc8r/cloud/helm/orc8r/templates/eventd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/eventd.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "eventd.pdb") -}}
 {{- define "eventd.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-eventd

--- a/orc8r/cloud/helm/orc8r/templates/metricsd.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/metricsd.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "metricsd.pdb") -}}
 {{- define "metricsd.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-metricsd

--- a/orc8r/cloud/helm/orc8r/templates/nginx.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/nginx.pdb.yaml
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if and .Values.nginx.podDisruptionBudget.enabled (gt .Values.nginx.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}-nginx-proxy

--- a/orc8r/cloud/helm/orc8r/templates/obsidian.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/obsidian.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "obsidian.pdb") -}}
 {{- define "obsidian.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-obsidian

--- a/orc8r/cloud/helm/orc8r/templates/orc8r_worker.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orc8r_worker.pdb.yaml
@@ -12,7 +12,7 @@ limitations under the License.
 */}}
 {{- include "orc8rlib.pdb" (list . "orc8r_worker.pdb") -}}
 {{- define "orc8r_worker.pdb" -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-orc8r-worker

--- a/orc8r/cloud/helm/orc8r/templates/orchestrator.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orchestrator.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "orchestrator.pdb") -}}
 {{- define "orchestrator.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-orchestrator

--- a/orc8r/cloud/helm/orc8r/templates/service_registry.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/service_registry.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "service_registry.pdb") -}}
 {{- define "service_registry.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-service-registry

--- a/orc8r/cloud/helm/orc8r/templates/state.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/state.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "state.pdb") -}}
 {{- define "state.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-state

--- a/orc8r/cloud/helm/orc8r/templates/streamer.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/streamer.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "streamer.pdb") -}}
 {{- define "streamer.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-streamer

--- a/orc8r/cloud/helm/orc8r/templates/tenants.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/tenants.pdb.yaml
@@ -13,7 +13,7 @@ limitations under the License.
 {{- include "orc8rlib.pdb" (list . "tenants.pdb") -}}
 {{- define "tenants.pdb" -}}
 {{- if and .Values.controller.podDisruptionBudget.enabled (ge .Values.controller.replicas 1.0 )}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: orc8r-tenants


### PR DESCRIPTION
## Context

As I am working on updating the official docs for deploying orc8r with Minikube ([Deploy on Minikube](https://docs.magmacore.org/orc8r/dev_minikube)), I am using Minikube to deploy orc8r on a Kubernetes cluster. The old docs use Kubernetes 1.20 which modern Minikube rejects, my updated documentation uses Kubernetes 1.28 which removed the old API versions that the orc8r and lte-orc8r Helm charts still use.

this PR will be followed by:
- A PR updating the existing Minikube deployment page in the official docs
- A PR adding Minikube support to the magma-deployer

## Summary

Kubernetes 1.25 removed `policy/v1beta1` (PodDisruptionBudget) and `rbac.authorization.k8s.io/v1beta1` (ClusterRoleBinding). The orc8r and lte-orc8r Helm charts still use these removed API versions, causing `helm upgrade --install` to fail on any cluster running Kubernetes 1.25+.

This PR updates all affected templates to the stable API versions:
- `policy/v1beta1` → `policy/v1` (across orc8r and lte-orc8r charts)
- `rbac.authorization.k8s.io/v1beta1` → `rbac.authorization.k8s.io/v1`

## Test Plan

Validated on Kubernetes v1.28.0 (Minikube) on both orc8r v1.8 and v1.9.

Without this fix, the install fails with: no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"

With this fix, `helm upgrade --install` succeeds and all pods reach Running state.

## Additional Information

- [ ] This change is backwards-breaking

Since policy/v1 is supported in Kubernetes 1.21 and later versions and policy/v1beta1 was removed in 1.25, this is not a breaking change, see [Kubernetes deprecated API migration guide (v1.25)](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125).

## Security Considerations

No security impact.