### PR TITLE
fix(nms): keep read-only gateway fields when caching a gateway edit

### DIFF
--- a/nms/app/context/GatewayContext.tsx
+++ b/nms/app/context/GatewayContext.tsx
@@ -104,21 +104,27 @@ async function setGatewayState(params: {
   const {networkId, lteGateways, setLteGateways, key, value} = params;
 
   if (value != null) {
-    if (!(key in lteGateways)) {
+    const isNewGateway = !(key in lteGateways);
+    if (isNewGateway) {
       await MagmaAPI.lteGateways.lteNetworkIdGatewaysPost({
         networkId: networkId,
         gateway: value,
       });
-      // TODO[TS-migration] does it make sense that value is of type MutableLteGateway?
-      setLteGateways({...lteGateways, [key]: value as LteGateway});
     } else {
       await MagmaAPI.lteGateways.lteNetworkIdGatewaysGatewayIdPut({
         networkId: networkId,
         gatewayId: key,
         gateway: value,
       });
-      setLteGateways({...lteGateways, [key]: value as LteGateway});
     }
+    // value is a MutableLteGateway, so it does not carry the read-only fields
+    // of an LteGateway (status, checked_in_recently, registration_info). Merge
+    // it into the cached gateway to keep them, a gateway which is not cached
+    // yet has not checked in either.
+    const gateway: LteGateway = isNewGateway
+      ? {...value, checked_in_recently: false}
+      : {...lteGateways[key], ...value};
+    setLteGateways({...lteGateways, [key]: gateway});
   } else {
     await MagmaAPI.lteGateways.lteNetworkIdGatewaysGatewayIdDelete({
       networkId: networkId,

--- a/nms/app/views/equipment/__tests__/GatewayConfigTest.tsx
+++ b/nms/app/views/equipment/__tests__/GatewayConfigTest.tsx
@@ -14,18 +14,25 @@
 import AddEditGatewayButton from '../GatewayDetailConfigEdit';
 import ApnContext from '../../../context/ApnContext';
 import GatewayConfig from '../GatewayDetailConfig';
+import GatewayContext, {
+  GatewayContextProvider,
+} from '../../../context/GatewayContext';
 import LteNetworkContext from '../../../context/LteNetworkContext';
 import MagmaAPI from '../../../api/MagmaAPI';
 import React from 'react';
 import defaultTheme from '../../../theme/default';
 import {DynamicServices} from '../../../components/GatewayUtils';
-import {GatewayContextProvider} from '../../../context/GatewayContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {StyledEngineProvider, ThemeProvider} from '@mui/material/styles';
-import {fireEvent, render, waitFor, within} from '@testing-library/react';
+import {act, fireEvent, render, waitFor, within} from '@testing-library/react';
 import {mockAPI} from '../../../util/TestUtils';
 import {useEnqueueSnackbar} from '../../../hooks/useSnackbar';
-import type {Apn, LteGateway, LteNetwork} from '../../../../generated';
+import type {
+  Apn,
+  LteGateway,
+  LteNetwork,
+  MutableLteGateway,
+} from '../../../../generated';
 
 jest.mock('axios');
 jest.mock('../../../hooks/useSnackbar');
@@ -839,6 +846,68 @@ describe('<AddEditGatewayButton />', () => {
         networkId: 'test',
       });
     });
+  });
+});
+
+describe('<GatewayContextProvider />', () => {
+  const mockHealthyGw: LteGateway = {
+    ...mockGw0,
+    id: 'testGatewayId0',
+    checked_in_recently: true,
+    status: {checkin_time: 1629340000000},
+  };
+
+  beforeEach(() => {
+    (useEnqueueSnackbar as jest.Mock).mockReturnValue(jest.fn());
+    mockAPI(MagmaAPI.lteGateways, 'lteNetworkIdGatewaysGet', {
+      [mockHealthyGw.id]: mockHealthyGw,
+    });
+    mockAPI(MagmaAPI.lteGateways, 'lteNetworkIdGatewaysGatewayIdPut');
+  });
+
+  it('given a gateway edit without read-only fields when saved then the cached gateway keeps them', async () => {
+    let gatewayCtx: React.ContextType<typeof GatewayContext> | undefined;
+    const CaptureConsumer = () => {
+      gatewayCtx = React.useContext(GatewayContext);
+      return null;
+    };
+
+    render(
+      <GatewayContextProvider networkId="test">
+        <CaptureConsumer />
+      </GatewayContextProvider>,
+    );
+
+    await waitFor(() =>
+      expect(gatewayCtx?.state[mockHealthyGw.id]).toBeDefined(),
+    );
+
+    // setState takes a MutableLteGateway, which omits the read-only fields of
+    // the gateway. The gateway JSON editor for example removes the status
+    // before handing the gateway over to be saved.
+    const editedGateway: MutableLteGateway = {
+      apn_resources: mockHealthyGw.apn_resources,
+      cellular: mockHealthyGw.cellular,
+      connected_enodeb_serials: mockHealthyGw.connected_enodeb_serials,
+      description: mockHealthyGw.description,
+      device: mockHealthyGw.device,
+      id: mockHealthyGw.id,
+      magmad: mockHealthyGw.magmad,
+      name: 'editedGatewayName',
+      tier: mockHealthyGw.tier,
+    };
+
+    await act(async () => {
+      await gatewayCtx!.setState(mockHealthyGw.id, editedGateway);
+    });
+
+    const cachedGateway = gatewayCtx!.state[mockHealthyGw.id];
+    expect(cachedGateway.name).toBe('editedGatewayName');
+    // The gateway health of the equipment table, of the gateway detail status
+    // and of the gateway KPIs is read from the cached gateway, so a healthy
+    // gateway must not turn unhealthy after an edit.
+    expect(cachedGateway.checked_in_recently).toBe(true);
+    expect(cachedGateway.status?.checkin_time).toBe(1629340000000);
   });
 });
 


### PR DESCRIPTION
## Summary

Saving a gateway in the NMS dropped the read-only fields of the cached gateway, so a gateway that is actually healthy started reporting Health "Bad" with no Last Check-in time until the page refetched.

`setGatewayState` in `nms/app/context/GatewayContext.tsx` receives a `MutableLteGateway`, which does not carry `status`, `checked_in_recently` or `registration_info`, and wrote it into the gateway cache with a `value as LteGateway` cast. The cast silenced the mismatch instead of handling it, and a `TODO[TS-migration]` was already sitting on that line questioning it.

The gateway JSON editor makes this easy to hit: `GatewayDetailConfig.tsx` deletes `status` before handing the gateway to `setState`, so after saving from Edit JSON the cached gateway has no status at all. Gateway health in the equipment table, the gateway detail status panel and the gateway KPIs are all read from that cached gateway.

The fix merges the edited values into the cached gateway instead of replacing it. A gateway that is not cached yet has not checked in either, so it starts with `checked_in_recently: false`.

```diff
-      // TODO[TS-migration] does it make sense that value is of type MutableLteGateway?
-      setLteGateways({...lteGateways, [key]: value as LteGateway});
+    const gateway: LteGateway = isNewGateway
+      ? {...value, checked_in_recently: false}
+      : {...lteGateways[key], ...value};
+    setLteGateways({...lteGateways, [key]: gateway});
```

This follows what the other contexts already do: `EnodebContext` carries `enb_state` over on update, and `GatewayPoolsContext` defaults `gateway_ids` on create. All 15 context providers were checked; the remaining setters that accept a `Mutable*` type (`TraceContext`, `GatewayPoolsContext`, `CbsdContext`, and the single-subscriber branch of `SubscriberContext`) refetch after the write, so they are unaffected. `FEGGatewayContext` has the identical cast and is fixed separately, since no caller strips its read-only fields today.

`checked_in_recently` was introduced by #12699 (fixing #12004) so gateway health could be evaluated in the backend, and it was consumed by the NMS in #12735. This change stops it from being discarded on save. Open issues #15725 and #15613 report health inaccuracies coming from check-in timing on the deployment side and are distinct from this client side cache defect.

## Test Plan

A regression test was added in `nms/app/views/equipment/__tests__/GatewayConfigTest.tsx`. It mounts `GatewayContextProvider`, saves an edit that carries no read-only fields, and asserts the cached gateway keeps `checked_in_recently` and `status.checkin_time`.

With the fix applied:

```
PASS app app/views/equipment/__tests__/GatewayConfigTest.tsx (37.925 s)
  <AddEditGatewayButton />
    √ Verify Gateway Add (3439 ms)
    √ Verify Gateway Ran Edit (914 ms)
    √ Verify Gateway NGC Config (887 ms)
  <GatewayContextProvider />
    √ given a gateway edit without read-only fields when saved then the cached gateway keeps them (26 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```

Restoring the old cast makes the new test fail, which confirms it catches the bug:

```
FAIL app app/views/equipment/__tests__/GatewayConfigTest.tsx (26.797 s)
  <GatewayContextProvider />
    × given a gateway edit without read-only fields when saved then the cached gateway keeps them (25 ms)

  ● <GatewayContextProvider /> › given a gateway edit without read-only fields when saved then the cached gateway keeps them

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: undefined

    > 909 |     expect(cachedGateway.checked_in_recently).toBe(true);

Test Suites: 1 failed, 1 total
Tests:       1 failed, 3 passed, 4 total
```

`tsc --noEmit` reports 0 errors.

Passing test run:

![GatewayConfigTest passing: Tests 4 passed, 4 total, including the new gateway cache regression test](https://raw.githubusercontent.com/Hammaduddin561/magma/pr-16038-screenshot/gateway-cache-test-pass.png)

## Additional Information

- [ ] This change is backwards-breaking

Client side only. It changes how the in-memory gateway cache is updated after a save, so there are no API, schema, migration or config changes.

## Security Considerations

No security impact. This corrects an internal React context cache and adds no new inputs, endpoints or permissions. It removes a data integrity defect where operators saw a healthy gateway reported as unhealthy after an edit.
