### PR TITLE
fix(nms): spread bulk-added subscribers into subscriber map

### DIFF
--- a/nms/app/context/SubscriberContext.tsx
+++ b/nms/app/context/SubscriberContext.tsx
@@ -178,9 +178,7 @@ async function setSubscriberState(params: {
     value.map(newSubscriber => {
       newSubscriberMap[newSubscriber.id] = newSubscriber as Subscriber;
     });
-    // TODO[TS-migration] Should newSubscriberMap be spread here?
-    // @ts-ignore
-    setSubscriberMap({...subscriberMap, newSubscriberMap});
+    setSubscriberMap({...subscriberMap, ...newSubscriberMap});
     return;
   }
   if (value != null) {

--- a/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.tsx
+++ b/nms/app/views/subscriber/__tests__/SubscriberAddEditTest.tsx
@@ -16,21 +16,24 @@ import LteNetworkContext, {
 } from '../../../context/LteNetworkContext';
 import PolicyContext, {PolicyContextType} from '../../../context/PolicyContext';
 import React from 'react';
+import SubscriberContext, {
+  SubscriberContextProvider,
+} from '../../../context/SubscriberContext';
 import SubscriberDashboard from '../SubscriberOverview';
 import SubscriberDetailConfig from '../SubscriberDetailConfig';
 import defaultTheme from '../../../theme/default';
-import {SubscriberContextProvider} from '../../../context/SubscriberContext';
 
 import MagmaAPI from '../../../api/MagmaAPI';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {
+  MutableSubscriber,
   NetworkEpcConfigs,
   NetworkRanConfigs,
   PolicyRule,
   Subscriber,
 } from '../../../../generated';
 import {StyledEngineProvider, ThemeProvider} from '@mui/material/styles';
-import {fireEvent, render, waitFor, within} from '@testing-library/react';
+import {act, fireEvent, render, waitFor, within} from '@testing-library/react';
 import {forbiddenNetworkTypes} from '../SubscriberUtils';
 import {mockAPI} from '../../../util/TestUtils';
 import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
@@ -475,5 +478,85 @@ describe('<AddSubscriberButton />', () => {
         },
       });
     });
+  });
+
+  it('given bulk-added subscribers when added then map is keyed by IMSI', async () => {
+    let capturedCtx: React.ContextType<typeof SubscriberContext> | undefined;
+    const CaptureConsumer = () => {
+      capturedCtx = React.useContext(SubscriberContext);
+      return (
+        <div data-testid="subscriberImsis">
+          {Object.keys(capturedCtx.state).join(',')}
+        </div>
+      );
+    };
+
+    const {findByTestId, getByTestId} = render(
+      <SubscriberContextProvider networkId="test">
+        <CaptureConsumer />
+      </SubscriberContextProvider>,
+    );
+
+    // Wait for the provider to finish loading the initial subscriber map.
+    await findByTestId('subscriberImsis');
+    await waitFor(() =>
+      expect(getByTestId('subscriberImsis')).toHaveTextContent(
+        'IMSI00000000001002',
+      ),
+    );
+
+    const newSubscribers: Array<MutableSubscriber> = [
+      {
+        id: 'IMSI00000000001099',
+        name: 'bulk_subscriber_0',
+        lte: {
+          auth_algo: 'MILENAGE',
+          // Placeholder auth values (not real credentials); kept low-entropy
+          // so secret scanners do not flag this test fixture.
+          auth_key: 'AAAAAAAAAAAAAAAAAAAAAA==',
+          auth_opc: 'AAAAAAAAAAAAAAAAAAAAAA==',
+          state: 'ACTIVE',
+          sub_profile: 'default',
+        },
+      },
+      {
+        id: 'IMSI00000000001100',
+        name: 'bulk_subscriber_1',
+        lte: {
+          auth_algo: 'MILENAGE',
+          // Placeholder auth values (not real credentials); kept low-entropy
+          // so secret scanners do not flag this test fixture.
+          auth_key: 'AAAAAAAAAAAAAAAAAAAAAA==',
+          auth_opc: 'AAAAAAAAAAAAAAAAAAAAAA==',
+          state: 'ACTIVE',
+          sub_profile: 'default',
+        },
+      },
+    ];
+
+    // A bulk add passes an array of subscribers, which triggers the
+    // Array.isArray(value) branch in setSubscriberState.
+    await act(async () => {
+      await capturedCtx!.setState!('', newSubscribers);
+    });
+
+    const stateKeys = Object.keys(capturedCtx!.state);
+
+    // The newly added subscribers must be spread into the map, each keyed by
+    // its own IMSI (alongside the pre-existing subscribers)...
+    expect(stateKeys).toEqual(
+      expect.arrayContaining([
+        'IMSI00000000001002',
+        'IMSI00000000001003',
+        'IMSI00000000001099',
+        'IMSI00000000001100',
+      ]),
+    );
+    expect(capturedCtx!.state['IMSI00000000001099']).toBeDefined();
+    expect(capturedCtx!.state['IMSI00000000001100']).toBeDefined();
+
+    // ...and must NOT be nested under a literal `newSubscriberMap` key, which
+    // was the data-corruption bug previously masked by `@ts-ignore`.
+    expect('newSubscriberMap' in capturedCtx!.state).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The bulk "add subscribers" flow in the NMS was corrupting the `SubscriberContext` map. On a bulk add, the new subscribers were not merged into the map by IMSI; the whole batch got stored under a single literal key, `newSubscriberMap`.

After a bulk add the map ended up like this:

```
{ IMSI...002: {...}, IMSI...003: {...}, newSubscriberMap: { IMSI...099: {...}, IMSI...100: {...} } }
```

instead of a flat map keyed by IMSI. As a result, every consumer of the context (the subscriber table, the detail pages, the gateway to subscriber mapping, the KPIs) saw a bogus `newSubscriberMap` entry where an IMSI should be, and the newly added subscribers were missing until the page did a full refetch.

The cause is in `nms/app/context/SubscriberContext.tsx`, in the `Array.isArray(value)` branch of `setSubscriberState`:

```ts
// before
setSubscriberMap({...subscriberMap, newSubscriberMap});
```

`{...subscriberMap, newSubscriberMap}` is shorthand for `{...subscriberMap, newSubscriberMap: newSubscriberMap}`, so the whole map gets nested under the literal `newSubscriberMap` key instead of being spread in. TypeScript had actually flagged this, but the error was silenced with a `// @ts-ignore` and a leftover `// TODO[TS-migration] Should newSubscriberMap be spread here?` comment. The single-add branch and the delete branch next to it already spread correctly, so this branch was just missing the `...`.

The fix is one line: spread it the same way the neighboring branches do, and drop the suppression.

```diff
-    // TODO[TS-migration] Should newSubscriberMap be spread here?
-    // @ts-ignore
-    setSubscriberMap({...subscriberMap, newSubscriberMap});
+    setSubscriberMap({...subscriberMap, ...newSubscriberMap});
```

With the spread in place the type error goes away, so the `@ts-ignore` is no longer needed. That also answers the old TODO: yes, it should have been spread.

Some history, in case it helps review: the missing spread goes back to the original bulk-add PR (#7317) from the Flow days, and the `@ts-ignore` and TODO were added later during the flow to TypeScript migration (#13098). The file was moved once afterwards in #13325, but the line itself never changed. There does not seem to be an existing issue or PR that covers it.

## Test Plan

A regression test was added in `nms/app/views/subscriber/__tests__/SubscriberAddEditTest.tsx`. It mounts `SubscriberContextProvider`, does a bulk add of two subscribers, and asserts the context map is keyed by IMSI with no `newSubscriberMap` key.

With the fix applied:

```
PASS app app/views/subscriber/__tests__/SubscriberAddEditTest.tsx (20.274 s)
  <AddSubscriberButton />
    √ Verify Subscribers Add (7792 ms)
    √ Verify Subscriber edit (977 ms)
    √ given bulk-added subscribers when added then map is keyed by IMSI (118 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

Reverting just the one-line fix makes the new test fail, which confirms it catches the bug:

```
FAIL app app/views/subscriber/__tests__/SubscriberAddEditTest.tsx
  × given bulk-added subscribers when added then map is keyed by IMSI
    expect(received).toEqual(expected) // deep equality
    Expected: ArrayContaining ["IMSI00000000001002", "IMSI00000000001003", "IMSI00000000001099", "IMSI00000000001100"]
    Received:                 ["IMSI00000000001002", "IMSI00000000001003", "newSubscriberMap"]
```

`tsc --noEmit` and `eslint` on both changed files come back clean.

Passing test run:

![SubscriberAddEditTest passing: Tests 3 passed, 3 total, including the new bulk-add regression test](https://raw.githubusercontent.com/Hammaduddin561/magma/pr-16035-screenshot/subscriber-map-test-pass.png)

## Additional Information

- [ ] This change is backwards-breaking

This is a client-side bug fix. It only changes the in-memory shape of the `SubscriberContext` map back to the flat IMSI-keyed form the rest of the app already expects, so there are no API, schema, migration, or config changes.

## Security Considerations

No security impact. This corrects an internal React context data structure, so there are no new inputs, endpoints, or permissions. If anything it removes a data-integrity bug, since operators were seeing an incomplete subscriber list after a bulk add.
