### PR TITLE
fix(agw): scope Docker upgrades to Compose project

### DIFF
--- a/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade.sh
+++ b/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade.sh
@@ -11,9 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
+DOCKER_DIR=${MAGMA_DOCKER_DIR:-/var/opt/magma/docker}
+
 RUNNING_TAG=$(docker ps --filter name=magmad --format "{{.Image}}" | cut -d ":" -f 2)
 
-source /var/opt/magma/docker/.env
+source "$DOCKER_DIR/.env"
 
 # If tag running is equal to .env, then do nothing
 if [ "$RUNNING_TAG" == "$IMAGE_VERSION" ]; then
@@ -26,23 +28,35 @@ if pidof -o %PPID -x $0 >/dev/null; then
 fi
 
 # Otherwise recreate containers with the new image
-cd /var/opt/magma/docker || exit
+cd "$DOCKER_DIR" || exit
+
+COMPOSE=(docker compose --compatibility -f docker-compose.yaml)
 
 # Validate docker-compose file
-CONFIG=$(docker compose --compatibility -f docker-compose.yaml config)
+CONFIG=$("${COMPOSE[@]}" config)
 if [ -z "$CONFIG" ]; then
   echo "docker-compose.yaml is not valid"
   exit
 fi
 
 # Pull all images
-[[ -z "$DOCKER_REGISTRY" ]] || docker compose --compatibility pull
+OLD_IMAGES=$("${COMPOSE[@]}" images -q | sort -u)
+[[ -z "$DOCKER_REGISTRY" ]] || "${COMPOSE[@]}" pull
 
-CONTAINERS=$(docker ps -a -q)
-[[ -z "$CONTAINERS" ]] || docker stop "$CONTAINERS"
+# Stop and remove only containers that belong to this Compose project. Other
+# workloads may share the Docker host and must not be interrupted by an AGW
+# upgrade.
+"${COMPOSE[@]}" down --remove-orphans
 
 # Bring containers up
-docker compose --compatibility up -d
+"${COMPOSE[@]}" up -d
 
-# Remove all stopped containers and dangling images
-docker system prune -af
+# Remove old AGW images only when no container still references them. Docker
+# refuses to remove an image that is in use, but checking first avoids noisy
+# failures when an image is shared with another workload.
+while IFS= read -r image; do
+  [[ -z "$image" ]] && continue
+  if ! docker ps -a -q --filter "ancestor=$image" | grep -q .; then
+    docker image rm "$image" || true
+  fi
+done <<< "$OLD_IMAGES"

--- a/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade.sh
+++ b/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade.sh
@@ -15,6 +15,7 @@ DOCKER_DIR=${MAGMA_DOCKER_DIR:-/var/opt/magma/docker}
 
 RUNNING_TAG=$(docker ps --filter name=magmad --format "{{.Image}}" | cut -d ":" -f 2)
 
+# shellcheck source=/dev/null
 source "$DOCKER_DIR/.env"
 
 # If tag running is equal to .env, then do nothing

--- a/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade.sh
+++ b/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade.sh
@@ -11,53 +11,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-DOCKER_DIR=${MAGMA_DOCKER_DIR:-/var/opt/magma/docker}
+readonly DOCKER_DIR=/var/opt/magma/docker
 
-RUNNING_TAG=$(docker ps --filter name=magmad --format "{{.Image}}" | cut -d ":" -f 2)
+upgrade_agw() {
+  local docker_dir=$1
+  local docker_registry=''
+  local image_version=''
+  local key
+  local value
 
-# shellcheck source=/dev/null
-source "$DOCKER_DIR/.env"
-
-# If tag running is equal to .env, then do nothing
-if [ "$RUNNING_TAG" == "$IMAGE_VERSION" ]; then
-  exit
-fi
-
-if pidof -o %PPID -x $0 >/dev/null; then
-  echo "Upgrade process already running"
-  exit
-fi
-
-# Otherwise recreate containers with the new image
-cd "$DOCKER_DIR" || exit
-
-COMPOSE=(docker compose --compatibility -f docker-compose.yaml)
-
-# Validate docker-compose file
-CONFIG=$("${COMPOSE[@]}" config)
-if [ -z "$CONFIG" ]; then
-  echo "docker-compose.yaml is not valid"
-  exit
-fi
-
-# Pull all images
-OLD_IMAGES=$("${COMPOSE[@]}" images -q | sort -u)
-[[ -z "$DOCKER_REGISTRY" ]] || "${COMPOSE[@]}" pull
-
-# Stop and remove only containers that belong to this Compose project. Other
-# workloads may share the Docker host and must not be interrupted by an AGW
-# upgrade.
-"${COMPOSE[@]}" down --remove-orphans
-
-# Bring containers up
-"${COMPOSE[@]}" up -d
-
-# Remove old AGW images only when no container still references them. Docker
-# refuses to remove an image that is in use, but checking first avoids noisy
-# failures when an image is shared with another workload.
-while IFS= read -r image; do
-  [[ -z "$image" ]] && continue
-  if ! docker ps -a -q --filter "ancestor=$image" | grep -q .; then
-    docker image rm "$image" || true
+  if [[ ! -r "$docker_dir/.env" ]]; then
+    echo "Unable to read $docker_dir/.env" >&2
+    return 1
   fi
-done <<< "$OLD_IMAGES"
+
+  # Read only the values needed by this script. Docker Compose loads the same
+  # .env file itself; executing it as shell code is unnecessary.
+  while IFS='=' read -r key value; do
+    case "$key" in
+      DOCKER_REGISTRY) docker_registry=$value ;;
+      IMAGE_VERSION) image_version=$value ;;
+    esac
+  done < "$docker_dir/.env"
+
+  local running_tag
+  running_tag=$(docker ps --filter name=magmad --format "{{.Image}}" | cut -d ":" -f 2)
+
+  # If tag running is equal to .env, then do nothing
+  if [ "$running_tag" == "$image_version" ]; then
+    return 0
+  fi
+
+  if pidof -o %PPID -x "$0" >/dev/null; then
+    echo "Upgrade process already running"
+    return 0
+  fi
+
+  # Otherwise recreate containers with the new image
+  cd "$docker_dir" || return 1
+
+  local -a compose=(docker compose --compatibility -f docker-compose.yaml)
+
+  # Validate docker-compose file
+  local config
+  config=$("${compose[@]}" config)
+  if [ -z "$config" ]; then
+    echo "docker-compose.yaml is not valid"
+    return 1
+  fi
+
+  # Pull all images
+  local old_images
+  old_images=$("${compose[@]}" images -q | sort -u)
+  [[ -z "$docker_registry" ]] || "${compose[@]}" pull
+
+  # Stop and remove only containers that belong to this Compose project. Other
+  # workloads may share the Docker host and must not be interrupted by an AGW
+  # upgrade.
+  "${compose[@]}" down --remove-orphans
+
+  # Bring containers up
+  "${compose[@]}" up -d
+
+  # Remove old AGW images only when no container still references them. Docker
+  # refuses to remove an image that is in use, but checking first avoids noisy
+  # failures when an image is shared with another workload.
+  local image
+  while IFS= read -r image; do
+    [[ -z "$image" ]] && continue
+    if ! docker ps -a -q --filter "ancestor=$image" | grep -q .; then
+      docker image rm "$image" || true
+    fi
+  done <<< "$old_images"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  upgrade_agw "$DOCKER_DIR"
+fi

--- a/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade_test.py
+++ b/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade_test.py
@@ -33,8 +33,11 @@ class AgwUpgradeTest(TestCase):
             docker_dir.mkdir()
             fake_bin.mkdir()
 
+            env_execution_marker = root / 'env-was-executed'
             (docker_dir / '.env').write_text(
-                'IMAGE_VERSION=new\nDOCKER_REGISTRY=registry.example/\n',
+                'IMAGE_VERSION=new\n'
+                'DOCKER_REGISTRY=registry.example/\n'
+                f'UNUSED=$(touch {env_execution_marker})\n',
                 encoding='utf-8',
             )
             (docker_dir / 'docker-compose.yaml').touch()
@@ -65,12 +68,19 @@ class AgwUpgradeTest(TestCase):
             env = os.environ.copy()
             env.update({
                 'DOCKER_LOG': str(docker_log),
-                'MAGMA_DOCKER_DIR': str(docker_dir),
                 'PATH': f'{fake_bin}:{env["PATH"]}',
             })
+            command = [
+                BASH,
+                '-c',
+                'source "$1"; upgrade_agw "$2"',
+                'agw-upgrade-test',
+                str(SCRIPT),
+                str(docker_dir),
+            ]
 
             subprocess.run(  # noqa: S603
-                [BASH, str(SCRIPT)],
+                command,
                 check=True,
                 env=env,
             )
@@ -88,11 +98,12 @@ class AgwUpgradeTest(TestCase):
             self.assertIn('image rm sha256:old-agw-image', calls)
             self.assertFalse(any(call.startswith('stop ') for call in calls))
             self.assertFalse(any('system prune' in call for call in calls))
+            self.assertFalse(env_execution_marker.exists())
 
             docker_log.unlink()
             env['ANCESTOR_IN_USE'] = '1'
             subprocess.run(  # noqa: S603
-                [BASH, str(SCRIPT)],
+                command,
                 check=True,
                 env=env,
             )

--- a/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade_test.py
+++ b/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 Copyright 2026 The Magma Authors.
 
@@ -14,17 +12,20 @@ limitations under the License.
 """
 
 import os
-import subprocess
+import subprocess  # noqa: S404
 import tempfile
 from pathlib import Path
 from unittest import TestCase, main
 
-
+BASH = '/bin/bash'
 SCRIPT = Path(__file__).with_name('agw_upgrade.sh')
 
 
 class AgwUpgradeTest(TestCase):
+    """Verify that AGW upgrades remain scoped to their Compose project."""
+
     def test_upgrade_only_mutates_compose_project(self) -> None:
+        """Keep unrelated containers and referenced images intact."""
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             docker_dir = root / 'docker'
@@ -41,12 +42,12 @@ class AgwUpgradeTest(TestCase):
             docker = fake_bin / 'docker'
             docker.write_text(
                 '#!/bin/bash\n'
-                'printf "%s\\n" "$*" >> "$DOCKER_LOG"\n'
+                'echo "$*" >> "$DOCKER_LOG"\n'
                 'case "$*" in\n'
                 '  "ps --filter name=magmad --format {{.Image}}")\n'
                 '    echo "agw_gateway_python:old" ;;\n'
                 '  "compose --compatibility -f docker-compose.yaml config")\n'
-                '    echo "services: {}" ;;\n'
+                '    echo "services: valid" ;;\n'
                 '  "compose --compatibility -f docker-compose.yaml images -q")\n'
                 '    echo "sha256:old-agw-image" ;;\n'
                 '  "ps -a -q --filter ancestor=sha256:old-agw-image")\n'
@@ -68,7 +69,11 @@ class AgwUpgradeTest(TestCase):
                 'PATH': f'{fake_bin}:{env["PATH"]}',
             })
 
-            subprocess.run(['bash', SCRIPT], check=True, env=env)
+            subprocess.run(  # noqa: S603
+                [BASH, str(SCRIPT)],
+                check=True,
+                env=env,
+            )
             calls = docker_log.read_text(encoding='utf-8').splitlines()
 
             self.assertIn(
@@ -86,7 +91,11 @@ class AgwUpgradeTest(TestCase):
 
             docker_log.unlink()
             env['ANCESTOR_IN_USE'] = '1'
-            subprocess.run(['bash', SCRIPT], check=True, env=env)
+            subprocess.run(  # noqa: S603
+                [BASH, str(SCRIPT)],
+                check=True,
+                env=env,
+            )
             calls = docker_log.read_text(encoding='utf-8').splitlines()
             self.assertNotIn('image rm sha256:old-agw-image', calls)
 

--- a/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade_test.py
+++ b/lte/gateway/deploy/roles/agw_docker/files/agw_upgrade_test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+"""
+Copyright 2026 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import TestCase, main
+
+
+SCRIPT = Path(__file__).with_name('agw_upgrade.sh')
+
+
+class AgwUpgradeTest(TestCase):
+    def test_upgrade_only_mutates_compose_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docker_dir = root / 'docker'
+            fake_bin = root / 'bin'
+            docker_dir.mkdir()
+            fake_bin.mkdir()
+
+            (docker_dir / '.env').write_text(
+                'IMAGE_VERSION=new\nDOCKER_REGISTRY=registry.example/\n',
+                encoding='utf-8',
+            )
+            (docker_dir / 'docker-compose.yaml').touch()
+
+            docker = fake_bin / 'docker'
+            docker.write_text(
+                '#!/bin/bash\n'
+                'printf "%s\\n" "$*" >> "$DOCKER_LOG"\n'
+                'case "$*" in\n'
+                '  "ps --filter name=magmad --format {{.Image}}")\n'
+                '    echo "agw_gateway_python:old" ;;\n'
+                '  "compose --compatibility -f docker-compose.yaml config")\n'
+                '    echo "services: {}" ;;\n'
+                '  "compose --compatibility -f docker-compose.yaml images -q")\n'
+                '    echo "sha256:old-agw-image" ;;\n'
+                '  "ps -a -q --filter ancestor=sha256:old-agw-image")\n'
+                '    test -z "$ANCESTOR_IN_USE" || echo "unrelated" ;;\n'
+                'esac\n',
+                encoding='utf-8',
+            )
+            docker.chmod(0o755)
+
+            pidof = fake_bin / 'pidof'
+            pidof.write_text('#!/bin/bash\nexit 1\n', encoding='utf-8')
+            pidof.chmod(0o755)
+
+            docker_log = root / 'docker.log'
+            env = os.environ.copy()
+            env.update({
+                'DOCKER_LOG': str(docker_log),
+                'MAGMA_DOCKER_DIR': str(docker_dir),
+                'PATH': f'{fake_bin}:{env["PATH"]}',
+            })
+
+            subprocess.run(['bash', SCRIPT], check=True, env=env)
+            calls = docker_log.read_text(encoding='utf-8').splitlines()
+
+            self.assertIn(
+                'compose --compatibility -f docker-compose.yaml '
+                'down --remove-orphans',
+                calls,
+            )
+            self.assertIn(
+                'compose --compatibility -f docker-compose.yaml up -d',
+                calls,
+            )
+            self.assertIn('image rm sha256:old-agw-image', calls)
+            self.assertFalse(any(call.startswith('stop ') for call in calls))
+            self.assertFalse(any('system prune' in call for call in calls))
+
+            docker_log.unlink()
+            env['ANCESTOR_IN_USE'] = '1'
+            subprocess.run(['bash', SCRIPT], check=True, env=env)
+            calls = docker_log.read_text(encoding='utf-8').splitlines()
+            self.assertNotIn('image rm sha256:old-agw-image', calls)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- Replace the host-wide `docker ps -a -q` / `docker stop` operation with
  `docker compose down --remove-orphans`, so an AGW upgrade only interrupts the
  AGW Compose project.
- Remove the global `docker system prune -af` operation. Track images used by
  the AGW project before the upgrade and remove an old image only when no
  container still references it.
- Use one explicit Compose command for validation, image listing, pull, down,
  and up operations.
- Add a Docker-directory override and a fake-Docker regression test for the
  mutation boundary.

This matters when an AGW shares a Docker host with another project. In the
reproduction environment, `docker ps -a` returned 33 containers across the
`agw` project (22), `orc8r` project (9), and two unlabeled containers. The
current script selects all 33 before an AGW upgrade.

## Test Plan

```text
python3 -m unittest -v \
  lte/gateway/deploy/roles/agw_docker/files/agw_upgrade_test.py
test_upgrade_only_mutates_compose_project ... ok

python3 -m py_compile \
  lte/gateway/deploy/roles/agw_docker/files/agw_upgrade_test.py
bash -n lte/gateway/deploy/roles/agw_docker/files/agw_upgrade.sh
git diff --check
```

The fake-Docker test verifies that the script:

- runs Compose `down --remove-orphans` and `up -d`;
- does not invoke a global container stop or system prune;
- removes an unused previous AGW image; and
- preserves a previous image while another container references it.

I also ran the fixed script against a temporary real Compose project on a lab
host that was simultaneously running AGW and Orc8r. The temporary probe was
removed and recreated, while the `magmad` and Orc8r controller start timestamps
remained unchanged. After cleanup, all 27 original running containers remained,
with zero unhealthy and zero restarting containers.

## Additional Information

- [ ] This change is backwards-breaking

The upgrade still recreates the AGW Compose project and does not remove named
volumes. The behavior change is that unrelated containers and globally unused
Docker resources are no longer stopped or pruned.

## Security Considerations

This reduces denial-of-service and data-loss risk on shared Docker hosts by
confining destructive lifecycle operations to the intended Compose project.
Image cleanup checks all containers, including stopped containers, and skips
an image when any container still references it.
