### PR TITLE
fix(agw): preserve types in C++ deletion helper

### DIFF
--- a/lte/gateway/c/core/common/BUILD.bazel
+++ b/lte/gateway/c/core/common/BUILD.bazel
@@ -37,6 +37,12 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "dynamic_memory_check_asan_test",
+    srcs = ["dynamic_memory_check_test.cpp"],
+    deps = [":dynamic_memory_check"],
+)
+
 cc_library(
     name = "common_defs",
     hdrs = ["common_defs.h"],

--- a/lte/gateway/c/core/common/dynamic_memory_check.cpp
+++ b/lte/gateway/c/core/common/dynamic_memory_check.cpp
@@ -61,14 +61,3 @@ void bdestroy_wrapper(bstring* b) {
 #ifdef __cplusplus
 }
 #endif
-
-// Frees the contents of pointer, called while freeing an entry from protobuf
-// map
-// TODO(rsarwad): rename free_wrapper once all tasks are migrated to cpp.
-// Shall be addressed while addressing issue_id: 13096
-void free_cpp_wrapper(void** ptr) {
-  if ((ptr) && (*ptr)) {
-    delete *ptr;
-    *ptr = nullptr;
-  }
-}

--- a/lte/gateway/c/core/common/dynamic_memory_check.h
+++ b/lte/gateway/c/core/common/dynamic_memory_check.h
@@ -36,6 +36,12 @@
 */
 #pragma once
 
+#ifdef __cplusplus
+extern "C++" {
+#include <type_traits>
+}
+#endif
+
 // TODO(rsarwad): Shall rename file to hpp while addressing issue_id: 13096
 #ifdef __cplusplus
 extern "C" {
@@ -47,4 +53,19 @@ void bdestroy_wrapper(bstring* b);
 #ifdef __cplusplus
 }
 #endif
-void free_cpp_wrapper(void** ptr);
+
+#ifdef __cplusplus
+extern "C++" {
+// Delete C++ objects through their concrete type so destructors run. Deleting
+// through void* is undefined and skips object-owned resource cleanup.
+template <typename T>
+inline void free_cpp_wrapper(T** ptr) {
+  static_assert(!std::is_void<T>::value,
+                "free_cpp_wrapper requires a concrete C++ object type");
+  if (ptr && *ptr) {
+    delete *ptr;
+    *ptr = nullptr;
+  }
+}
+}  // extern "C++"
+#endif

--- a/lte/gateway/c/core/common/dynamic_memory_check_test.cpp
+++ b/lte/gateway/c/core/common/dynamic_memory_check_test.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+
+#include "lte/gateway/c/core/common/dynamic_memory_check.h"
+
+namespace {
+
+bool destructor_called = false;
+
+class DestructionTracked {
+ public:
+  DestructionTracked() : payload_(new int[64]) {}
+
+  ~DestructionTracked() {
+    delete[] payload_;
+    destructor_called = true;
+  }
+
+ private:
+  int* payload_;
+};
+
+}  // namespace
+
+int main() {
+  void* allocation = std::malloc(256);
+  assert(allocation != nullptr);
+  std::memset(allocation, 0xA5, 256);
+
+  free_wrapper(&allocation);
+  assert(allocation == nullptr);
+
+  // A pointer-to-pointer with a null pointee must be a safe no-op. Repeating
+  // the call also verifies that free_wrapper leaves the caller's state null.
+  free_wrapper(&allocation);
+  assert(allocation == nullptr);
+
+  // Typed deletion must invoke the concrete destructor and release the
+  // object's owned allocation.
+  DestructionTracked* tracked = new DestructionTracked();
+  free_cpp_wrapper(&tracked);
+  if (tracked != nullptr || !destructor_called) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.cpp
+++ b/lte/gateway/c/core/oai/tasks/s1ap/s1ap_mme.cpp
@@ -427,7 +427,7 @@ oai::UeDescription* s1ap_new_ue(oai::EnbDescription* enb_ref,
   if (rc != magma::PROTO_MAP_OK) {
     OAILOG_ERROR(LOG_S1AP, "Could not insert UE descr in ue_coll: %s\n",
                  magma::map_rc_code2string(rc));
-    free_cpp_wrapper(reinterpret_cast<void**>(&ue_ref));
+    free_cpp_wrapper(&ue_ref);
     return nullptr;
   }
   // Increment number of UE

--- a/lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/pgw_procedures.cpp
@@ -48,7 +48,7 @@ void delete_pending_procedures(
       base_proc1 = base_proc2;
     }
     LIST_INIT(ctx_p->pending_procedures);
-    free_cpp_wrapper(reinterpret_cast<void**>(&ctx_p->pending_procedures));
+    free_cpp_wrapper(&ctx_p->pending_procedures);
   }
 }
 //------------------------------------------------------------------------------
@@ -100,16 +100,14 @@ void pgw_free_procedure_create_bearer(pgw_ni_cbr_proc_t** ni_cbr_proc) {
           free_wrapper((void**)&eps_bearer_entry_wrapper->sgw_eps_bearer_entry
                            ->pgw_cp_ip_port);
         }
-        free_cpp_wrapper(reinterpret_cast<void**>(
-            &eps_bearer_entry_wrapper->sgw_eps_bearer_entry));
-        free_cpp_wrapper(reinterpret_cast<void**>(&eps_bearer_entry_wrapper));
+        free_cpp_wrapper(&eps_bearer_entry_wrapper->sgw_eps_bearer_entry);
+        free_cpp_wrapper(&eps_bearer_entry_wrapper);
         if (LIST_EMPTY((*ni_cbr_proc)->pending_eps_bearers)) {
-          free_cpp_wrapper(
-              reinterpret_cast<void**>(&(*ni_cbr_proc)->pending_eps_bearers));
+          free_cpp_wrapper(&(*ni_cbr_proc)->pending_eps_bearers);
           break;
         }
       }
     }
   }
-  free_cpp_wrapper(reinterpret_cast<void**>(ni_cbr_proc));
+  free_cpp_wrapper(ni_cbr_proc);
 }

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_context_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_context_manager.cpp
@@ -211,7 +211,7 @@ magma::proto_map_rc_t sgw_cm_remove_bearer_context_information(
     while (p1) {
       if (p1->sgw_s11_teid == teid) {
         LIST_REMOVE(p1, entries);
-        free_cpp_wrapper(reinterpret_cast<void**>(&p1));
+        free_cpp_wrapper(&p1);
         break;
       }
       p1 = LIST_NEXT(p1, entries);

--- a/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/sgw_handlers.cpp
@@ -273,12 +273,12 @@ status_code_e sgw_handle_s11_create_session_request(
     OAILOG_ERROR_UE(
         LOG_SPGW_APP, imsi64,
         "Could not create new transaction for SESSION_CREATE message\n");
-    free_cpp_wrapper(reinterpret_cast<void**>(&new_endpoint_p));
+    free_cpp_wrapper(&new_endpoint_p);
     increment_counter("spgw_create_session", 1, 2, "result", "failure", "cause",
                       "internal_software_error");
     OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
   }
-  free_cpp_wrapper(reinterpret_cast<void**>(&new_endpoint_p));
+  free_cpp_wrapper(&new_endpoint_p);
   OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
 }
 
@@ -2093,10 +2093,9 @@ void handle_failed_s8_create_bearer_response(
           if (sgw_eps_bearer_entry_p->sgw_eps_bearer_entry) {
             free_wrapper((void**)&sgw_eps_bearer_entry_p->sgw_eps_bearer_entry
                              ->pgw_cp_ip_port);
-            free_cpp_wrapper(reinterpret_cast<void**>(
-                &sgw_eps_bearer_entry_p->sgw_eps_bearer_entry));
+            free_cpp_wrapper(&sgw_eps_bearer_entry_p->sgw_eps_bearer_entry);
           }
-          free_cpp_wrapper(reinterpret_cast<void**>(&sgw_eps_bearer_entry_p));
+          free_cpp_wrapper(&sgw_eps_bearer_entry_p);
           break;
         }
         sgw_eps_bearer_entry_p = LIST_NEXT(sgw_eps_bearer_entry_p, entries);
@@ -2106,10 +2105,8 @@ void handle_failed_s8_create_bearer_response(
         pgw_base_proc_t* base_proc1 =
             LIST_FIRST(sgw_context_p->pending_procedures);
         LIST_REMOVE(base_proc1, entries);
-        free_cpp_wrapper(
-            reinterpret_cast<void**>(&sgw_context_p->pending_procedures));
-        free_cpp_wrapper(
-            reinterpret_cast<void**>(&pgw_ni_cbr_proc->pending_eps_bearers));
+        free_cpp_wrapper(&sgw_context_p->pending_procedures);
+        free_cpp_wrapper(&pgw_ni_cbr_proc->pending_eps_bearers);
         pgw_free_procedure_create_bearer((pgw_ni_cbr_proc_t**)&pgw_ni_cbr_proc);
       }
     }

--- a/lte/gateway/c/core/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw/spgw_state.cpp
@@ -117,8 +117,9 @@ void spgw_free_s11_bearer_context_information(void** ptr) {
       context_p->clear_sgw_eps_bearer_context();
       context_p->clear_pgw_eps_bearer_context();
     }  // end of s11_bearer_context_p
-  }    // end of ptr
-  free_cpp_wrapper(ptr);
+    free_cpp_wrapper(&context_p);
+  }  // end of ptr
+  *ptr = nullptr;
 }
 
 void free_eps_bearer_context(
@@ -202,9 +203,10 @@ void sgw_free_ue_context(void** ptr) {
   while (p1) {
     p2 = LIST_NEXT(p1, entries);
     LIST_REMOVE(p1, entries);
-    free_cpp_wrapper(reinterpret_cast<void**>(&p1));
+    free_cpp_wrapper(&p1);
     p1 = p2;
   }
-  free_cpp_wrapper(reinterpret_cast<void**>(ptr));
+  free_cpp_wrapper(&ue_context_p);
+  *ptr = nullptr;
   return;
 }

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_handlers.cpp
@@ -135,7 +135,7 @@ void sgw_remove_sgw_bearer_context_information(sgw_state_t* sgw_state,
     while (p1) {
       if (p1->sgw_s11_teid == teid) {
         LIST_REMOVE(p1, entries);
-        free_cpp_wrapper(reinterpret_cast<void**>(&p1));
+        free_cpp_wrapper(&p1);
         break;
       }
       p1 = LIST_NEXT(p1, entries);
@@ -1486,7 +1486,7 @@ void sgw_s8_proc_s11_create_bearer_rsp(
       }
       // Remove the temporary spgw entry
       LIST_REMOVE(sgw_eps_bearer_entry_p, entries);
-      free_cpp_wrapper(reinterpret_cast<void**>(&sgw_eps_bearer_entry_p));
+      free_cpp_wrapper(&sgw_eps_bearer_entry_p);
       break;
     }
     sgw_eps_bearer_entry_p = LIST_NEXT(sgw_eps_bearer_entry_p, entries);
@@ -1494,10 +1494,8 @@ void sgw_s8_proc_s11_create_bearer_rsp(
   if (pgw_ni_cbr_proc && (LIST_EMPTY(pgw_ni_cbr_proc->pending_eps_bearers))) {
     pgw_base_proc_t* base_proc1 = LIST_FIRST(sgw_context_p->pending_procedures);
     LIST_REMOVE(base_proc1, entries);
-    free_cpp_wrapper(
-        reinterpret_cast<void**>(&sgw_context_p->pending_procedures));
-    free_cpp_wrapper(
-        reinterpret_cast<void**>(&pgw_ni_cbr_proc->pending_eps_bearers));
+    free_cpp_wrapper(&sgw_context_p->pending_procedures);
+    free_cpp_wrapper(&pgw_ni_cbr_proc->pending_eps_bearers);
     pgw_free_procedure_create_bearer((pgw_ni_cbr_proc_t**)&pgw_ni_cbr_proc);
   }
   OAILOG_FUNC_OUT(LOG_SGW_S8);

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state.cpp
@@ -66,7 +66,7 @@ void sgw_s8_free_eps_bearer_context(
       free_wrapper(
           reinterpret_cast<void**>(&(*sgw_eps_bearer_ctxt)->pgw_cp_ip_port));
     }
-    free_cpp_wrapper(reinterpret_cast<void**>(sgw_eps_bearer_ctxt));
+    free_cpp_wrapper(sgw_eps_bearer_ctxt);
   }
 }
 
@@ -90,7 +90,8 @@ void sgw_free_s11_bearer_context_information(void** ptr) {
   if (sgw_eps_context) {
     sgw_s8_free_pdn_connection(&sgw_eps_context->pdn_connection);
     delete_pending_procedures(sgw_eps_context);
-    free_cpp_wrapper(reinterpret_cast<void**>(ptr));
+    free_cpp_wrapper(&sgw_eps_context);
+    *ptr = nullptr;
   }
   return;
 }

--- a/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.cpp
+++ b/lte/gateway/c/core/oai/tasks/sgw_s8/sgw_s8_state_manager.cpp
@@ -124,7 +124,7 @@ void SgwStateManager::free_state() {
                    "temporary_create_session_procedure_id_map ");
     }
   }
-  free_cpp_wrapper(reinterpret_cast<void**>(&state_cache_p));
+  free_cpp_wrapper(&state_cache_p);
 }
 
 status_code_e SgwStateManager::read_ue_state_from_db() {


### PR DESCRIPTION
## Summary

- replace the untyped `free_cpp_wrapper(void**)` delete path with a typed template so concrete C++ destructors run
- migrate 23 AGW call sites across S1AP, SGW/SPGW, and SGW-S8 to preserve the pointee type
- add an ASan/LSan regression that verifies destructor-owned memory is released and the caller pointer is nulled

The legacy path emitted `deleting 'void*' is undefined` and a focused reproduction leaked 256 bytes because the concrete destructor was skipped.

## Test Plan

- focused `dynamic_memory_check_asan_test`: passed under ASan/LSan
- full `//lte/gateway/c/core:lib_agw_of` build with ASan flags: passed
- `spgw_procedures_session_test`: all 4 session-path tests passed under ASan/LSan
- clang-format dry-run with `--Werror`: passed on touched C++ files
- `git diff --check`: passed

## Additional Information

- [ ] This change is backwards-breaking

## Security Considerations

No new external inputs or privileges are introduced. The change improves deterministic C++ object destruction and resource cleanup.
