### PR TITLE
ci: upgrade github actions workflow runners

### DIFF
--- a/.github/workflows/agw-build-publish-container.yml
+++ b/.github/workflows/agw-build-publish-container.yml
@@ -54,7 +54,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.set-agwc-tags.outputs.image_tag }}
       registry: ${{ steps.set-registry.outputs.registry }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
 
@@ -161,7 +161,7 @@ jobs:
       - run: echo "docker-builder-go conclusion = ${{ steps.docker-builder-go.conclusion }}"
 
   build-containers-ghz:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build-containers
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -236,7 +236,7 @@ jobs:
     secrets: inherit
 
   publish-container-test-results:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() && github.event_name == 'push'
     needs: [test-containers-precommit, test-containers-extended, test-containers-extended-long]
     steps:

--- a/.github/workflows/agw-coverage.yml
+++ b/.github/workflows/agw-coverage.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -58,7 +58,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: C / C++ code coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Maximize build space
@@ -111,7 +111,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Python code coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Maximize build space

--- a/.github/workflows/agw-workflow.yml
+++ b/.github/workflows/agw-workflow.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -55,7 +55,7 @@ jobs:
   lint-clang-format:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2 # pin@v0.18.1
       - name: Check clang-format for orc8r/gateway/c
@@ -77,7 +77,7 @@ jobs:
 
   jsonlint-mconfig:
     name: jsonlint-mconfig
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -87,7 +87,7 @@ jobs:
 
   pylint:
     name: pylint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     steps:

--- a/.github/workflows/autolabel-pullrequests.yml
+++ b/.github/workflows/autolabel-pullrequests.yml
@@ -45,7 +45,7 @@ concurrency:
 
 jobs:
   AutoLabelPR:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   backport:
     name: Backport
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: >
       github.event.pull_request.merged
       && contains(join(github.event.pull_request.labels.*.name, ', '), 'apply-')

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       files_changed: ${{ steps.changes.outputs.files_changed }}
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
@@ -76,7 +76,7 @@ jobs:
   bazel_diff:
     needs: path_filter
     name: Bazel-Diff Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       bazel_diff_ran: ${{ steps.bazel_diff_outputs.outputs.bazel_diff_ran }}
       run_package_job: ${{ steps.bazel_diff_outputs.outputs.run_package_job }}
@@ -219,7 +219,7 @@ jobs:
             bazel-target-rule: "cc_test"
             docker-image-cache: "ghcr.io/magma/magma/bazel-cache-prod:latest"
     name: Bazel Test Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Print variables
         run: |
@@ -345,7 +345,7 @@ jobs:
   if_bazel_build_and_test_success:
     name: Run when bazel successful
     needs: bazel_build_and_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: success() # Only run after all matrix jobs have passed
     # See https://github.com/magma/magma/wiki/How-to-set-up-a-required-matrix-workflow-on-GitHub-actions
     # or https://github.com/magma/magma/pull/13562 for more details.
@@ -358,7 +358,7 @@ jobs:
 
   report_result_bazel_build_and_test:
     name: Bazel build and test status
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always()
     # This job always needs to run. It will be green if the bazel_build_and_test
     # job was successful in all matrix jobs or if the job was skipped.
@@ -402,7 +402,7 @@ jobs:
       needs.path_filter.outputs.files_changed == 'true' ||
       github.event_name == 'workflow_dispatch'
     name: Bazel Starlark Format Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
@@ -421,7 +421,7 @@ jobs:
       needs.bazel_diff.outputs.bazel_diff_ran == 'false' ||
       (needs.bazel_diff.outputs.bazel_diff_ran == 'true' && needs.bazel_diff.outputs.py_service_targets != '')
     name: Bazel Python Import Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Out Repo
         # This is necessary for overlays into the Docker container below.
@@ -493,7 +493,7 @@ jobs:
       needs.bazel_diff.outputs.bazel_diff_ran == 'false' ||
       (needs.bazel_diff.outputs.bazel_diff_ran == 'true' && needs.bazel_diff.outputs.run_package_job == 'true')
     name: Bazel Package Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_agw_deb_pkg.outputs.artifacts }}
     steps:
@@ -636,7 +636,7 @@ jobs:
       github.repository_owner == 'magma' &&
       ( github.ref_name == 'master' || startsWith(github.ref_name, 'v1.') )
     name: Sentry release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -693,7 +693,7 @@ jobs:
           sentry-cli --log-level=info releases finalize ${COMMIT_HASH_WITH_VERSION}
   python_file_check:
     name: Check if there are not bazelified python files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -703,7 +703,7 @@ jobs:
           ./bazel/scripts/check_py_bazel.sh
   c_cpp_file_check:
     name: Check if there are non-bazelified c or c++ files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check Out Repo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -37,7 +37,7 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       EVENT_NAME: "${{ github.event_name }}"
       ISSUE_NUMBER: "${{ github.event.number }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       # Version is github job run number when running on master
@@ -87,7 +87,7 @@ jobs:
   orc8r-build:
     if: github.repository_owner == 'magma'
     name: orc8r build job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:
@@ -125,7 +125,7 @@ jobs:
           echo "artifacts=$(echo $ARTIFACTS)" >> $GITHUB_OUTPUT
   cloud-upload:
     name: cloud upload job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' && github.repository_owner == 'magma'
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -141,7 +141,7 @@ jobs:
   cwag-deploy:
     if: github.repository_owner == 'magma'
     name: cwag deploy job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:
@@ -212,7 +212,7 @@ jobs:
   cwf-operator-build:
     if: github.repository_owner == 'magma'
     name: cwf operator build job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -255,7 +255,7 @@ jobs:
   feg-build:
     if: github.repository_owner == 'magma'
     name: feg-build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:
@@ -311,7 +311,7 @@ jobs:
   nms-build:
     if: github.repository_owner == 'magma'
     name: nms-build job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:
@@ -349,7 +349,7 @@ jobs:
   Publish_to_firebase:
     name: Publish to firebase
     if: always() && github.event_name == 'push' && github.repository_owner == 'magma'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       [
         agw-build,
@@ -383,7 +383,7 @@ jobs:
   domain-proxy-build:
     if: github.repository_owner == 'magma'
     name: domain proxy build job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       artifacts: ${{ steps.publish_artifacts.outputs.artifacts }}
     env:

--- a/.github/workflows/check-rebase.yml
+++ b/.github/workflows/check-rebase.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   checkRebase:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       HEAD_FULL_NAME: "${{github.event.pull_request.head.repo.full_name}}"
       BASE_FULL_NAME: "${{github.event.pull_request.base.repo.full_name}}"

--- a/.github/workflows/cloud-workflow.yml
+++ b/.github/workflows/cloud-workflow.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -68,7 +68,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cloud-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
       GO111MODULE: 'on'

--- a/.github/workflows/codeowners-syntax.yml
+++ b/.github/workflows/codeowners-syntax.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   sanity:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Checks-out your repository, which is validated in the next step
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/comment-pr-on-check-failure.yml
+++ b/.github/workflows/comment-pr-on-check-failure.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   skip_check:
     name: Job to check if the workflow ${{ github.event.workflow.name }} can be skipped
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event.workflow_run.event == 'pull_request' ||  github.event.workflow_run.event == 'pull_request_target'
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -75,7 +75,7 @@ jobs:
   comment_pr:
     name: Comment on PR for check ${{ github.event.workflow.name }}
     needs: skip_check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: needs.skip_check.outputs.should_skip == 'false'
     env:
       CHECK_GUIDELINE: "[Guide to the different CI checks and resolution guidelines](https://github.com/magma/magma/wiki/Contributing-Code#continuous-integration-ci--continuous-deployment-cd)"

--- a/.github/workflows/cwag-workflow.yml
+++ b/.github/workflows/cwag-workflow.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Map a step output to a job output
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
@@ -50,7 +50,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwag pre-commit job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/cwf-integ-test.yml
+++ b/.github/workflows/cwf-integ-test.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   docker-build:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Maximize build space

--- a/.github/workflows/cwf-operator.yml
+++ b/.github/workflows/cwf-operator.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Map a step output to a job output
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
@@ -49,7 +49,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: cwf operator pre-commit job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   reverted-pr-check:
     name: Reverted PR Check Job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PR_TITLE: "${{ github.event.pull_request.title }}"
     # Map a step output to a job output
@@ -59,7 +59,7 @@ jobs:
     needs: reverted-pr-check
     if: ${{ needs.reverted-pr-check.outputs.is_reverted_pr == 'false' }}
     name: DCO Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Get PR Commits
         id: 'get-pr-commits'

--- a/.github/workflows/debian-packages-promote.yml
+++ b/.github/workflows/debian-packages-promote.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   debian-packages-promote:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       distribution: ${{ inputs.distribution }}
       source-repository: magma-packages-test

--- a/.github/workflows/docker-builder-devcontainer.yml
+++ b/.github/workflows/docker-builder-devcontainer.yml
@@ -53,7 +53,7 @@ env:
 
 jobs:
   build_dockerfile_bazel_base:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Maximize build space
@@ -72,7 +72,7 @@ jobs:
           df -h
   build_dockerfile_devcontainer:
     needs: build_dockerfile_bazel_base
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Maximize build space

--- a/.github/workflows/docker-builder-python-precommit.yml
+++ b/.github/workflows/docker-builder-python-precommit.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   build_dockerfile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: ./.github/workflows/composite/docker-builder

--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   docker-promote:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BRANCH_TAG: ${{ inputs.branch_tag }}
       RELEASE_TAG: ${{ inputs.release_tag }}

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -63,7 +63,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Markdown lint check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -81,7 +81,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Markdown insync check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -105,7 +105,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Check for missing sidebar pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -120,7 +120,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Check for broken symlinks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -138,7 +138,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: Check for broken URLs in markdown files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec # pin@v1.0.15

--- a/.github/workflows/docusaurus-workflow.yml
+++ b/.github/workflows/docusaurus-workflow.yml
@@ -21,7 +21,7 @@ on:
       - master
 jobs:
   docusaurus-build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Export vars

--- a/.github/workflows/dp-workflow.yml
+++ b/.github/workflows/dp-workflow.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       cc: ${{ steps.filter.outputs.cc }}
       rc: ${{ steps.filter.outputs.rc }}
@@ -93,7 +93,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.cc == 'true' }}
     name: "Configuration controller unit tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERAGE_RCFILE: ${{ github.workspace }}/dp/.coveragerc
       PYTHONPATH: "${{ github.workspace }}"
@@ -138,7 +138,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.rc == 'true' }}
     name: "Radio controller unit tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERAGE_RCFILE: ${{ github.workspace }}/dp/.coveragerc
       PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/build/gen"
@@ -217,7 +217,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.db == 'true' }}
     name: "Domain proxy db migration test"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     continue-on-error: false
     defaults:
       run:
@@ -259,7 +259,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.db == 'true' }}
     name: "DB service unit tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COVERAGE_RCFILE: ${{ github.workspace }}/dp/.coveragerc
       PYTHONPATH: "${{ github.workspace }}:${{ github.workspace }}/build/gen"
@@ -306,7 +306,7 @@ jobs:
 
   integration_tests_orc8r:
     name: "Domain proxy integration tests with orc8r"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: path_filter
     if: ${{ needs.path_filter.outputs.integration_tests_orc8r == 'true' }}
     continue-on-error: false
@@ -321,7 +321,7 @@ jobs:
     name: "Helm chart smoke tests"
     needs: path_filter
     if: ${{ needs.path_filter.outputs.helm == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: dp

--- a/.github/workflows/federated-integ-test.yml
+++ b/.github/workflows/federated-integ-test.yml
@@ -24,7 +24,7 @@ jobs:
   # Build images on ubuntu which is faster than MacOs.
   docker-build-orc8r:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -50,7 +50,7 @@ jobs:
 
   docker-build-feg:
     if: github.repository_owner == 'magma' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:

--- a/.github/workflows/feg-workflow.yml
+++ b/.github/workflows/feg-workflow.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -60,7 +60,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: feg lint and precommit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GO111MODULE: on
       MAGMA_ROOT: "${{ github.workspace }}"

--- a/.github/workflows/fossa-workflow.yml
+++ b/.github/workflows/fossa-workflow.yml
@@ -33,7 +33,7 @@ jobs:
   fossa-analyze:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Download fossa analyze script

--- a/.github/workflows/golang-check-version.yml
+++ b/.github/workflows/golang-check-version.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   check_go_version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:

--- a/.github/workflows/helm-chart-dependency-check.yml
+++ b/.github/workflows/helm-chart-dependency-check.yml
@@ -37,7 +37,7 @@ jobs:
   check_helm_chart_dependencies:
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Check dependency of helm chart ${{ matrix.charts[0] }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0

--- a/.github/workflows/helm-deploy-on-demand.yml
+++ b/.github/workflows/helm-deploy-on-demand.yml
@@ -28,7 +28,7 @@ jobs:
       MAGMA_ROOT: "${{ github.workspace }}"
       EVENT_NAME: "${{ github.event_name }}"
       ISSUE_NUMBER: "${{ github.event.number }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - name: Launch build and publish script

--- a/.github/workflows/helm-promote.yml
+++ b/.github/workflows/helm-promote.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   helm-promote:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_VERSION: ${{ inputs.magma_version }}
       MAGMA_ARTIFACTORY: https://linuxfoundation.jfrog.io/artifactory

--- a/.github/workflows/insync-checkin.yml
+++ b/.github/workflows/insync-checkin.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   insync-checkin:
     name: insync checkin job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:

--- a/.github/workflows/magma-build-3rd-party.yml
+++ b/.github/workflows/magma-build-3rd-party.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   build_dependencies:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ghcr.io/magma/magma/devcontainer:sha-84cfceb
     env:
       repository: magma-packages-test

--- a/.github/workflows/magma-build-openvswitch.yml
+++ b/.github/workflows/magma-build-openvswitch.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   build-packages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: ${{ github.workspace }}
       DEST: ${{ github.workspace }}/deb_packages

--- a/.github/workflows/magma-publish-go.yml
+++ b/.github/workflows/magma-publish-go.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build_dependencies:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Download Go package

--- a/.github/workflows/nms-workflow.yml
+++ b/.github/workflows/nms-workflow.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   path_filter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
     steps:
@@ -62,7 +62,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-typescript job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: "${{ github.workspace }}/nms"
@@ -81,7 +81,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-eslint job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -109,7 +109,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-yarn-test job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
     steps:
@@ -126,7 +126,7 @@ jobs:
     needs: path_filter
     if: ${{ needs.path_filter.outputs.should_not_skip == 'true' }}
     name: nms-e2e-test job
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAGMA_ROOT: "${{ github.workspace }}"
       NMS_ROOT: "${{ github.workspace }}/nms"

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   # This job is a manual approximation of https://github.com/peter-evans/create-or-update-comment
   comment:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6.3.3
         with:

--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   pre_job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_not_skip: ${{ steps.changes.outputs.filesChanged }}
       files_changed: ${{ steps.changes.outputs.filesChanged_files }}
@@ -67,7 +67,7 @@ jobs:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_not_skip == 'true' }}
     name: Python Format Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:

--- a/.github/workflows/reviewdog-workflow.yml
+++ b/.github/workflows/reviewdog-workflow.yml
@@ -30,7 +30,7 @@ concurrency:
 # github-pr-review: Adds lint as GitHub comments
 jobs:
   files_changed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       changed_cpp: ${{ steps.changes.outputs.cpp }}
       changed_javascript: ${{ steps.changes.outputs.javascript }}
@@ -68,7 +68,7 @@ jobs:
     #  For details on cpplint options see the detailed comments in
     #  https://github.com/google/styleguide/blob/gh-pages/cpplint/cpplint.py
     ##
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -92,7 +92,7 @@ jobs:
   golangci-lint:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_go == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -109,7 +109,7 @@ jobs:
 
   hadolint:
     name: dockerfile-lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -130,7 +130,7 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_javascript == 'true' }}
     name: eslint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -155,7 +155,7 @@ jobs:
 
   markdownlint:
     name: markdownlint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -174,7 +174,7 @@ jobs:
 
   misspell:
     name: misspell
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -196,7 +196,7 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_python == 'true' }}
     name: mypy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code.
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
@@ -213,7 +213,7 @@ jobs:
 
   shellcheck:
     name: shellcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -232,7 +232,7 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_terraform == 'true' }}
     name: tflint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -252,7 +252,7 @@ jobs:
     needs: files_changed
     if: ${{ needs.files_changed.outputs.changed_python == 'true' }}
     name: wemake-python-styleguide
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:
@@ -284,7 +284,7 @@ jobs:
 
   yamllint:
     name: yamllint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
         with:

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   check-semantic-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: amannn/action-semantic-pull-request@01d5fd8a8ebb9aafe902c40c53f0f4744f7381eb # pin@v5.0.2
         id: semantic-pr

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   skip_check:
     name: Job to retrieve the value in pr/skipped file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -70,7 +70,7 @@ jobs:
   unit-test-results:
     name: Upload unit test for ${{ github.event.workflow.name }}
     needs: skip_check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: >
       github.event.workflow_run.conclusion != 'skipped' &&
         github.event.workflow_run.head_repository.full_name != github.repository &&


### PR DESCRIPTION
<!--
fix:ci=upgraded github actions workflow runners
-->

## Summary

- updated `runs on: ubuntu 20.04` to `runs on: ubuntu 22.04` across all GitHub action workflow files.
- no `runs on: ubuntu 18.04` references found, so no change.
- close #14866

## Test Plan
- ran `grep -rn "ubuntu-20.04" .github/workflows/` before and after the change to confirm  all occurrences were updated.
- opened this as a draft PR so all CI workflows run against the updated runners and validate the change end-to-end.


