### PR TITLE
fix(nms): keep read-only federation gateway fields when caching a gateway edit

### DIFF
--- a/nms/app/context/FEGGatewayContext.tsx
+++ b/nms/app/context/FEGGatewayContext.tsx
@@ -122,15 +122,17 @@ async function setGatewayState(params: GatewayStateParams) {
         networkId: networkId,
         gateway: value,
       });
-      setFegGateways({...fegGateways, [key]: value as FederationGateway});
     } else {
       await MagmaAPI.federationGateways.fegNetworkIdGatewaysGatewayIdPut({
         networkId: networkId,
         gatewayId: key,
         gateway: value,
       });
-      setFegGateways({...fegGateways, [key]: value as FederationGateway});
     }
+    // value is a MutableFederationGateway, so it does not carry the read-only
+    // fields of a FederationGateway (status, registration_info). Merge it into
+    // the cached gateway to keep them.
+    setFegGateways({...fegGateways, [key]: {...fegGateways[key], ...value}});
     const newFegGatewaysHealthStatus = {...fegGatewaysHealthStatus};
     newFegGatewaysHealthStatus[key] = await getFederationGatewayHealthStatus(
       networkId,

--- a/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.tsx
+++ b/nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.tsx
@@ -11,20 +11,23 @@
  * limitations under the License.
  */
 
+import FEGGatewayContext, {
+  FEGGatewayContextProvider,
+} from '../../../context/FEGGatewayContext';
 import FEGGatewayDetailConfig from '../FEGGatewayDetailConfig';
 import MagmaAPI from '../../../api/MagmaAPI';
 import React from 'react';
 import defaultTheme from '../../../theme/default';
-import {FEGGatewayContextProvider} from '../../../context/FEGGatewayContext';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {StyledEngineProvider, ThemeProvider} from '@mui/material/styles';
-import {fireEvent, render, waitFor} from '@testing-library/react';
+import {act, fireEvent, render, waitFor} from '@testing-library/react';
 import {mockAPI} from '../../../util/TestUtils';
 import type {
   Csfb,
   FederationGateway,
   Gx,
   Gy,
+  MutableFederationGateway,
   S6a,
   Swx,
 } from '../../../../generated';
@@ -418,5 +421,65 @@ describe('<FEGGatewayDetailConfig />', () => {
         },
       });
     });
+  });
+});
+
+describe('<FEGGatewayContextProvider />', () => {
+  const mockCheckedInGw: FederationGateway = {
+    ...mockGw0,
+    status: {checkin_time: 1629340000000},
+  };
+
+  beforeEach(() => {
+    mockAPI(MagmaAPI.federationGateways, 'fegNetworkIdGatewaysGet', {
+      [mockCheckedInGw.id]: mockCheckedInGw,
+    });
+    mockAPI(MagmaAPI.federationGateways, 'fegNetworkIdGatewaysGatewayIdPut');
+    mockAPI(
+      MagmaAPI.federationGateways,
+      'fegNetworkIdGatewaysGatewayIdHealthStatusGet',
+      {status: 'HEALTHY', description: ''},
+    );
+    mockAPI(MagmaAPI.federationNetworks, 'fegNetworkIdClusterStatusGet', {
+      active_gateway: mockCheckedInGw.id,
+    });
+  });
+
+  it('given a gateway edit without read-only fields when saved then the cached gateway keeps them', async () => {
+    let fegGatewayCtx: React.ContextType<typeof FEGGatewayContext> | undefined;
+    const CaptureConsumer = () => {
+      fegGatewayCtx = React.useContext(FEGGatewayContext);
+      return null;
+    };
+
+    render(
+      <FEGGatewayContextProvider networkId="mynetwork">
+        <CaptureConsumer />
+      </FEGGatewayContextProvider>,
+    );
+
+    await waitFor(() =>
+      expect(fegGatewayCtx?.state[mockCheckedInGw.id]).toBeDefined(),
+    );
+
+    // setState takes a MutableFederationGateway, which omits the read-only
+    // fields of the gateway.
+    const editedGateway: MutableFederationGateway = {
+      description: mockCheckedInGw.description,
+      device: mockCheckedInGw.device,
+      federation: mockCheckedInGw.federation,
+      id: mockCheckedInGw.id,
+      magmad: mockCheckedInGw.magmad,
+      name: 'editedGatewayName',
+      tier: mockCheckedInGw.tier,
+    };
+
+    await act(async () => {
+      await fegGatewayCtx!.setState(mockCheckedInGw.id, editedGateway);
+    });
+
+    const cachedGateway = fegGatewayCtx!.state[mockCheckedInGw.id];
+    expect(cachedGateway.name).toBe('editedGatewayName');
+    expect(cachedGateway.status?.checkin_time).toBe(1629340000000);
   });
 });


### PR DESCRIPTION
## Summary

`setGatewayState` in `nms/app/context/FEGGatewayContext.tsx` receives a `MutableFederationGateway`, which does not carry the read-only fields of a `FederationGateway` (`status`, `registration_info`), and wrote it into the federation gateway cache with a `value as FederationGateway` cast. The cast hid the mismatch instead of handling it, so after a federation gateway is saved the cached gateway loses its status and registration info and no longer matches the gateway the API returns.

The fix merges the edited values into the cached gateway instead of replacing it.

```diff
-      setFegGateways({...fegGateways, [key]: value as FederationGateway});
+    setFegGateways({...fegGateways, [key]: {...fegGateways[key], ...value}});
```

`GatewayContext` had the identical cast and is fixed in #16038, where the gateway JSON editor strips `status` before saving and a healthy gateway therefore reports Health "Bad" until the next refetch. The two changes are kept in separate PRs because they are separate contexts: in the federation case no current caller strips the read-only fields, so there is no user visible symptom today. This change keeps the cached federation gateway consistent with the API response and prevents the same defect from appearing when a caller does drop those fields.

## Test Plan

A regression test was added in `nms/app/views/equipment/__tests__/FEGGatewayDetailConfigTest.tsx`. It mounts `FEGGatewayContextProvider`, saves an edit that carries no read-only fields, and asserts the cached gateway keeps `status.checkin_time`.

With the fix applied:

```
PASS app app/views/equipment/__tests__/FEGGatewayDetailConfigTest.tsx (25.543 s)
  <FEGGatewayDetailConfig />
    √ renders federation gateway configs correctly (576 ms)
    √ verify gx edit is working (1438 ms)
    √ verify gy edit is working (919 ms)
    √ verify swx edit is working (718 ms)
    √ verify s6a edit is working (706 ms)
    √ verify csfb edit is working (570 ms)
  <FEGGatewayContextProvider />
    √ given a gateway edit without read-only fields when saved then the cached gateway keeps them (22 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
```

Restoring the old cast makes the new test fail, which confirms it catches the defect:

```
FAIL app app/views/equipment/__tests__/FEGGatewayDetailConfigTest.tsx (23.517 s)
  <FEGGatewayContextProvider />
    × given a gateway edit without read-only fields when saved then the cached gateway keeps them (23 ms)

  ● <FEGGatewayContextProvider /> › given a gateway edit without read-only fields when saved then the cached gateway keeps them

    expect(received).toBe(expected) // Object.is equality

    Expected: 1629340000000
    Received: undefined

    > 483 |     expect(cachedGateway.status?.checkin_time).toBe(1629340000000);

Test Suites: 1 failed, 1 total
Tests:       1 failed, 6 passed, 7 total
```

`tsc --noEmit` reports 0 errors.

Passing test run:

![FEGGatewayDetailConfigTest passing: Tests 7 passed, 7 total, including the new federation gateway cache regression test](https://raw.githubusercontent.com/Hammaduddin561/magma/pr-16039-screenshot/feg-gateway-cache-test-pass.png)

## Additional Information

- [ ] This change is backwards-breaking

Client side only. It changes how the in-memory federation gateway cache is updated after a save, so there are no API, schema, migration or config changes.

## Security Considerations

No security impact. This corrects an internal React context cache and adds no new inputs, endpoints or permissions.
