### PR TITLE
fix(orc8r): replace removed nginx "ssl on" directive with "listen ... ssl"

### DIFF
--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_certs_nginx_proxy_ssl.conf.tpl
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_certs_nginx_proxy_ssl.conf.tpl
@@ -1,6 +1,5 @@
 server {
-  listen 443;
-  ssl on;
+  listen 443 ssl;
   ssl_certificate /var/opt/magma/certs/nms/tls.crt;
   ssl_certificate_key /var/opt/magma/certs/nms/tls.key;
   location / {

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_nginx_proxy_ssl.conf.tpl
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_nginx_proxy_ssl.conf.tpl
@@ -1,6 +1,5 @@
 server {
-  listen 443;
-  ssl on;
+  listen 443 ssl;
   ssl_certificate /etc/nginx/conf.d/nms_nginx.pem;
   ssl_certificate_key /etc/nginx/conf.d/nms_nginx.key.pem;
   location / {


### PR DESCRIPTION
## Summary

The `nms-nginx-proxy` TLS config templates render an nginx server block that uses the
legacy `ssl on;` directive:

```nginx
server {
  listen 443;
  ssl on;
  ...
}
```

The standalone `ssl` directive was made **obsolete in nginx 1.15.0** and **removed in
nginx 1.25.1** (see the [ngx_http_ssl_module docs](https://nginx.org/en/docs/http/ngx_http_ssl_module.html)).
On any nginx image at 1.25.1 or newer — which the current `nms-nginx-proxy` image uses —
nginx aborts at config-parse time with:

```
[emerg] unknown directive "ssl" in /etc/nginx/conf.d/nginx_proxy_ssl.conf:3
```

so the pod never starts and enters a crash loop. This is tracked in #15541.

This PR replaces `listen 443; ssl on;` with the documented replacement `listen 443 ssl;`
in both TLS templates. TLS behaviour is unchanged; only the deprecated/removed syntax is
updated.

Files changed:
- `orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_nginx_proxy_ssl.conf.tpl`
- `orc8r/cloud/helm/orc8r/charts/nms/templates/etc/_certs_nginx_proxy_ssl.conf.tpl`

## Test Plan

Validated the rendered server block with `nginx -t` on **nginx 1.31.3** (removal-era,
same generation as the `nms-nginx-proxy` container):

```
# BEFORE  (listen 443; ssl on;)
nginx: [emerg] unknown directive "ssl" in OLD.conf
nginx: configuration file OLD.conf test failed          # exit 1  (== #15541)

# AFTER   (listen 443 ssl;)
nginx: the configuration file NEW.conf syntax is ok
nginx: configuration file NEW.conf test is successful   # exit 0
```

Also confirmed the fixed syntax still passes on the older deprecation-era nginx 1.18. TLS is
still served on 443 with the same cert/key.

## Additional Information

- [ ] This change is backwards-breaking

Not backwards-breaking: `listen ... ssl` has been supported since nginx 0.7.14 and is the
only supported form from 1.25.1 onward, so the change is compatible with both old and new
nginx.

## Security Considerations

No negative security impact. TLS remains enabled on port 443 with the same certificate/key.
The change actually restores TLS termination on modern nginx (where the pod currently fails
to start), removing an availability failure.

Fixes #15541
